### PR TITLE
chore: fix 'test' and 'clippy' warnings

### DIFF
--- a/partner-chains-cli/src/start_node/mod.rs
+++ b/partner-chains-cli/src/start_node/mod.rs
@@ -181,7 +181,7 @@ fn account_id_hex_from_ecdsa_key(key: &str) -> anyhow::Result<String> {
 	let trimmed = key.trim_start_matches("0x");
 	let pk = PublicKey::from_str(trimmed)?;
 	let account_id: AccountId32 = MultiSigner::from(ecdsa::Public::from(pk)).into_account();
-	Ok(hex::encode(&account_id))
+	Ok(hex::encode(account_id))
 }
 
 pub fn start_node<C: IOContext>(

--- a/runtime/src/mock.rs
+++ b/runtime/src/mock.rs
@@ -426,10 +426,6 @@ fn initialize_with_slot_digest_and_increment_block_number(slot_number: u64) {
 	System::initialize(&(System::block_number() + 1), &System::parent_hash(), &pre_digest);
 }
 
-fn current_epoch_number() -> ScEpochNumber {
-	sidechain_slots::epoch_number(pallet_aura::CurrentSlot::<Test>::get(), SLOTS_PER_EPOCH)
-}
-
 macro_rules! assert_current_epoch {
 	($epoch:expr) => {{
 		assert_eq!(Sidechain::current_epoch_number().0, $epoch + ARBITRARY_FIRST_EPOCH);


### PR DESCRIPTION
# Description

Fixing warning when running `cargo test` and `cargo clippy`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

