### PR TITLE
feat: replace async_trait with native (asterisk) Rust support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9721,7 +9721,6 @@ dependencies = [
 name = "sp-session-validator-management-query"
 version = "1.0.0"
 dependencies = [
- "async-trait",
  "authority-selection-inherents",
  "derive-new",
  "hex-literal",
@@ -9744,6 +9743,7 @@ dependencies = [
  "sp-std",
  "thiserror",
  "tokio",
+ "trait-variant",
 ]
 
 [[package]]
@@ -10943,6 +10943,17 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "trait-variant"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ codegen-units = 1
 [workspace.dependencies]
 anyhow = "1.0.75"
 async-trait = "0.1.68"
+trait-variant = "0.1.2"
 assert_cmd = "2.0.12"
 clap = { version = "4.4.18", features = ["derive"] }
 ed25519-zebra = { version = "4.0.3" }

--- a/primitives/session-validator-management/query/Cargo.toml
+++ b/primitives/session-validator-management/query/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
-async-trait = { workspace = true }
+trait-variant = { workspace = true }
 serde = { workspace = true }
 derive-new = { workspace = true }
 serde_json = { workspace = true }

--- a/primitives/session-validator-management/query/src/lib.rs
+++ b/primitives/session-validator-management/query/src/lib.rs
@@ -2,7 +2,6 @@ pub mod commands;
 pub mod get_registrations;
 pub mod types;
 
-use async_trait::async_trait;
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
 use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
 use derive_new::new;
@@ -23,8 +22,8 @@ use types::*;
 
 pub type QueryResult<T> = Result<T, String>;
 
-#[async_trait]
-pub trait SessionValidatorManagementQueryApi {
+#[trait_variant::make(SessionValidatorManagementQueryApi: Send)]
+pub trait LocalSessionValidatorManagementQueryApi {
 	/// Returns the committee for given sidechain epoch. The order of the list represents the order of slot allocation.
 	fn get_epoch_committee(&self, epoch_number: u64) -> QueryResult<GetCommitteeResponse>;
 
@@ -58,7 +57,6 @@ pub struct SessionValidatorManagementQuery<
 	_marker: std::marker::PhantomData<(Block, SessionKeys, CrossChainPublic, SidechainParams)>,
 }
 
-#[async_trait]
 impl<
 		C,
 		Block,


### PR DESCRIPTION
# Description

This PR is a response to this [discussion](https://github.com/input-output-hk/partner-chains/pull/15#discussion_r1706524851)

Pros:
* example of using native support for `async fn` in traits
* we adapt to newer Rust
Cons:
* we now have both `#[async_trait]` in some places (required by #[rpc(...)]`) and some native usage
* we need `#[trait_variant]` in public trait

There is an issue in polkadot-sdk for similar change but it waits for jsonrpsee changes.

Please, lets have a disucssion on this matter.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

