### PR TITLE
change: change McBlockHash inner type from Vec to an array

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 ## Changed
 * polkadot-sdk dependency updated to partnerchains-stable2407 (stable2407 is v1.15.0 in the previous scheme)
 * remove Relay docker build files
+* changed the inner type of `McBlockHash` from Vec to an array
 
 ## Removed
 

--- a/mainchain-follower/db-sync-follower/src/block/tests.rs
+++ b/mainchain-follower/db-sync-follower/src/block/tests.rs
@@ -16,9 +16,7 @@ async fn get_latest_block_info(pool: PgPool) {
 	let source = mk_datasource(pool, irrelevant_security_parameter);
 	let expected = MainchainBlock {
 		number: McBlockNumber(5),
-		hash: McBlockHash(
-			hex!("EBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("EBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(193),
 		slot: McSlotNumber(193500),
 		timestamp: NaiveDateTime::from_str("2022-04-21T17:36:10")
@@ -129,9 +127,8 @@ async fn test_get_stable_block_at_filters_out_by_max_slots_boundary(pool: PgPool
 #[sqlx::test(migrations = "./testdata/migrations")]
 async fn test_get_stable_block_info_by_hash_for_unknown_hash(pool: PgPool) {
 	let source = mk_datasource(pool, 2);
-	let unknown_hash = McBlockHash(
-		hex!("0000D7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-	);
+	let unknown_hash =
+		McBlockHash(hex!("0000D7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1"));
 	let result = source
 		.get_stable_block_for(unknown_hash, BLOCK_4_TS_MILLIS.into())
 		.await
@@ -197,7 +194,7 @@ async fn test_get_latest_stable_block_with_stability_margin_2(pool: PgPool) {
 #[sqlx::test(migrations = "./testdata/migrations")]
 async fn test_get_stable_block_caching(pool: PgPool) {
 	fn dummy_hash(n: u8) -> McBlockHash {
-		McBlockHash(vec![n; 32])
+		McBlockHash([n; 32])
 	}
 
 	async fn update_block_hash_in_db(pool: &PgPool, n: u8) {
@@ -285,9 +282,7 @@ fn mainchain_epoch_config() -> MainchainEpochConfig {
 fn block_0() -> MainchainBlock {
 	MainchainBlock {
 		number: McBlockNumber(0),
-		hash: McBlockHash(
-			hex!("0BEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("0BEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(189),
 		slot: McSlotNumber(189410),
 		timestamp: 1650558480, // 2022-04-21T16:28:00Z
@@ -297,9 +292,7 @@ fn block_0() -> MainchainBlock {
 fn block_1() -> MainchainBlock {
 	MainchainBlock {
 		number: McBlockNumber(1),
-		hash: McBlockHash(
-			hex!("ABEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("ABEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(190),
 		slot: McSlotNumber(190400),
 		timestamp: 1650559470, // 2022-04-21T16:44:30Z
@@ -309,9 +302,7 @@ fn block_1() -> MainchainBlock {
 fn block_2() -> MainchainBlock {
 	MainchainBlock {
 		number: McBlockNumber(2),
-		hash: McBlockHash(
-			hex!("BBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("BBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(190),
 		slot: McSlotNumber(190500),
 		timestamp: 1650559570, // 2022-04-23T16:46:10Z
@@ -321,9 +312,7 @@ fn block_2() -> MainchainBlock {
 fn block_3() -> MainchainBlock {
 	MainchainBlock {
 		number: McBlockNumber(3),
-		hash: McBlockHash(
-			hex!("CBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("CBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(191),
 		slot: McSlotNumber(191500),
 		timestamp: 1650560570, // 2022-04-21T17:02:50Z
@@ -333,9 +322,7 @@ fn block_3() -> MainchainBlock {
 fn block_4() -> MainchainBlock {
 	MainchainBlock {
 		number: McBlockNumber(4),
-		hash: McBlockHash(
-			hex!("DBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
-		),
+		hash: McBlockHash(hex!("DBEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1")),
 		epoch: McEpochNumber(192),
 		slot: McSlotNumber(192500),
 		timestamp: 1650561570, // 2022-04-25T17:19:30Z

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -104,7 +104,7 @@ impl From<Block> for main_chain_follower_api::block::MainchainBlock {
 	fn from(b: Block) -> Self {
 		main_chain_follower_api::block::MainchainBlock {
 			number: McBlockNumber(b.block_no.0),
-			hash: McBlockHash(b.hash.to_vec()),
+			hash: McBlockHash(b.hash),
 			epoch: McEpochNumber(b.epoch_no.0),
 			slot: McSlotNumber(b.slot_no.0),
 			timestamp: b.time.and_utc().timestamp().try_into().expect("i64 timestamp is valid u64"),

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -69,7 +69,7 @@ mod block {
 	fn mock_block() -> MainchainBlock {
 		MainchainBlock {
 			number: McBlockNumber(5),
-			hash: McBlockHash(vec![1, 2, 3, 4]),
+			hash: McBlockHash([123; 32]),
 			epoch: McEpochNumber(3),
 			slot: McSlotNumber(12),
 			timestamp: 8,
@@ -79,7 +79,7 @@ mod block {
 	pub fn mock_stable_block() -> MainchainBlock {
 		MainchainBlock {
 			number: McBlockNumber(1),
-			hash: McBlockHash(vec![1; 32]),
+			hash: McBlockHash([1; 32]),
 			epoch: McEpochNumber(2),
 			slot: McSlotNumber(3),
 			timestamp: 4,

--- a/mainchain-follower/mock/src/block.rs
+++ b/mainchain-follower/mock/src/block.rs
@@ -27,7 +27,7 @@ impl BlockDataSource for BlockDataSourceMock {
 		hash_arr[..4].copy_from_slice(&block_number.to_be_bytes());
 		Ok(Some(MainchainBlock {
 			number: McBlockNumber(block_number),
-			hash: McBlockHash(hash_arr.to_vec()),
+			hash: McBlockHash(hash_arr),
 			epoch: McEpochNumber(epoch),
 			slot: McSlotNumber(block_number as u64),
 			timestamp: reference_timestamp.0,

--- a/node/src/tests/inherent_data_tests.rs
+++ b/node/src/tests/inherent_data_tests.rs
@@ -69,7 +69,7 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 async fn block_verification_cidp_should_be_created_correctly() {
 	let mut block_data_source = MockBlockDataSource::default();
 	let parent_stable_block = block_data_source.get_all_stable_blocks().first().unwrap().clone();
-	let mc_block_hash = McBlockHash(vec![2; 32]);
+	let mc_block_hash = McBlockHash([2; 32]);
 	block_data_source.push_stable_block(MainchainBlock {
 		number: McBlockNumber(parent_stable_block.number.0 + 5),
 		hash: mc_block_hash.clone(),

--- a/node/src/tests/runtime_api_mock.rs
+++ b/node/src/tests/runtime_api_mock.rs
@@ -133,6 +133,6 @@ pub fn mock_header() -> <Block as BlockT>::Header {
 		Default::default(),
 		Default::default(),
 		Default::default(),
-		Digest { logs: McHashInherentDigest::from_mc_block_hash(McBlockHash(vec![1; 32])) },
+		Digest { logs: McHashInherentDigest::from_mc_block_hash(McBlockHash([1; 32])) },
 	)
 }

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -381,9 +381,9 @@ impl TryFrom<Vec<u8>> for McTxHash {
 	}
 }
 
-#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum)]
+#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
-pub struct McBlockHash(pub Vec<u8>);
+pub struct McBlockHash(pub [u8; 32]);
 
 impl Display for McBlockHash {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {

--- a/primitives/sidechain-mc-hash/src/lib.rs
+++ b/primitives/sidechain-mc-hash/src/lib.rs
@@ -191,7 +191,7 @@ impl InherentDigest for McHashInherentDigest {
 			if let DigestItem::PreRuntime(id, data) = item {
 				if *id == MC_HASH_DIGEST_ID {
 					let data = data.clone().try_into().map_err(|_| {
-						format!("Invalid MC hash in digest: {:?}", ByteString(data.to_vec()))
+						format!("Invalid MC hash referenced by block author in digest: {:?}\nMC hash must be exactly 32 bytes long.", ByteString(data.to_vec()))
 					})?;
 					return Ok(McBlockHash(data));
 				}

--- a/primitives/sidechain-mc-hash/src/lib.rs
+++ b/primitives/sidechain-mc-hash/src/lib.rs
@@ -2,7 +2,7 @@ use crate::McHashInherentError::StableBlockNotFound;
 use main_chain_follower_api::{
 	block::MainchainBlock, common::Timestamp as McTimestamp, BlockDataSource, DataSourceError,
 };
-use sidechain_domain::{McBlockHash, McBlockNumber, McEpochNumber};
+use sidechain_domain::{byte_string::ByteString, McBlockHash, McBlockNumber, McEpochNumber};
 use sp_consensus_slots::{Slot, SlotDuration};
 use sp_inherents::{InherentData, InherentDataProvider, InherentDigest, InherentIdentifier};
 use sp_runtime::{traits::Header as HeaderT, DigestItem};
@@ -190,10 +190,9 @@ impl InherentDigest for McHashInherentDigest {
 		for item in digest {
 			if let DigestItem::PreRuntime(id, data) = item {
 				if *id == MC_HASH_DIGEST_ID {
-					let data = data
-						.clone()
-						.try_into()
-						.map_err(|_| format!("Invalid MC hash in digest: {data:?}"))?;
+					let data = data.clone().try_into().map_err(|_| {
+						format!("Invalid MC hash in digest: {:?}", ByteString(data.to_vec()))
+					})?;
 					return Ok(McBlockHash(data));
 				}
 			}

--- a/primitives/sidechain-mc-hash/src/lib.rs
+++ b/primitives/sidechain-mc-hash/src/lib.rs
@@ -167,7 +167,7 @@ pub struct McHashInherentDigest;
 
 impl McHashInherentDigest {
 	pub fn from_mc_block_hash(mc_block_hash: McBlockHash) -> Vec<DigestItem> {
-		vec![DigestItem::PreRuntime(MC_HASH_DIGEST_ID, mc_block_hash.0)]
+		vec![DigestItem::PreRuntime(MC_HASH_DIGEST_ID, mc_block_hash.0.to_vec())]
 	}
 }
 
@@ -190,7 +190,11 @@ impl InherentDigest for McHashInherentDigest {
 		for item in digest {
 			if let DigestItem::PreRuntime(id, data) = item {
 				if *id == MC_HASH_DIGEST_ID {
-					return Ok(McBlockHash(data.clone()));
+					let data = data
+						.clone()
+						.try_into()
+						.map_err(|_| format!("Invalid MC hash in digest: {data:?}"))?;
+					return Ok(McBlockHash(data));
 				}
 			}
 		}

--- a/primitives/sidechain-mc-hash/src/test.rs
+++ b/primitives/sidechain-mc-hash/src/test.rs
@@ -5,7 +5,7 @@ mod inherent_digest_tests {
 
 	#[tokio::test]
 	async fn from_inherent_data_works() {
-		let inherent_data = MockMcHashInherentDataProvider { mc_hash: McBlockHash(b"abcd".into()) }
+		let inherent_data = MockMcHashInherentDataProvider { mc_hash: McBlockHash([42; 32]) }
 			.create_inherent_data()
 			.await
 			.unwrap();
@@ -13,17 +13,18 @@ mod inherent_digest_tests {
 		let result = McHashInherentDigest::from_inherent_data(&inherent_data)
 			.expect("from_inherent_data should not fail");
 
-		assert_eq!(result, vec![DigestItem::PreRuntime(MC_HASH_DIGEST_ID, b"abcd".into())])
+		assert_eq!(result, vec![DigestItem::PreRuntime(MC_HASH_DIGEST_ID, vec![42; 32])])
 	}
 
 	#[tokio::test]
 	async fn value_from_digest_works() {
-		let digest = DigestItem::PreRuntime(MC_HASH_DIGEST_ID, b"abcdef".into());
+		let digest_to_ignore = DigestItem::PreRuntime(*b"irlv", vec![0; 32]);
+		let digest = DigestItem::PreRuntime(MC_HASH_DIGEST_ID, vec![42; 32]);
 
-		let result = McHashInherentDigest::value_from_digest(&[digest])
+		let result = McHashInherentDigest::value_from_digest(&[digest_to_ignore, digest])
 			.expect("value_from_digest should not fail");
 
-		assert_eq!(result, McBlockHash(b"abcdef".into()))
+		assert_eq!(result, McBlockHash([42; 32]))
 	}
 }
 
@@ -43,7 +44,7 @@ mod validation_tests {
 		let mut block_data_source = MockBlockDataSource::default();
 		let parent_stable_block =
 			block_data_source.get_all_stable_blocks().first().unwrap().clone();
-		let mc_block_hash = McBlockHash(vec![2; 32]);
+		let mc_block_hash = McBlockHash([2; 32]);
 		let slot_duration = SlotDuration::from_millis(1000);
 
 		block_data_source.push_stable_block(MainchainBlock {
@@ -77,7 +78,7 @@ mod validation_tests {
 			Default::default(),
 			Default::default(),
 			Default::default(),
-			Digest { logs: McHashInherentDigest::from_mc_block_hash(McBlockHash(vec![1; 32])) },
+			Digest { logs: McHashInherentDigest::from_mc_block_hash(McBlockHash([1; 32])) },
 		)
 	}
 }


### PR DESCRIPTION
# Description

Changed the inner type of `McBlockHash` from variable-length `Vec<u8>` to constant length array `[u8; 32]`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

