### PR TITLE
change: ETCM-8051 setup-main-chain-state checks

### DIFF
--- a/partner-chains-cli/src/config.rs
+++ b/partner-chains-cli/src/config.rs
@@ -380,7 +380,7 @@ pub const KEYS_FILE_PATH: &str = "partner-chains-public-keys.json";
 pub const CHAIN_CONFIG_FILE_PATH: &str = "partner-chains-cli-chain-config.json";
 pub const RESOURCES_CONFIG_FILE_PATH: &str = "partner-chains-cli-resources-config.json";
 pub const CHAIN_SPEC_PATH: &str = "chain-spec.json";
-pub const PARTNER_CHAINS_CLI_PATH: &str = "./sidechain-main-cli";
+pub const SIDECHAIN_MAIN_CLI_PATH: &str = "./sidechain-main-cli";
 
 pub fn load_chain_config(context: &impl IOContext) -> anyhow::Result<ChainConfig> {
 	if let Some(chain_config_file) = context.read_file(CHAIN_CONFIG_FILE_PATH) {

--- a/partner-chains-cli/src/config.rs
+++ b/partner-chains-cli/src/config.rs
@@ -380,6 +380,7 @@ pub const KEYS_FILE_PATH: &str = "partner-chains-public-keys.json";
 pub const CHAIN_CONFIG_FILE_PATH: &str = "partner-chains-cli-chain-config.json";
 pub const RESOURCES_CONFIG_FILE_PATH: &str = "partner-chains-cli-resources-config.json";
 pub const CHAIN_SPEC_PATH: &str = "chain-spec.json";
+pub const PARTNER_CHAINS_CLI_PATH: &str = "./sidechain-main-cli";
 
 pub fn load_chain_config(context: &impl IOContext) -> anyhow::Result<ChainConfig> {
 	if let Some(chain_config_file) = context.read_file(CHAIN_CONFIG_FILE_PATH) {

--- a/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -1,7 +1,7 @@
 use crate::config::config_fields::{CARDANO_PAYMENT_SIGNING_KEY_FILE, POSTGRES_CONNECTION_STRING};
 use crate::config::{
 	config_fields, ChainConfig, ConfigFieldDefinition, SidechainParams, CHAIN_CONFIG_FILE_PATH,
-	PARTNER_CHAINS_CLI_PATH,
+	SIDECHAIN_MAIN_CLI_PATH,
 };
 use crate::io::IOContext;
 use crate::permissioned_candidates::{ParsedPermissionedCandidatesKeys, PermissionedCandidateKeys};
@@ -95,9 +95,9 @@ impl CmdRun for SetupMainChainStateCmd {
 		context.print(
 			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!",
 		);
-		if !context.file_exists(PARTNER_CHAINS_CLI_PATH) {
+		if !context.file_exists(SIDECHAIN_MAIN_CLI_PATH) {
 			return Err(anyhow!(
-				"Partner Chains CLI executable file ({PARTNER_CHAINS_CLI_PATH}) is missing."
+				"Partner Chains CLI executable file ({SIDECHAIN_MAIN_CLI_PATH}) is missing."
 			));
 		}
 		let config_initial_authorities =
@@ -262,7 +262,7 @@ fn set_candidates_on_main_chain<C: IOContext>(
 			.collect::<Vec<_>>()
 			.join(" ");
 		let output = context.run_command(&format!(
-			"{PARTNER_CHAINS_CLI_PATH} {} {} {} {}",
+			"{SIDECHAIN_MAIN_CLI_PATH} {} {} {} {}",
 			command,
 			candidate_keys,
 			smart_contracts::sidechain_params_arguments(chain_params),
@@ -306,7 +306,7 @@ fn set_d_parameter_on_main_chain<C: IOContext>(
 			CARDANO_PAYMENT_SIGNING_KEY_FILE.prompt_with_default_from_file_and_save(context);
 		let sidechain_main_cli_command = insert.d_parameter_command();
 		let command = format!(
-			"{PARTNER_CHAINS_CLI_PATH} {sidechain_main_cli_command} --d-parameter-permissioned-candidates-count {p} --d-parameter-registered-candidates-count {r} {} {}",
+			"{SIDECHAIN_MAIN_CLI_PATH} {sidechain_main_cli_command} --d-parameter-permissioned-candidates-count {p} --d-parameter-registered-candidates-count {r} {} {}",
 			smart_contracts::sidechain_params_arguments(chain_params),
 			smart_contracts::runtime_config_arguments(&sidechain_main_cli_resources, &payment_signing_key_path)
 		);

--- a/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -6,7 +6,6 @@ use crate::config::{
 use crate::io::IOContext;
 use crate::permissioned_candidates::{ParsedPermissionedCandidatesKeys, PermissionedCandidateKeys};
 use crate::sidechain_main_cli_resources::establish_sidechain_main_cli_configuration;
-use crate::smart_contracts::check_for_kupo_ogmios_connection_error;
 use crate::{smart_contracts, CmdRun};
 use anyhow::anyhow;
 use epoch_derivation::MainchainEpochDerivation;
@@ -272,7 +271,6 @@ fn set_candidates_on_main_chain<C: IOContext>(
 				&payment_signing_key_path
 			)
 		))?;
-		check_for_kupo_ogmios_connection_error(&output, &sidechain_main_cli_resources)?;
 		if output.contains("transactionId") {
 			context.print("Permissioned candidates updated. The change will be effective in two main chain epochs.");
 			Ok(())

--- a/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -6,6 +6,7 @@ use crate::config::{
 use crate::io::IOContext;
 use crate::permissioned_candidates::{ParsedPermissionedCandidatesKeys, PermissionedCandidateKeys};
 use crate::sidechain_main_cli_resources::establish_sidechain_main_cli_configuration;
+use crate::smart_contracts::check_for_kupo_ogmios_connection_error;
 use crate::{smart_contracts, CmdRun};
 use anyhow::anyhow;
 use epoch_derivation::MainchainEpochDerivation;
@@ -271,6 +272,7 @@ fn set_candidates_on_main_chain<C: IOContext>(
 				&payment_signing_key_path
 			)
 		))?;
+		check_for_kupo_ogmios_connection_error(&output, &sidechain_main_cli_resources)?;
 		if output.contains("transactionId") {
 			context.print("Permissioned candidates updated. The change will be effective in two main chain epochs.");
 			Ok(())

--- a/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -98,7 +98,7 @@ impl CmdRun for SetupMainChainStateCmd {
 		);
 		if !context.file_exists(SIDECHAIN_MAIN_CLI_PATH) {
 			return Err(anyhow!(
-				"Partner Chains CLI executable file ({SIDECHAIN_MAIN_CLI_PATH}) is missing."
+				"Partner Chains Smart Contracts executable file ({SIDECHAIN_MAIN_CLI_PATH}) is missing",
 			));
 		}
 		let config_initial_authorities =

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,5 +1,5 @@
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
-use crate::config::{config_fields, PARTNER_CHAINS_CLI_PATH};
+use crate::config::{config_fields, SIDECHAIN_MAIN_CLI_PATH};
 use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
 use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
@@ -15,7 +15,7 @@ use sp_core::offchain::Timestamp;
 #[test]
 fn no_ariadne_parameters_on_main_chain_no_updates() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -36,7 +36,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 #[test]
 fn no_ariadne_parameters_on_main_chain_do_updates() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -59,7 +59,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 #[test]
 fn ariadne_parameters_are_on_main_chain_no_updates() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -81,7 +81,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 #[test]
 fn ariadne_parameters_are_on_main_chain_do_update() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -105,7 +105,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 #[test]
 fn fails_if_update_permissioned_candidates_fail() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -125,7 +125,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 #[test]
 fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 	let mock_context = MockIOContext::new()
-		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
+		.with_file(SIDECHAIN_MAIN_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -152,7 +152,7 @@ fn should_return_error_message_if_pc_cli_missing() {
 	mock_context.no_more_io_expected();
 	assert_eq!(
 		result.unwrap_err().to_string(),
-		"Partner Chains CLI executable file (./sidechain-main-cli) is missing."
+		"Partner Chains Smart Contracts executable file (./sidechain-main-cli) is missing"
 	);
 }
 

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,5 +1,5 @@
-use crate::config::config_fields;
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
+use crate::config::{config_fields, PARTNER_CHAINS_CLI_PATH};
 use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
 use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
@@ -15,6 +15,7 @@ use sp_core::offchain::Timestamp;
 #[test]
 fn no_ariadne_parameters_on_main_chain_no_updates() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -35,6 +36,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 #[test]
 fn no_ariadne_parameters_on_main_chain_do_updates() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -57,6 +59,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 #[test]
 fn ariadne_parameters_are_on_main_chain_no_updates() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -78,6 +81,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 #[test]
 fn ariadne_parameters_are_on_main_chain_do_update() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -101,6 +105,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 #[test]
 fn fails_if_update_permissioned_candidates_fail() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -120,6 +125,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 #[test]
 fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 	let mock_context = MockIOContext::new()
+		.with_file(PARTNER_CHAINS_CLI_PATH, "<mock executable>")
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
@@ -135,6 +141,19 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	mock_context.no_more_io_expected();
 	assert!(result.is_ok());
+}
+
+#[test]
+fn should_return_error_message_if_pc_cli_missing() {
+	let mock_context = MockIOContext::new()
+		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
+		.with_expected_io(vec![read_chain_config_io(), print_info_io()]);
+	let result = SetupMainChainStateCmd.run(&mock_context);
+	mock_context.no_more_io_expected();
+	assert_eq!(
+		result.unwrap_err().to_string(),
+		"Partner Chains CLI executable file (./sidechain-main-cli) is missing."
+	);
 }
 
 fn read_chain_config_io() -> MockIO {

--- a/partner-chains-cli/src/smart_contracts.rs
+++ b/partner-chains-cli/src/smart_contracts.rs
@@ -1,5 +1,6 @@
 use crate::config::SidechainParams;
 use crate::sidechain_main_cli_resources::SidechainMainCliResources;
+use anyhow::anyhow;
 
 pub fn sidechain_params_arguments(sidechain_params: &SidechainParams) -> String {
 	format!("--sidechain-id {} --genesis-committee-hash-utxo {} --threshold-numerator {} --threshold-denominator {} --governance-authority {} --atms-kind plain-ecdsa-secp256k1",
@@ -23,4 +24,66 @@ pub fn runtime_config_arguments(
 			if runtime_config.ogmios.protocol.is_secure() { "--ogmios-secure" } else { "" },
 			payment_signing_key_path
 	)
+}
+
+pub fn check_for_kupo_ogmios_connection_error(
+	response: &str,
+	sidechain_main_cli_resources: &SidechainMainCliResources,
+) -> anyhow::Result<()> {
+	if response.contains("ECONNREFUSED") {
+		let kupo_port_str = &sidechain_main_cli_resources.kupo.port.to_string();
+		let (target, connection) = if response.contains(kupo_port_str) {
+			("Kupo", sidechain_main_cli_resources.kupo.clone())
+		} else {
+			("Ogmios", sidechain_main_cli_resources.ogmios.clone())
+		};
+		Err(anyhow!(
+			"Failed to connect to {target} at {connection}. Please check connection configuration and try again."
+		))
+	} else {
+		Ok(())
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	mod check_for_kupo_ogmios_connection_error {
+		use crate::{
+			config::config_fields::{KUPO_PORT, OGMIOS_PORT},
+			sidechain_main_cli_resources::SidechainMainCliResources,
+			smart_contracts::check_for_kupo_ogmios_connection_error,
+		};
+
+		#[test]
+		fn should_display_user_friendly_message_when_kupo_connection_fails() {
+			let error_string = format!("(UnknownContractError \"An error occurred when running CTL base monad: connect ECONNREFUSED ::1:{}\")", KUPO_PORT.default.unwrap());
+			let sidechain_main_cli_resources = &SidechainMainCliResources::default();
+
+			let result = check_for_kupo_ogmios_connection_error(
+				&error_string,
+				&sidechain_main_cli_resources,
+			);
+
+			assert_eq!(
+				result.unwrap_err().to_string(),
+				"Failed to connect to Kupo at http://localhost:1442. Please check connection configuration and try again."
+			);
+		}
+
+		#[test]
+		fn should_display_user_friendly_message_when_ogmios_connection_fails() {
+			let error_string = format!("(UnknownContractError \"An error occurred when running CTL base monad: connect ECONNREFUSED ::1:{}\")", OGMIOS_PORT.default.unwrap());
+			let sidechain_main_cli_resources = &SidechainMainCliResources::default();
+
+			let result = check_for_kupo_ogmios_connection_error(
+				&error_string,
+				&sidechain_main_cli_resources,
+			);
+
+			assert_eq!(
+				result.unwrap_err().to_string(),
+				"Failed to connect to Ogmios at http://localhost:1337. Please check connection configuration and try again."
+			);
+		}
+	}
 }

--- a/partner-chains-cli/src/smart_contracts.rs
+++ b/partner-chains-cli/src/smart_contracts.rs
@@ -1,6 +1,5 @@
 use crate::config::SidechainParams;
 use crate::sidechain_main_cli_resources::SidechainMainCliResources;
-use anyhow::anyhow;
 
 pub fn sidechain_params_arguments(sidechain_params: &SidechainParams) -> String {
 	format!("--sidechain-id {} --genesis-committee-hash-utxo {} --threshold-numerator {} --threshold-denominator {} --governance-authority {} --atms-kind plain-ecdsa-secp256k1",
@@ -24,66 +23,4 @@ pub fn runtime_config_arguments(
 			if runtime_config.ogmios.protocol.is_secure() { "--ogmios-secure" } else { "" },
 			payment_signing_key_path
 	)
-}
-
-pub fn check_for_kupo_ogmios_connection_error(
-	response: &str,
-	sidechain_main_cli_resources: &SidechainMainCliResources,
-) -> anyhow::Result<()> {
-	if response.contains("ECONNREFUSED") {
-		let kupo_port_str = &sidechain_main_cli_resources.kupo.port.to_string();
-		let (target, connection) = if response.contains(kupo_port_str) {
-			("Kupo", sidechain_main_cli_resources.kupo.clone())
-		} else {
-			("Ogmios", sidechain_main_cli_resources.ogmios.clone())
-		};
-		Err(anyhow!(
-			"Failed to connect to {target} at {connection}. Please check connection configuration and try again."
-		))
-	} else {
-		Ok(())
-	}
-}
-
-#[cfg(test)]
-mod tests {
-	mod check_for_kupo_ogmios_connection_error {
-		use crate::{
-			config::config_fields::{KUPO_PORT, OGMIOS_PORT},
-			sidechain_main_cli_resources::SidechainMainCliResources,
-			smart_contracts::check_for_kupo_ogmios_connection_error,
-		};
-
-		#[test]
-		fn should_display_user_friendly_message_when_kupo_connection_fails() {
-			let error_string = format!("(UnknownContractError \"An error occurred when running CTL base monad: connect ECONNREFUSED ::1:{}\")", KUPO_PORT.default.unwrap());
-			let sidechain_main_cli_resources = &SidechainMainCliResources::default();
-
-			let result = check_for_kupo_ogmios_connection_error(
-				&error_string,
-				&sidechain_main_cli_resources,
-			);
-
-			assert_eq!(
-				result.unwrap_err().to_string(),
-				"Failed to connect to Kupo at http://localhost:1442. Please check connection configuration and try again."
-			);
-		}
-
-		#[test]
-		fn should_display_user_friendly_message_when_ogmios_connection_fails() {
-			let error_string = format!("(UnknownContractError \"An error occurred when running CTL base monad: connect ECONNREFUSED ::1:{}\")", OGMIOS_PORT.default.unwrap());
-			let sidechain_main_cli_resources = &SidechainMainCliResources::default();
-
-			let result = check_for_kupo_ogmios_connection_error(
-				&error_string,
-				&sidechain_main_cli_resources,
-			);
-
-			assert_eq!(
-				result.unwrap_err().to_string(),
-				"Failed to connect to Ogmios at http://localhost:1337. Please check connection configuration and try again."
-			);
-		}
-	}
 }


### PR DESCRIPTION
# Description

* ~Display a better error message for Kupo and Ogmios connection error~ removed checks for Kupo and Ogmios connection. it will better be handled by the smart contracts CLI
* Check for existence of `sidechain-main-cli` before running

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

