### PR TITLE
change: ETCM-7811 native token movement observability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-native-token-management"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sidechain-domain",
+ "sp-io",
+ "sp-native-token-management",
+]
+
+[[package]]
 name = "pallet-partner-chains-session"
 version = "1.0.0"
 source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
@@ -6098,6 +6112,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-keyring",
+ "sp-native-token-management",
  "sp-runtime",
  "sp-session-validator-management",
  "sp-session-validator-management-query",
@@ -9016,6 +9031,7 @@ dependencies = [
  "pallet-balances",
  "pallet-block-rewards",
  "pallet-grandpa",
+ "pallet-native-token-management",
  "pallet-partner-chains-session",
  "pallet-session-validator-management",
  "pallet-session-validator-management-benchmarking",
@@ -9043,6 +9059,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-keyring",
+ "sp-native-token-management",
  "sp-offchain",
  "sp-partner-chains-session",
  "sp-runtime",
@@ -9589,6 +9606,25 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-application-crypto",
+]
+
+[[package]]
+name = "sp-native-token-management"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "main-chain-follower-api",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sidechain-domain",
+ "sidechain-mc-hash",
+ "sp-api",
+ "sp-blockchain",
+ "sp-inherents",
+ "sp-runtime",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,9 @@ members = [
 	"primitives/session-validator-management/query",
     "primitives/session-manager",
     "primitives/sidechain",
-	"partner-chains-cli"
-]
+	"partner-chains-cli",
+    "pallets/native-token-management",
+    "primitives/native-token-management"]
 resolver = "2"
 
 [profile.release]
@@ -188,3 +189,5 @@ authority-selection-inherents = { path = "primitives/authority-selection-inheren
 session-manager = { path = "primitives/session-manager", default-features = false }
 sp-sidechain = { path = "primitives/sidechain", default-features = false }
 chain-params = { path = "primitives/chain-params", default-features = false }
+pallet-native-token-management = { path = "pallets/native-token-management", default-features = false }
+sp-native-token-management = { path = "primitives/native-token-management", default-features = false }

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,9 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 ## Fixed
 
 ## Added
+* ETCM-7811 - native token movement observability components: `sp-native-token-management` and
+`pallet-native-token-management` crates; data sources behind the `native-token` feature in
+`main-chain-follower-api` and `db-sync-follower` crates.
 
 # v1.0.0rc1
 

--- a/devnet/.envrc
+++ b/devnet/.envrc
@@ -15,6 +15,11 @@ export COMMITTEE_CANDIDATE_ADDRESS=$(jq -r '.addresses.CommitteeCandidateValidat
 export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' devnet/addresses.json)
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' devnet/addresses.json)
 
+# native token observability
+export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432
 export CARDANO_ACTIVE_SLOTS_COEFF=0.05

--- a/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/mainchain-follower/db-sync-follower/Cargo.toml
@@ -39,3 +39,4 @@ ctor = "0.2.5"
 default = []
 block-source = ["main-chain-follower-api/block-source"]
 candidate-source = ["main-chain-follower-api/candidate-source"]
+native-token = ["main-chain-follower-api/native-token"]

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -82,6 +82,12 @@ impl Asset {
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct AssetName(pub Vec<u8>);
 
+impl From<sidechain_domain::AssetName> for AssetName {
+	fn from(name: sidechain_domain::AssetName) -> Self {
+		Self(name.0.to_vec())
+	}
+}
+
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct DistributedSetData {
 	pub utxo_id_tx_hash: [u8; 32],
@@ -198,6 +204,12 @@ pub(crate) struct MintAction {
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct PolicyId(pub Vec<u8>);
 
+impl From<sidechain_domain::PolicyId> for PolicyId {
+	fn from(id: sidechain_domain::PolicyId) -> Self {
+		Self(id.0.to_vec())
+	}
+}
+
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct StakePoolEntry {
 	pub pool_hash: [u8; 28],
@@ -256,6 +268,28 @@ impl<'r> Decode<'r, Postgres> for StakeDelegation {
 	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
 		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
 		let i = decoded.to_u64().ok_or("StakeDelegation is always a u64".to_string())?;
+		Ok(Self(i))
+	}
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NativeTokenAmount(pub u64);
+impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
+	fn from(value: NativeTokenAmount) -> Self {
+		Self(value.0)
+	}
+}
+
+impl sqlx::Type<Postgres> for NativeTokenAmount {
+	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+		PgTypeInfo::with_name("NUMERIC")
+	}
+}
+
+impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
+	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
+		let i = decoded.to_u64().ok_or("NativeTokenQuantity is always a u64".to_string())?;
 		Ok(Self(i))
 	}
 }
@@ -352,7 +386,7 @@ LIMIT 1",
 }
 
 /// Query to get the block by its hash
-#[cfg(feature = "block-source")]
+#[cfg(any(feature = "block-source", feature = "native-token"))]
 pub(crate) async fn get_block_by_hash(
 	pool: &Pool<Postgres>,
 	hash: McBlockHash,
@@ -526,4 +560,36 @@ pub(crate) async fn index_exists(pool: &Pool<Postgres>, index_name: &str) -> boo
 		.await
 		.map(|rows| rows.len() == 1)
 		.unwrap()
+}
+
+#[cfg(feature = "native-token")]
+pub(crate) async fn get_total_native_tokens_transfered(
+	pool: &Pool<Postgres>,
+	after_slot: SlotNumber,
+	to_slot: SlotNumber,
+	asset: Asset,
+	illiquid_supply_address: Address,
+) -> Result<Option<NativeTokenAmount>, SqlxError> {
+	let query = sqlx::query_as::<_, (Option<NativeTokenAmount>,)>(
+		"
+SELECT
+    SUM(ma_tx_out.quantity)
+FROM tx_out
+LEFT JOIN ma_tx_out    ON ma_tx_out.tx_out_id = tx_out.id
+LEFT JOIN multi_asset  ON multi_asset.id = ma_tx_out.ident
+INNER JOIN tx          ON tx_out.tx_id = tx.id
+INNER JOIN block       ON tx.block_id = block.id
+WHERE address = $1
+AND multi_asset.policy = $2
+AND multi_asset.name = $3
+AND $4 < block.slot_no AND block.slot_no <= $5;
+    ",
+	)
+	.bind(&illiquid_supply_address.0)
+	.bind(&asset.policy_id.0)
+	.bind(&asset.asset_name.0)
+	.bind(after_slot)
+	.bind(to_slot);
+
+	Ok(query.fetch_one(pool).await?.0)
 }

--- a/mainchain-follower/db-sync-follower/src/lib.rs
+++ b/mainchain-follower/db-sync-follower/src/lib.rs
@@ -10,6 +10,8 @@ pub mod metrics;
 pub mod block;
 #[cfg(feature = "candidate-source")]
 pub mod candidates;
+#[cfg(feature = "native-token")]
+pub mod native_token;
 
 pub struct SqlxError(sqlx::Error);
 

--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -1,0 +1,63 @@
+use crate::db_model::Address;
+use crate::db_model::NativeTokenAmount;
+use crate::db_model::SlotNumber;
+use crate::metrics::McFollowerMetrics;
+use crate::observed_async_trait;
+use async_trait::async_trait;
+use main_chain_follower_api::NativeTokenManagementDataSource;
+use main_chain_follower_api::Result;
+use sidechain_domain::*;
+use sqlx::PgPool;
+
+#[cfg(test)]
+mod tests;
+
+pub struct NativeTokenManagementDataSourceImpl {
+	pub pool: PgPool,
+	pub metrics_opt: Option<McFollowerMetrics>,
+}
+
+observed_async_trait!(
+impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
+	async fn get_total_native_token_transfer(
+		&self,
+		after_block: Option<McBlockHash>,
+		to_block: McBlockHash,
+		native_token_policy_id: PolicyId,
+		native_token_asset_name: AssetName,
+		illiquid_supply_address: MainchainAddress,
+	) -> Result<sidechain_domain::NativeTokenAmount> {
+		if after_block == Some(to_block.clone()) {
+			return Ok(NativeTokenAmount(0).into());
+		}
+
+		let after_slot = match after_block {
+			None => SlotNumber(0),
+			Some(after_block) => {
+				crate::db_model::get_block_by_hash(&self.pool, after_block)
+					.await?
+					.expect("Parent MC hash is valid")
+					.slot_no
+			},
+		};
+		let to_slot = crate::db_model::get_block_by_hash(&self.pool, to_block)
+			.await?
+			.expect("current MC hash is valid")
+			.slot_no;
+
+		let total_transfer = crate::db_model::get_total_native_tokens_transfered(
+			&self.pool,
+			after_slot,
+			to_slot,
+			crate::db_model::Asset {
+				policy_id: native_token_policy_id.into(),
+				asset_name: native_token_asset_name.into(),
+			},
+			Address(illiquid_supply_address.to_string()),
+		)
+		.await?;
+
+		Ok(total_transfer.unwrap_or(NativeTokenAmount(0)).into())
+	}
+}
+);

--- a/mainchain-follower/db-sync-follower/src/native_token/tests.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/tests.rs
@@ -1,0 +1,90 @@
+use super::NativeTokenManagementDataSourceImpl;
+use main_chain_follower_api::NativeTokenManagementDataSource;
+use sidechain_domain::{AssetName, MainchainAddress, McBlockHash, PolicyId};
+use sqlx::PgPool;
+use std::str::FromStr;
+
+fn native_token_policy_id() -> PolicyId {
+	PolicyId::from_hex_unsafe("6c969320597b755454ff3653ad09725d590c570827a129aeb4385526")
+}
+
+fn native_token_asset_name() -> AssetName {
+	AssetName::from_hex_unsafe("546573744275647a507265766965775f3335")
+}
+
+fn illiquid_supply_address() -> MainchainAddress {
+	MainchainAddress::from_str("addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz")
+		.unwrap()
+}
+
+fn block_hash(i: u32) -> McBlockHash {
+	McBlockHash::from_str(&format!(
+		"b00000000000000000000000000000000000000000000000000000000000000{i}"
+	))
+	.unwrap()
+}
+
+pub fn genesis_hash() -> McBlockHash {
+	block_hash(0)
+}
+
+fn make_source(pool: PgPool) -> NativeTokenManagementDataSourceImpl {
+	NativeTokenManagementDataSourceImpl { pool, metrics_opt: None }
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn defaults_to_zero_when_there_are_no_transfers(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = None;
+	let to_block = genesis_hash();
+	let result = source
+		.get_total_native_token_transfer(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 0)
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn gets_sum_of_all_transfers_when_queried_up_to_latest_block(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = None;
+	let to_block = block_hash(5);
+	let result = source
+		.get_total_native_token_transfer(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 11 + 12 + 13 + 14)
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn gets_sum_of_transfers_in_range(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = Some(block_hash(1));
+	let to_block = block_hash(5);
+	let result = source
+		.get_total_native_token_transfer(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 12 + 13 + 14)
+}

--- a/mainchain-follower/db-sync-follower/testdata/native-token/migrations/1_create_schema.sql
+++ b/mainchain-follower/db-sync-follower/testdata/native-token/migrations/1_create_schema.sql
@@ -1,0 +1,212 @@
+CREATE DOMAIN hash28type AS bytea CONSTRAINT flyway_needs_this CHECK (octet_length(VALUE) = 28);
+
+CREATE DOMAIN hash32type AS bytea CONSTRAINT flyway_needs_this CHECK(octet_length(VALUE) = 32);
+
+CREATE DOMAIN "uinteger" AS integer CONSTRAINT flyway_needs_this CHECK (VALUE >= 0);
+
+CREATE DOMAIN "lovelace" AS numeric(20,0) CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
+
+CREATE DOMAIN "word64type" AS numeric(20,0)	CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
+
+CREATE DOMAIN word63type AS bigint CONSTRAINT word63type_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN word31type AS integer CONSTRAINT word31type_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN txindex AS smallint CONSTRAINT txindex_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN asset32type AS bytea CHECK (octet_length (VALUE) <= 32);
+
+CREATE DOMAIN int65type AS numeric (20, 0) CHECK (VALUE >= -18446744073709551615 AND VALUE <= 18446744073709551615);
+
+CREATE TYPE scriptpurposetype AS ENUM ('spend', 'mint', 'cert', 'reward');
+
+CREATE TABLE epoch_param (
+	id bigserial NOT NULL,
+	epoch_no "uinteger" NOT NULL,
+	min_fee_a "uinteger" NOT NULL,
+	min_fee_b "uinteger" NOT NULL,
+	max_block_size "uinteger" NOT NULL,
+	max_tx_size "uinteger" NOT NULL,
+	max_bh_size "uinteger" NOT NULL,
+	key_deposit "lovelace" NOT NULL,
+	pool_deposit "lovelace" NOT NULL,
+	max_epoch "uinteger" NOT NULL,
+	optimal_pool_count "uinteger" NOT NULL,
+	influence float8 NOT NULL,
+	monetary_expand_rate float8 NOT NULL,
+	treasury_growth_rate float8 NOT NULL,
+	decentralisation float8 NOT NULL,
+	entropy hash32type NULL,
+	protocol_major "uinteger" NOT NULL,
+	protocol_minor "uinteger" NOT NULL,
+	min_utxo_value "lovelace" NOT NULL,
+	min_pool_cost "lovelace" NOT NULL,
+	nonce hash32type NULL,
+	coins_per_utxo_word "lovelace" NULL,
+	cost_model_id int8 NULL,
+	price_mem float8 NULL,
+	price_step float8 NULL,
+	max_tx_ex_mem "word64type" NULL,
+	max_tx_ex_steps "word64type" NULL,
+	max_block_ex_mem "word64type" NULL,
+	max_block_ex_steps "word64type" NULL,
+	max_val_size "word64type" NULL,
+	collateral_percent "uinteger" NULL,
+	max_collateral_inputs "uinteger" NULL,
+	block_id int8 NOT NULL,
+	CONSTRAINT epoch_param_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_epoch_param UNIQUE (epoch_no, block_id)
+);
+CREATE INDEX idx_epoch_param_block_id ON epoch_param USING btree (block_id);
+
+CREATE TABLE pool_hash (
+	id bigserial NOT NULL,
+	hash_raw hash28type NOT NULL,
+	"view" varchar NOT NULL,
+	CONSTRAINT pool_hash_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_pool_hash UNIQUE (hash_raw)
+);
+
+
+CREATE TABLE epoch_stake (
+	id SERIAL PRIMARY KEY,
+	addr_id int8 NOT NULL,
+	pool_id int8 NOT NULL,
+	amount "lovelace" NOT NULL,
+	epoch_no "uinteger" NOT NULL,
+	CONSTRAINT unique_stake UNIQUE (epoch_no, addr_id, pool_id)
+);
+CREATE INDEX idx_epoch_stake_addr_id ON epoch_stake USING btree (addr_id);
+CREATE INDEX idx_epoch_stake_epoch_no ON epoch_stake USING btree (epoch_no);
+CREATE INDEX idx_epoch_stake_pool_id ON epoch_stake USING btree (pool_id);
+
+CREATE TABLE block (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    epoch_no word31type,
+    slot_no word63type,
+    epoch_slot_no word31type,
+    block_no word31type,
+    previous_id bigint,
+    slot_leader_id bigint NOT NULL,
+    size word31type NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    tx_count bigint NOT NULL,
+    proto_major word31type NOT NULL,
+    proto_minor word31type NOT NULL,
+    vrf_key character varying,
+    op_cert hash32type,
+    op_cert_counter word63type,
+    CONSTRAINT block_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE datum (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    tx_id bigint NOT NULL,
+    value JSONB,
+    CONSTRAINT datum_id PRIMARY KEY (id)
+);
+
+CREATE TABLE tx (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    block_id bigint NOT NULL,
+    block_index word31type NOT NULL,
+    out_sum lovelace NOT NULL,
+    fee lovelace NOT NULL,
+    deposit bigint NOT NULL,
+    size word31type NOT NULL,
+    invalid_before word64type,
+    invalid_hereafter word64type,
+    valid_contract boolean NOT NULL,
+    script_size word31type NOT NULL,
+    CONSTRAINT tx_pkey PRIMARY KEY (id),
+     -- this constraint unique_tx_block_index does not exist in the real database but it ensure we put
+     -- consistent data in our database
+	  CONSTRAINT unique_tx_block_index UNIQUE (block_id, block_index)
+);
+
+CREATE TABLE redeemer_data (
+	id bigserial NOT NULL,
+	hash public.hash32type NOT NULL,
+	tx_id int8 NOT NULL,
+	value jsonb NULL,
+	CONSTRAINT redeemer_data_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_redeemer_data UNIQUE (hash)
+);
+CREATE INDEX redeemer_data_tx_id_idx ON public.redeemer_data USING btree (tx_id);
+
+ALTER TABLE public.redeemer_data ADD CONSTRAINT redeemer_data_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+CREATE TABLE tx_in (
+    id bigint NOT NULL,
+    tx_in_id bigint NOT NULL,
+    tx_out_id bigint NOT NULL,
+    tx_out_index txindex NOT NULL,
+    redeemer_id bigint,
+    CONSTRAINT tx_in_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE tx_out (
+    id bigint NOT NULL,
+    tx_id bigint NOT NULL,
+    index txindex NOT NULL,
+    address character varying NOT NULL,
+    address_raw bytea NOT NULL,
+    address_has_script boolean NOT NULL,
+    payment_cred hash28type,
+    stake_address_id bigint,
+    value lovelace NOT NULL,
+    data_hash hash32type
+);
+
+CREATE TABLE redeemer (
+    id bigint PRIMARY KEY,
+    tx_id bigint NOT NULL,
+    unit_mem word63type NOT NULL,
+    unit_steps word63type NOT NULL,
+    fee lovelace NOT NULL,
+    purpose scriptpurposetype NOT NULL,
+    index uinteger NOT NULL,
+    script_hash hash28type NULL,
+    redeemer_data_id bigint NOT NULL
+);
+ALTER TABLE redeemer ADD CONSTRAINT unique_redeemer UNIQUE(tx_id, purpose, index);
+ALTER TABLE redeemer ADD CONSTRAINT redeemer_tx_id_fkey FOREIGN KEY(tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE redeemer ADD CONSTRAINT redeemer_datum_id_fkey FOREIGN KEY(redeemer_data_id) REFERENCES redeemer_data(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+CREATE TABLE multi_asset (
+    id bigint PRIMARY KEY,
+    policy hash28type NOT NULL,
+    name asset32type NOT NULL,
+    fingerprint varchar NOT NULL
+);
+ALTER TABLE multi_asset ADD CONSTRAINT unique_multi_asset UNIQUE (policy, name);
+
+CREATE TABLE ma_tx_mint (
+    id bigint PRIMARY KEY,
+    quantity int65type NOT NULL,
+    tx_id bigint NOT NULL,
+    ident bigint NOT NULL
+);
+ALTER TABLE ma_tx_mint ADD CONSTRAINT unique_ma_tx_mint UNIQUE(ident, tx_id);
+CREATE UNIQUE INDEX idx_ma_tx_mint_tx_id ON ma_tx_mint(tx_id);
+
+ALTER TABLE epoch_stake ADD CONSTRAINT epoch_stake_pool_id_fkey FOREIGN KEY (pool_id) REFERENCES pool_hash(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE ONLY tx
+    ADD CONSTRAINT unique_tx UNIQUE (hash);
+ALTER TABLE ONLY tx
+    ADD CONSTRAINT tx_block_id_fkey FOREIGN KEY (block_id) REFERENCES block(id) ON UPDATE RESTRICT ON DELETE CASCADE;
+
+CREATE TABLE public.ma_tx_out (
+	id bigserial NOT NULL,
+	quantity public."word64type" NOT NULL,
+	tx_out_id int8 NOT NULL,
+	ident int8 NOT NULL,
+	CONSTRAINT ma_tx_out_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_ma_tx_out UNIQUE (ident, tx_out_id),
+	CONSTRAINT ma_tx_out_ident_fkey FOREIGN KEY (ident) REFERENCES public.multi_asset(id) ON DELETE CASCADE ON UPDATE RESTRICT
+	-- CONSTRAINT ma_tx_out_tx_out_id_fkey FOREIGN KEY (tx_out_id) REFERENCES public.tx_out(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+CREATE INDEX idx_ma_tx_out_tx_out_id ON public.ma_tx_out USING btree (tx_out_id);

--- a/mainchain-follower/db-sync-follower/testdata/native-token/migrations/2_data.sql
+++ b/mainchain-follower/db-sync-follower/testdata/native-token/migrations/2_data.sql
@@ -1,0 +1,94 @@
+do $$
+declare
+    policy_id integer := 1001;
+    policy hash28type := decode('6c969320597b755454ff3653ad09725d590c570827a129aeb4385526', 'hex');
+    policy_name asset32type :=  '\x546573744275647a507265766965775f3335';
+    validator_addr text := 'addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz';
+
+    genesis_hash hash32type := decode('b000000000000000000000000000000000000000000000000000000000000000','hex');
+    block_hash_1 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000001','hex');
+    block_hash_2 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000002','hex');
+    block_hash_3 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000003','hex');
+    block_hash_4 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000004','hex');
+    block_hash_5 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000005','hex');
+
+    transfer_tx_id_1 integer := 1;
+    transfer_tx_id_2 integer := 2;
+    irrelevant_tx_id integer := 3;
+    transfer_tx_id_3 integer := 4;
+    transfer_tx_id_4 integer := 5;
+
+    transfer_tx_hash_1 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000001','hex');
+    transfer_tx_hash_2 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000002','hex');
+    irrelevant_tx_hash hash32type := decode('f000000000000000000000000000000000000000000000000000000000000003','hex');
+    transfer_tx_hash_3 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000004','hex');
+    transfer_tx_hash_4 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000005','hex');
+
+    transfer_utxo_id_1   integer := 0;
+    transfer_utxo_id_2   integer := 1;
+    irrelevant_utxo_id_1 integer := 2;
+    irrelevant_utxo_id_2 integer := 3;
+    transfer_utxo_id_3   integer := 4;
+    transfer_utxo_id_4   integer := 5;
+begin
+
+insert into multi_asset
+(id       , policy,                                                      "name",                                   fingerprint)
+values
+(0        , '\xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad01', '\xbadbadbadbadbadbadbadbadbadbadbad001', 'asset1thisassetshouldbeignoredbythequeries01'),
+(policy_id, policy                                                      , policy_name                             , 'asset1yedvsfmkxu27zaaa37lw44pa8ql9favqlyclnm'),
+(2        , '\xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad02', '\xbadbadbadbadbadbadbadbadbadbadbad002', 'asset1thisassetshouldbeignoredbythequeries02')
+;
+
+-- the integration test assume a securityParameter of 50, epoch duration of 1000 slots and a coeff of 1
+
+INSERT INTO block
+(id, hash        , epoch_no, slot_no , epoch_slot_no, block_no, previous_id, slot_leader_id, size, "time"                     , tx_count, proto_major, proto_minor, vrf_key, op_cert, op_cert_counter)
+VALUES
+(0 , genesis_hash, 189     , 189410, 410            , 0       , NULL       , 0             , 1024, '2022-04-21T16:28:00Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(1 , block_hash_1, 190     , 190400, 400            , 1       , NULL       , 0             , 1024, '2022-04-21T16:44:30Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(2 , block_hash_2, 190     , 190500, 500            , 2       , NULL       , 0             , 1024, '2022-04-21T16:46:10Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(3 , block_hash_3, 191     , 191500, 500            , 3       , NULL       , 0             , 1024, '2022-04-21T17:02:50Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(4 , block_hash_4, 192     , 192500, 500            , 4       , NULL       , 0             , 1024, '2022-04-21T17:19:30Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(5 , block_hash_5, 193     , 193500, 500            , 5       , NULL       , 0             , 1024, '2022-04-21T17:36:10Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           )
+;
+-- sometimes the block number can be null so we add this block just to handle that case
+INSERT INTO block
+(id , hash                                                                            , epoch_no, slot_no, epoch_slot_no, block_no, previous_id, slot_leader_id, "size", "time"                   , tx_count, proto_major, proto_minor, vrf_key, op_cert, op_cert_counter)
+VALUES
+(100, decode('b000000000000000000000000000000000000000000000000000000000000BAD','hex'), NULL    , NULL   , NULL         , NULL    , NULL       , 1             , 0     , '2022-06-06 23:00:00.000', 0       , 0          , 0          , NULL   , NULL   , NULL           )
+;
+
+
+INSERT INTO tx
+( id               , hash               , block_id, block_index, out_sum, fee, deposit, size, invalid_before, invalid_hereafter, valid_contract, script_size )
+VALUES
+( transfer_tx_id_1 , transfer_tx_hash_1 , 1       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_2 , transfer_tx_hash_2 , 3       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( irrelevant_tx_id , irrelevant_tx_hash , 3       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_3 , transfer_tx_hash_3 , 5       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_4 , transfer_tx_hash_4 , 5       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
+;
+
+INSERT INTO tx_out
+( id                   , tx_id           , index, address        , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash )
+VALUES
+( transfer_utxo_id_1   , transfer_tx_id_1, 0    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_2   , transfer_tx_id_2, 1    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( irrelevant_utxo_id_1 , irrelevant_tx_id, 0    , 'other_addr'   , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( irrelevant_utxo_id_2 , irrelevant_tx_id, 1    , 'another_addr' , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_3   , transfer_tx_id_3, 2    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_4   , transfer_tx_id_4, 0    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
+;
+
+INSERT INTO ma_tx_out
+(id   , quantity , tx_out_id , ident)
+VALUES
+(3001 , 11       , transfer_utxo_id_1      ,  policy_id),
+(3002 , 12       , transfer_utxo_id_2      ,  policy_id),
+(3003 , 13       , transfer_utxo_id_3      ,  policy_id),
+(3004 , 14       , transfer_utxo_id_4      ,  policy_id),
+(3005 , 100      , irrelevant_utxo_id_1    ,  0)
+;
+
+end $$;

--- a/mainchain-follower/main-chain-follower-api/Cargo.toml
+++ b/mainchain-follower/main-chain-follower-api/Cargo.toml
@@ -34,7 +34,9 @@ std = [
 serde = []
 block-source = ["std"]
 candidate-source = ["std"]
+native-token= ["std"]
 all-sources = [
     "block-source",
     "candidate-source",
+    "native-token"
 ]

--- a/mainchain-follower/main-chain-follower-api/src/lib.rs
+++ b/mainchain-follower/main-chain-follower-api/src/lib.rs
@@ -19,6 +19,11 @@ pub mod candidate;
 #[cfg(feature = "candidate-source")]
 pub use candidate::CandidateDataSource;
 
+#[cfg(feature = "native-token")]
+pub mod native_token;
+#[cfg(feature = "native-token")]
+pub use native_token::NativeTokenManagementDataSource;
+
 #[cfg(feature = "std")]
 pub mod mock_services;
 

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -170,12 +170,51 @@ mod candidates {
 	}
 }
 
+#[cfg(feature = "native-token")]
+pub use native_token::*;
+
+#[cfg(feature = "native-token")]
+mod native_token {
+	use super::*;
+	use crate::native_token::*;
+	use derive_new::new;
+	use std::collections::HashMap;
+
+	#[derive(new)]
+	pub struct MockNativeTokenDataSource {
+		transfers: HashMap<(Option<McBlockHash>, McBlockHash), NativeTokenAmount>,
+	}
+
+	impl Default for MockNativeTokenDataSource {
+		fn default() -> Self {
+			Self { transfers: Default::default() }
+		}
+	}
+
+	#[async_trait]
+	impl NativeTokenManagementDataSource for MockNativeTokenDataSource {
+		async fn get_total_native_token_transfer(
+			&self,
+			after_block: Option<McBlockHash>,
+			to_block: McBlockHash,
+			_native_token_policy_id: PolicyId,
+			_native_token_asset_name: AssetName,
+			_illiquid_supply_address: MainchainAddress,
+		) -> Result<NativeTokenAmount> {
+			println!("Called with {after_block:?} and {to_block:?}");
+			Ok(self.transfers.get(&(after_block, to_block)).cloned().unwrap_or_default())
+		}
+	}
+}
+
 #[derive(Clone)]
 pub struct TestDataSources {
 	#[cfg(feature = "block-source")]
 	pub block: Arc<dyn BlockDataSource + Send + Sync>,
 	#[cfg(feature = "candidate-source")]
 	pub candidate: Arc<dyn CandidateDataSource + Send + Sync>,
+	#[cfg(feature = "native-token")]
+	pub native_token: Arc<dyn NativeTokenManagementDataSource + Send + Sync>,
 }
 
 impl Default for TestDataSources {
@@ -191,6 +230,8 @@ impl TestDataSources {
 			block: Arc::from(MockBlockDataSource::default()),
 			#[cfg(feature = "candidate-source")]
 			candidate: Arc::from(MockCandidateDataSource::default()),
+			#[cfg(feature = "native-token")]
+			native_token: Arc::from(MockNativeTokenDataSource::default()),
 		}
 	}
 

--- a/mainchain-follower/main-chain-follower-api/src/native_token.rs
+++ b/mainchain-follower/main-chain-follower-api/src/native_token.rs
@@ -1,0 +1,16 @@
+use crate::Result;
+use async_trait::async_trait;
+use sidechain_domain::*;
+
+#[async_trait]
+pub trait NativeTokenManagementDataSource {
+	/// Retrieves total of native token transfers into the illiquid supply in the range (after_block, to_block]
+	async fn get_total_native_token_transfer(
+		&self,
+		after_block: Option<McBlockHash>,
+		to_block: McBlockHash,
+		native_token_policy_id: PolicyId,
+		native_token_asset_name: AssetName,
+		illiquid_supply_address: MainchainAddress,
+	) -> Result<NativeTokenAmount>;
+}

--- a/mainchain-follower/mock/Cargo.toml
+++ b/mainchain-follower/mock/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true }
 sidechain-domain = { workspace = true }
 
 [features]
-default = [ "std", "block-source", "candidate-source" ]
+default = [ "std", "block-source", "candidate-source", "native-token" ]
 std = [
 	"serde_json/std",
 	"sidechain-domain/std",
@@ -27,3 +27,4 @@ std = [
 ]
 block-source = ["main-chain-follower-api/block-source"]
 candidate-source = ["main-chain-follower-api/candidate-source"]
+native-token = ["main-chain-follower-api/native-token"]

--- a/mainchain-follower/mock/src/lib.rs
+++ b/mainchain-follower/mock/src/lib.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 pub mod block;
 #[cfg(feature = "candidate-source")]
 pub mod candidate;
+#[cfg(feature = "native-token")]
+pub mod native_token;
 
 #[allow(unused)]
 pub(crate) struct UnimplementedMocks;

--- a/mainchain-follower/mock/src/native_token.rs
+++ b/mainchain-follower/mock/src/native_token.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+pub use main_chain_follower_api::block::*;
+use main_chain_follower_api::native_token::*;
+use main_chain_follower_api::*;
+use sidechain_domain::*;
+
+pub struct NativeTokenDataSourceMock;
+
+impl NativeTokenDataSourceMock {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+#[async_trait]
+impl NativeTokenManagementDataSource for NativeTokenDataSourceMock {
+	async fn get_total_native_token_transfer(
+		&self,
+		_after_block: Option<McBlockHash>,
+		_to_block: McBlockHash,
+		_native_token_policy_id: PolicyId,
+		_native_token_asset_name: AssetName,
+		_illiquid_supply_address: MainchainAddress,
+	) -> Result<NativeTokenAmount> {
+		Ok(NativeTokenAmount(1000))
+	}
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -87,9 +87,10 @@ frame-benchmarking-cli = { workspace = true }
 # Local Dependencies
 sidechain-runtime = { workspace = true }
 sidechain-mc-hash = { workspace = true, features = ["mock"] }
+sp-native-token-management = { workspace = true }
 main-chain-follower-api = { workspace = true }
-db-sync-follower = { workspace = true, features = ["block-source", "candidate-source"] }
-main-chain-follower-mock = { workspace = true, features = ["block-source", "candidate-source"] }
+db-sync-follower = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }
+main-chain-follower-mock = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }
 tokio = { workspace = true }
 cli-commands = { workspace = true }
 

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -1,10 +1,16 @@
+use db_sync_follower::native_token::NativeTokenManagementDataSourceImpl;
 use db_sync_follower::{
 	block::{BlockDataSourceImpl, DbSyncBlockDataSourceConfig},
 	candidates::{cached::CandidateDataSourceCached, CandidatesDataSourceImpl},
 	metrics::McFollowerMetrics,
 };
-use main_chain_follower_api::{BlockDataSource, CandidateDataSource};
-use main_chain_follower_mock::{block::BlockDataSourceMock, candidate::MockCandidateDataSource};
+use main_chain_follower_api::{
+	BlockDataSource, CandidateDataSource, NativeTokenManagementDataSource,
+};
+use main_chain_follower_mock::{
+	block::BlockDataSourceMock, candidate::MockCandidateDataSource,
+	native_token::NativeTokenDataSourceMock,
+};
 use sc_service::error::Error as ServiceError;
 use std::error::Error;
 use std::sync::Arc;
@@ -13,6 +19,7 @@ use std::sync::Arc;
 pub struct DataSources {
 	pub block: Arc<dyn BlockDataSource + Send + Sync>,
 	pub candidate: Arc<dyn CandidateDataSource + Send + Sync>,
+	pub native_token: Arc<dyn NativeTokenManagementDataSource + Send + Sync>,
 }
 
 pub(crate) async fn create_cached_main_chain_follower_data_sources(
@@ -46,6 +53,7 @@ pub fn create_mock_data_sources(
 	Ok(DataSources {
 		block: Arc::new(BlockDataSourceMock),
 		candidate: Arc::new(MockCandidateDataSource::from_env()?),
+		native_token: Arc::new(NativeTokenDataSourceMock::new()),
 	})
 }
 
@@ -67,5 +75,6 @@ pub async fn create_cached_data_sources(
 			CandidatesDataSourceImpl::from_config(pool.clone(), metrics_opt.clone()).await?,
 			CANDIDATES_FOR_EPOCH_CACHE_SIZE,
 		)?),
+		native_token: Arc::new(NativeTokenManagementDataSourceImpl { pool, metrics_opt }),
 	})
 }

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -2,10 +2,11 @@ use crate::chain_spec::get_account_id_from_seed;
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::*;
 use sidechain_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
-	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
+	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig,
+	RuntimeGenesisConfig, SessionCommitteeManagementConfig, SessionConfig, SidechainConfig,
+	SudoConfig, SystemConfig,
 };
 use sp_core::bytes::from_hex;
 use sp_core::{ed25519, sr25519};
@@ -163,6 +164,18 @@ pub fn staging_genesis(
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -1,9 +1,9 @@
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::{AssetName, MainchainAddress, MainchainAddressHash, PolicyId, UtxoId};
 use sidechain_runtime::{
-	AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
+	AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig, RuntimeGenesisConfig,
 	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
 };
 
@@ -43,6 +43,18 @@ pub fn chain_spec() -> Result<ChainSpec, EnvVarReadError> {
 			// Same as SessionConfig
 			initial_authorities: vec![],
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 	let genesis_json = serde_json::to_value(runtime_genesis_config)

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -1,10 +1,11 @@
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::*;
 use sidechain_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
-	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
+	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig,
+	RuntimeGenesisConfig, SessionCommitteeManagementConfig, SessionConfig, SidechainConfig,
+	SudoConfig, SystemConfig,
 };
 use sidechain_slots::SlotsPerEpoch;
 use sp_core::bytes::from_hex;
@@ -203,6 +204,18 @@ pub fn testnet_genesis(
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 

--- a/node/src/tests/inherent_data_tests.rs
+++ b/node/src/tests/inherent_data_tests.rs
@@ -3,7 +3,9 @@ use crate::tests::mock::{test_client, test_create_inherent_data_config};
 use crate::tests::runtime_api_mock::mock_header;
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
 use main_chain_follower_api::{block::MainchainBlock, mock_services::*};
-use sidechain_domain::{McBlockHash, McBlockNumber, McEpochNumber, McSlotNumber};
+use sidechain_domain::{
+	McBlockHash, McBlockNumber, McEpochNumber, McSlotNumber, NativeTokenAmount,
+};
 use sp_consensus_aura::Slot;
 use sp_core::H256;
 use sp_inherents::CreateInherentDataProviders;
@@ -28,9 +30,10 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 	.unwrap();
 
 	#[cfg(not(feature = "block-beneficiary"))]
-	let (slot, timestamp, mc_hash, ariadne_data) = inherent_data_providers;
+	let (slot, timestamp, mc_hash, ariadne_data, native_token) = inherent_data_providers;
 	#[cfg(feature = "block-beneficiary")]
-	let (slot, timestamp, mc_hash, ariadne_data, block_beneficiary) = inherent_data_providers;
+	let (slot, timestamp, mc_hash, ariadne_data, block_beneficiary, native_token) =
+		inherent_data_providers;
 	let mut inherent_data = InherentData::new();
 	slot.provide_inherent_data(&mut inherent_data).await.unwrap();
 	timestamp.provide_inherent_data(&mut inherent_data).await.unwrap();
@@ -38,6 +41,7 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 	ariadne_data.provide_inherent_data(&mut inherent_data).await.unwrap();
 	#[cfg(feature = "block-beneficiary")]
 	block_beneficiary.provide_inherent_data(&mut inherent_data).await.unwrap();
+	native_token.provide_inherent_data(&mut inherent_data).await.unwrap();
 	assert_eq!(
 		inherent_data
 			.get_data::<Slot>(&sp_consensus_aura::inherents::INHERENT_IDENTIFIER)
@@ -63,6 +67,10 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 		.get_data::<AuthoritySelectionInputs>(&sp_session_validator_management::INHERENT_IDENTIFIER)
 		.unwrap()
 		.is_some());
+	assert!(inherent_data
+		.get_data::<NativeTokenAmount>(&sp_native_token_management::INHERENT_IDENTIFIER)
+		.unwrap()
+		.is_some())
 }
 
 #[tokio::test]
@@ -88,10 +96,11 @@ async fn block_verification_cidp_should_be_created_correctly() {
 		.create_inherent_data_providers(mock_header().hash(), (30.into(), mc_block_hash))
 		.await
 		.unwrap();
-	let (timestamp, ariadne_data_provider) = inherent_data_providers;
+	let (timestamp, ariadne_data_provider, native_token_provider) = inherent_data_providers;
 	let mut inherent_data = InherentData::new();
 	timestamp.provide_inherent_data(&mut inherent_data).await.unwrap();
 	ariadne_data_provider.provide_inherent_data(&mut inherent_data).await.unwrap();
+	native_token_provider.provide_inherent_data(&mut inherent_data).await.unwrap();
 
 	assert_eq!(
 		inherent_data.get_data::<Timestamp>(&sp_timestamp::INHERENT_IDENTIFIER).unwrap(),
@@ -101,4 +110,8 @@ async fn block_verification_cidp_should_be_created_correctly() {
 		.get_data::<AuthoritySelectionInputs>(&sp_session_validator_management::INHERENT_IDENTIFIER)
 		.unwrap()
 		.is_some());
+	assert!(inherent_data
+		.get_data::<NativeTokenAmount>(&sp_native_token_management::INHERENT_IDENTIFIER)
+		.unwrap()
+		.is_some())
 }

--- a/node/src/tests/mock.rs
+++ b/node/src/tests/mock.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 impl From<TestDataSources> for DataSources {
 	fn from(value: TestDataSources) -> Self {
-		Self { block: value.block, candidate: value.candidate }
+		Self { block: value.block, candidate: value.candidate, native_token: value.native_token }
 	}
 }
 

--- a/node/src/tests/runtime_api_mock.rs
+++ b/node/src/tests/runtime_api_mock.rs
@@ -82,6 +82,17 @@ sp_api::mock_impl_runtime_apis! {
 			}
 		}
 	}
+
+	impl sp_native_token_management::NativeTokenManagementApi<Block> for TestApi {
+		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+			sp_native_token_management::MainChainScripts {
+				native_token_policy: Default::default(),
+				native_token_asset_name: Default::default(),
+				illiquid_supply_address: Default::default(),
+
+			}
+		}
+	}
 }
 
 impl HeaderBackend<Block> for TestApi {

--- a/pallets/native-token-management/Cargo.toml
+++ b/pallets/native-token-management/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pallet-native-token-management"
+version = "0.1.0"
+edition = "2021"
+description = "Pallet responsible for handling changes to the illiquid supply of the native token on main chain."
+
+[dependencies]
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-native-token-management = { workspace = true, features = ["serde"] }
+sidechain-domain = { workspace = true }
+
+[dev-dependencies]
+sp-io = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "scale-info/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-native-token-management/std"
+]

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -1,0 +1,135 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::inherent::IsFatalError;
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
+use sidechain_domain::NativeTokenAmount;
+use sp_native_token_management::*;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "mock"))]
+mod mock;
+
+#[derive(Encode, Debug, PartialEq)]
+pub enum InherentError {
+	TokenTransferNotHandled,
+	IncorrectTokenNumberTransfered,
+	UnexpectedTokenTransferInherent,
+}
+
+impl IsFatalError for InherentError {
+	fn is_fatal_error(&self) -> bool {
+		true
+	}
+}
+
+/// Interface for user-provided logic to handle native token transfers into the illiquid supply on the main chain.
+///
+/// The handler will be called with **the total sum** of transfers since the previous partner chain block.
+pub trait TokenTransferHandler {
+	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult;
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type TokenTransferHandler: TokenTransferHandler;
+	}
+
+	#[pallet::event]
+	pub enum Event<T: Config> {
+		TokensTransfered(NativeTokenAmount),
+	}
+
+	#[pallet::storage]
+	pub type MainChainScripts<T: Config> =
+		StorageValue<_, sp_native_token_management::MainChainScripts, ValueQuery>;
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
+		pub main_chain_scripts: sp_native_token_management::MainChainScripts,
+		pub _marker: PhantomData<T>,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			MainChainScripts::<T>::put(self.main_chain_scripts.clone());
+		}
+	}
+
+	#[pallet::inherent]
+	impl<T: Config> ProvideInherent for Pallet<T> {
+		type Call = Call<T>;
+		type Error = InherentError;
+		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+			Self::get_transfered_tokens_from_inherent_data(data)
+				.map(|data| Call::transfer_tokens { token_amount: data.token_amount })
+		}
+
+		fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
+			let Some(token_transfer) = Self::get_transfered_tokens_from_inherent_data(data) else {
+				return Err(InherentError::UnexpectedTokenTransferInherent);
+			};
+			let Call::transfer_tokens { token_amount } = call else {
+				unreachable!("There is no other extrinsic in this pallet");
+			};
+			if token_transfer.token_amount != *token_amount {
+				return Err(InherentError::IncorrectTokenNumberTransfered);
+			}
+
+			Ok(())
+		}
+
+		fn is_inherent(call: &Self::Call) -> bool {
+			matches!(call, Call::transfer_tokens { .. })
+		}
+
+		fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
+			Ok(Self::get_transfered_tokens_from_inherent_data(data)
+				.map(|_| InherentError::TokenTransferNotHandled))
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		fn get_transfered_tokens_from_inherent_data(
+			data: &InherentData,
+		) -> Option<TokenTransferData> {
+			data.get_data::<TokenTransferData>(&INHERENT_IDENTIFIER)
+				.expect("Token transfer data not correctly encoded")
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight((0, DispatchClass::Mandatory))]
+		pub fn transfer_tokens(
+			origin: OriginFor<T>,
+			token_amount: NativeTokenAmount,
+		) -> DispatchResult {
+			ensure_none(origin)?;
+			T::TokenTransferHandler::handle_token_transfer(token_amount)
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+			MainChainScripts::<T>::get()
+		}
+	}
+}

--- a/pallets/native-token-management/src/mock.rs
+++ b/pallets/native-token-management/src/mock.rs
@@ -1,0 +1,92 @@
+use crate::mock::sp_runtime::testing::H256;
+use crate::DispatchResult;
+use crate::TokenTransferHandler;
+use frame_support::sp_runtime::traits::BlakeTwo256;
+use frame_support::sp_runtime::traits::IdentityLookup;
+use frame_support::sp_runtime::BuildStorage;
+use frame_support::traits::ConstU16;
+use frame_support::traits::ConstU32;
+use frame_support::traits::ConstU64;
+use frame_support::*;
+use sidechain_domain::*;
+
+use self::mock_pallet::LastTokenTransfer;
+
+type AccountId = u64;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[frame_support::pallet]
+pub mod mock_pallet {
+	use frame_support::pallet_prelude::*;
+	use sidechain_domain::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::storage]
+	pub type LastTokenTransfer<T: Config> = StorageValue<_, NativeTokenAmount, OptionQuery>;
+}
+
+impl<T: mock_pallet::Config> TokenTransferHandler for mock_pallet::Pallet<T> {
+	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult {
+		LastTokenTransfer::<T>::put(token_amount);
+		Ok(())
+	}
+}
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		NativeTokenManagement: crate::pallet,
+		Mock: mock_pallet,
+	}
+);
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+	type Nonce = u64;
+	type Block = Block;
+	type RuntimeTask = RuntimeTask;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+}
+
+impl crate::pallet::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type TokenTransferHandler = Mock;
+}
+
+impl mock_pallet::Config for Test {}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	RuntimeGenesisConfig { system: Default::default(), native_token_management: Default::default() }
+		.build_storage()
+		.unwrap()
+		.into()
+}

--- a/pallets/native-token-management/src/tests.rs
+++ b/pallets/native-token-management/src/tests.rs
@@ -1,0 +1,135 @@
+use self::mock::{RuntimeOrigin, Test};
+	use self::mock::NativeTokenManagement;
+use crate::mock::mock_pallet;
+use crate::mock::new_test_ext;
+use crate::*;
+use frame_support::traits::UnfilteredDispatchable;
+
+mod create_inherent {
+	use super::*;
+
+	#[test]
+	fn creates_inherent_from_inherent_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1001);
+
+			let result = NativeTokenManagement::create_inherent(&inherent_data);
+
+			assert_eq!(result, Some(Call::transfer_tokens { token_amount: 1001.into() }))
+		})
+	}
+	#[test]
+	fn skips_inherent_if_no_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+
+			let result = NativeTokenManagement::create_inherent(&inherent_data);
+
+			assert_eq!(result, None)
+		})
+	}
+}
+
+mod check_inherent {
+	use super::*;
+
+	#[test]
+	fn pass_when_inherent_matches_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1002);
+			let inherent = Call::transfer_tokens { token_amount: 1002.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Ok(()))
+		})
+	}
+	#[test]
+	fn fail_when_token_amount_mismatch() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1002);
+			let inherent = Call::transfer_tokens { token_amount: 9999.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Err(InherentError::IncorrectTokenNumberTransfered))
+		})
+	}
+	#[test]
+	fn fail_when_unexpected_inherent() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+			let inherent = Call::transfer_tokens { token_amount: 1002.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Err(InherentError::UnexpectedTokenTransferInherent));
+		})
+	}
+}
+
+mod is_inherent_required {
+	use super::*;
+
+	#[test]
+	fn yes_when_data_present() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1001);
+			let error = NativeTokenManagement::is_inherent_required(&inherent_data)
+				.expect("Check should successfully run.")
+				.expect("Check should return an error object.");
+
+			assert_eq!(error, InherentError::TokenTransferNotHandled);
+		})
+	}
+
+	#[test]
+	fn no_when_data_absent() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+			let result = NativeTokenManagement::is_inherent_required(&inherent_data)
+				.expect("Check should successfully run.");
+
+			assert!(result.is_none());
+		})
+	}
+}
+
+mod inherent {
+	use super::*;
+
+	#[test]
+	fn succeeds_and_calls_transfer_handler() {
+		new_test_ext().execute_with(|| {
+			let inherent: Call<Test> = Call::transfer_tokens { token_amount: 1000.into() };
+
+			let _ = inherent.dispatch_bypass_filter(RuntimeOrigin::none()).unwrap();
+
+			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get().unwrap().0, 1000)
+		})
+	}
+
+	#[test]
+	fn fails_when_not_root() {
+		new_test_ext().execute_with(|| {
+			let inherent: Call<Test> = Call::transfer_tokens { token_amount: 1000.into() };
+
+			let result = inherent.dispatch_bypass_filter(RuntimeOrigin::signed(Default::default()));
+
+			assert_eq!(result.unwrap_err().error, DispatchError::BadOrigin);
+
+			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get(), None)
+		})
+	}
+}
+
+fn test_inherent_data(token_amount: u64) -> InherentData {
+	let mut inherent_data = InherentData::new();
+	inherent_data
+		.put_data(
+			INHERENT_IDENTIFIER,
+			&TokenTransferData { token_amount: NativeTokenAmount(token_amount) },
+		)
+		.unwrap();
+	inherent_data
+}

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -57,6 +57,23 @@ impl StakeDelegation {
 	}
 }
 
+#[derive(
+	Default,
+	Clone,
+	Copy,
+	Debug,
+	Encode,
+	Decode,
+	TypeInfo,
+	ToDatum,
+	PartialEq,
+	Eq,
+	From,
+	MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct NativeTokenAmount(pub u64);
+
 /// A main chain block number. In range [0, 2^31-1].
 #[derive(
 	Default,
@@ -162,6 +179,12 @@ const POLICY_ID_LEN: usize = 28;
 #[derive(Clone, Default, PartialEq, Eq, Encode, Decode, ToDatum, TypeInfo, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct PolicyId(pub [u8; POLICY_ID_LEN]);
+
+pub const MAX_ASSET_NAME_LEN: u32 = 32;
+
+#[derive(Clone, Default, PartialEq, Eq, Encode, Decode, ToDatum, TypeInfo, MaxEncodedLen)]
+#[byte_string(debug, hex_serialize, hex_deserialize, decode_hex)]
+pub struct AssetName(pub BoundedVec<u8, ConstU32<MAX_ASSET_NAME_LEN>>);
 
 const MAINCHAIN_PUBLIC_KEY_LEN: usize = 32;
 
@@ -389,7 +412,7 @@ impl TryFrom<Vec<u8>> for McTxHash {
 	}
 }
 
-#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen)]
+#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct McBlockHash(pub [u8; 32]);
 

--- a/primitives/native-token-management/Cargo.toml
+++ b/primitives/native-token-management/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "sp-native-token-management"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+async-trait = { workspace = true, optional = true }
+main-chain-follower-api = { workspace = true, optional = true, features = ["native-token"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sidechain-domain = { workspace = true }
+sidechain-mc-hash = { workspace = true, optional = true }
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true, optional = true }
+sp-inherents = { workspace = true }
+sp-runtime = { workspace = true }
+thiserror = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "async-trait",
+    "main-chain-follower-api/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sidechain-domain/std",
+    "sidechain-mc-hash",
+    "sp-api/std",
+    "sp-blockchain",
+    "sp-inherents/std",
+    "sp-runtime/std",
+    "thiserror"
+]
+serde = [
+	"dep:serde",
+	"scale-info/serde",
+	"sidechain-domain/serde",
+]

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -1,0 +1,127 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+pub use inherent_provider::*;
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use sidechain_domain::*;
+use sp_inherents::*;
+use sp_runtime::{
+	scale_info::TypeInfo,
+	traits::{Block as BlockT, Header, Zero},
+};
+
+#[cfg(test)]
+mod tests;
+
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"ntreserv";
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, TypeInfo, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MainChainScripts {
+	pub native_token_policy: PolicyId,
+	pub native_token_asset_name: AssetName,
+	pub illiquid_supply_address: MainchainAddress,
+}
+
+sp_api::decl_runtime_apis! {
+	pub trait NativeTokenManagementApi {
+		fn get_main_chain_scripts() -> MainChainScripts;
+	}
+}
+
+#[derive(Decode, Encode)]
+pub struct TokenTransferData {
+	pub token_amount: NativeTokenAmount,
+}
+
+#[cfg(feature = "std")]
+mod inherent_provider {
+	use super::*;
+	use main_chain_follower_api::{DataSourceError, NativeTokenManagementDataSource};
+	use sidechain_mc_hash::McHashInherentDigest;
+	use sp_api::{ApiError, ProvideRuntimeApi};
+	use sp_blockchain::HeaderBackend;
+	use std::sync::Arc;
+
+	pub struct NativeTokenManagementInherentDataProvider {
+		pub token_amount: NativeTokenAmount,
+	}
+
+	#[derive(thiserror::Error, sp_runtime::RuntimeDebug)]
+	pub enum IDPCreationError {
+		#[error("Failed to read native token data from data source: {0:?}")]
+		DataSourceError(DataSourceError),
+		#[error("Failed to retrieve main chain scripts from the runtime: {0:?}")]
+		GetMainChainScriptsError(ApiError),
+	}
+
+	impl From<DataSourceError> for IDPCreationError {
+		fn from(err: DataSourceError) -> Self {
+			Self::DataSourceError(err)
+		}
+	}
+
+	impl NativeTokenManagementInherentDataProvider {
+		pub async fn new<Block, C>(
+			client: Arc<C>,
+			data_source: &(dyn NativeTokenManagementDataSource + Send + Sync),
+			mc_hash: McBlockHash,
+			parent_hash: <Block as BlockT>::Hash,
+		) -> Result<Self, IDPCreationError>
+		where
+			Block: BlockT,
+			C: HeaderBackend<Block>,
+			C: ProvideRuntimeApi<Block> + Send + Sync,
+			C::Api: NativeTokenManagementApi<Block>,
+		{
+			let api = client.runtime_api();
+			let scripts = api
+				.get_main_chain_scripts(parent_hash)
+				.map_err(IDPCreationError::GetMainChainScriptsError)?;
+			let parent_mc_hash: Option<McBlockHash> = client
+				.header(parent_hash)
+				.unwrap()
+				.filter(|parent_header| !parent_header.number().is_zero())
+				.map(|parent_header| {
+					McHashInherentDigest::value_from_digest(&parent_header.digest().logs).unwrap()
+				});
+			let token_amount = data_source
+				.get_total_native_token_transfer(
+					parent_mc_hash,
+					mc_hash,
+					scripts.native_token_policy,
+					scripts.native_token_asset_name,
+					scripts.illiquid_supply_address,
+				)
+				.await?;
+
+			Ok(Self { token_amount })
+		}
+	}
+
+	#[async_trait::async_trait]
+	impl InherentDataProvider for NativeTokenManagementInherentDataProvider {
+		async fn provide_inherent_data(
+			&self,
+			inherent_data: &mut InherentData,
+		) -> Result<(), sp_inherents::Error> {
+			inherent_data.put_data(
+				INHERENT_IDENTIFIER,
+				&TokenTransferData { token_amount: self.token_amount.clone() },
+			)
+		}
+
+		async fn try_handle_error(
+			&self,
+			identifier: &InherentIdentifier,
+			_error: &[u8],
+		) -> Option<Result<(), sp_inherents::Error>> {
+			if *identifier == INHERENT_IDENTIFIER {
+				panic!("BUG: {:?} inherent shouldn't return any errors", INHERENT_IDENTIFIER)
+			} else {
+				None
+			}
+		}
+	}
+}

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -1,0 +1,148 @@
+pub(crate) mod runtime_api_mock;
+
+#[cfg(feature = "std")]
+mod inherent_provider {
+	use super::runtime_api_mock::*;
+	use crate::inherent_provider::*;
+	use crate::INHERENT_IDENTIFIER;
+	use main_chain_follower_api::mock_services::MockNativeTokenDataSource;
+	use sidechain_domain::*;
+	use sidechain_mc_hash::MC_HASH_DIGEST_ID;
+	use sp_inherents::InherentData;
+	use sp_inherents::InherentDataProvider;
+	use sp_runtime::testing::Digest;
+	use sp_runtime::testing::DigestItem;
+	use std::sync::Arc;
+
+	#[tokio::test]
+	async fn correctly_fetches_total_transfer_between_two_hashes() {
+		let parent_number = 1; // not genesis
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = Some(McBlockHash([3; 32]));
+		let total_transfered = 103;
+
+		let data_source =
+			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+	}
+
+	#[tokio::test]
+	async fn fetches_with_no_lower_bound_when_parent_is_genesis() {
+		let parent_number = 0; // genesis
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = None; // genesis doesn't refer to any mc hash
+		let total_transfered = 103;
+
+		let data_source =
+			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+	}
+
+	#[tokio::test]
+	async fn defaults_to_zero_when_no_data() {
+		let parent_number = 1;
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = Some(McBlockHash([3; 32]));
+
+		let data_source = MockNativeTokenDataSource::new([].into());
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, 0)
+	}
+
+	#[tokio::test]
+	async fn correctly_puts_data_into_inherent_data_structure() {
+		let token_amount = 1234;
+
+		let mut inherent_data = InherentData::new();
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider {
+			token_amount: NativeTokenAmount(token_amount),
+		};
+
+		inherent_provider.provide_inherent_data(&mut inherent_data).await.unwrap();
+
+		assert_eq!(
+			inherent_data
+				.get_data::<NativeTokenAmount>(&INHERENT_IDENTIFIER)
+				.unwrap()
+				.unwrap()
+				.0,
+			token_amount
+		)
+	}
+
+	fn create_data_source(
+		parent_mc_hash: Option<McBlockHash>,
+		mc_hash: McBlockHash,
+		total_transfered: u64,
+	) -> MockNativeTokenDataSource {
+		let total_transfered = NativeTokenAmount(total_transfered);
+		MockNativeTokenDataSource::new([((parent_mc_hash, mc_hash), total_transfered)].into())
+	}
+
+	fn create_client(
+		parent_hash: Hash,
+		parent_mc_hash: Option<McBlockHash>,
+		parent_number: u32,
+	) -> Arc<TestApi> {
+		Arc::new(TestApi {
+			headers: [(
+				parent_hash.clone(),
+				Header {
+					digest: Digest {
+						logs: match parent_mc_hash {
+							None => vec![],
+							Some(parent_mc_hash) => vec![DigestItem::PreRuntime(
+								MC_HASH_DIGEST_ID,
+								parent_mc_hash.0.to_vec(),
+							)],
+						},
+					},
+					extrinsics_root: Default::default(),
+					number: parent_number,
+					parent_hash: parent_hash.clone(),
+					state_root: Default::default(),
+				},
+			)]
+			.into(),
+		})
+	}
+}

--- a/primitives/native-token-management/src/tests/runtime_api_mock.rs
+++ b/primitives/native-token-management/src/tests/runtime_api_mock.rs
@@ -1,0 +1,78 @@
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
+use std::collections::HashMap;
+
+use crate::MainChainScripts;
+
+pub type Block = sp_runtime::generic::Block<
+	sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>,
+	sp_runtime::OpaqueExtrinsic,
+>;
+
+pub type Hash = <Block as sp_runtime::traits::Block>::Hash;
+pub type Header = <Block as sp_runtime::traits::Block>::Header;
+
+#[derive(Clone)]
+pub struct TestApi {
+	pub headers: HashMap<<Block as BlockT>::Hash, <Block as BlockT>::Header>,
+}
+
+impl sp_api::ProvideRuntimeApi<Block> for TestApi {
+	type Api = TestApi;
+
+	fn runtime_api(&self) -> sp_api::ApiRef<Self::Api> {
+		self.clone().into()
+	}
+}
+
+sp_api::mock_impl_runtime_apis! {
+	impl crate::NativeTokenManagementApi<Block> for TestApi {
+		fn get_main_chain_scripts() -> MainChainScripts {
+			MainChainScripts::default()
+		}
+
+	}
+}
+
+impl HeaderBackend<Block> for TestApi {
+	fn header(
+		&self,
+		id: <Block as BlockT>::Hash,
+	) -> Result<Option<<Block as BlockT>::Header>, sp_blockchain::Error> {
+		Ok(self.headers.get(&id).cloned())
+	}
+
+	fn info(&self) -> sp_blockchain::Info<Block> {
+		sp_blockchain::Info {
+			best_hash: Default::default(),
+			best_number: Zero::zero(),
+			finalized_hash: Default::default(),
+			finalized_number: Zero::zero(),
+			genesis_hash: Default::default(),
+			number_leaves: Default::default(),
+			finalized_state: None,
+			block_gap: None,
+		}
+	}
+
+	fn status(
+		&self,
+		_id: <Block as BlockT>::Hash,
+	) -> Result<sp_blockchain::BlockStatus, sp_blockchain::Error> {
+		Ok(sp_blockchain::BlockStatus::Unknown)
+	}
+
+	fn number(
+		&self,
+		_hash: <Block as BlockT>::Hash,
+	) -> Result<Option<NumberFor<Block>>, sp_blockchain::Error> {
+		Ok(None)
+	}
+
+	fn hash(
+		&self,
+		_number: NumberFor<Block>,
+	) -> Result<Option<<Block as BlockT>::Hash>, sp_blockchain::Error> {
+		unimplemented!()
+	}
+}

--- a/primitives/sidechain-mc-hash/Cargo.toml
+++ b/primitives/sidechain-mc-hash/Cargo.toml
@@ -7,7 +7,7 @@ description = "Logic for putting a main chain block reference in digest and inhe
 [dependencies]
 async-trait = { workspace = true }
 main-chain-follower-api = { workspace = true, features = ["block-source"] }
-sp-consensus-slots = { workspace = true }
+sp-consensus-slots = { workspace = true, features = ["std"] }
 sidechain-domain = { workspace = true, features = ["std"] }
 sp-consensus = { workspace = true }
 sp-inherents = { workspace = true, features = ["std"] }

--- a/primitives/sidechain-mc-hash/src/lib.rs
+++ b/primitives/sidechain-mc-hash/src/lib.rs
@@ -13,7 +13,7 @@ use std::{error::Error, ops::Deref};
 mod test;
 
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"scmchash";
-const MC_HASH_DIGEST_ID: [u8; 4] = *b"mcsh";
+pub const MC_HASH_DIGEST_ID: [u8; 4] = *b"mcsh";
 
 #[derive(Debug)]
 pub struct McHashInherentDataProvider {
@@ -118,6 +118,10 @@ impl McHashInherentDataProvider {
 
 	pub fn mc_block(&self) -> McBlockNumber {
 		self.mc_block.number
+	}
+
+	pub fn mc_hash(&self) -> McBlockHash {
+		self.mc_block.hash.clone()
 	}
 }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,6 +70,8 @@ sidechain-domain = { workspace = true, features = ["serde"] }
 chain-params = { workspace = true, features = ["serde"] }
 sidechain-slots = { workspace = true }
 session-manager = { workspace = true }
+pallet-native-token-management = { workspace = true }
+sp-native-token-management = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 sp-io = { workspace = true }
@@ -140,6 +142,8 @@ std = [
 	"sidechain-domain/std",
 	"sp-inherents/std",
 	"chain-params/std",
+	"pallet-native-token-management/std",
+	"sp-native-token-management/std"
 ]
 
 runtime-benchmarks = [

--- a/staging/.envrc
+++ b/staging/.envrc
@@ -15,6 +15,11 @@ export COMMITTEE_CANDIDATE_ADDRESS=$(jq -r '.addresses.CommitteeCandidateValidat
 export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' staging/addresses.json)
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' staging/addresses.json)
 
+# native token observability
+export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432
 export CARDANO_ACTIVE_SLOTS_COEFF=0.05

--- a/utils/byte-string-derivation/src/lib.rs
+++ b/utils/byte-string-derivation/src/lib.rs
@@ -203,6 +203,14 @@ fn gen_from_hex(name: &syn::Ident, ty: &SupportedType, generics: &Generics) -> i
 				Ok(#name(value))
 			}
 		},
+		SupportedType::BoundedVec(ty) => quote! {
+			pub fn decode_hex(s: &str) -> Result<Self, &'static str> {
+				let bytes = sp_core::bytes::from_hex(s).map_err(|_| "Cannot decode bytes from hex string")?;
+				let value = <#ty>::try_from(bytes).map_err(|_| "Invalid length")?;
+				Ok(#name(value))
+			}
+
+		},
 		_ => quote! {
 			pub fn decode_hex(s: &str) -> Result<Self, &'static str> {
 				Ok(#name(sp_core::bytes::from_hex(s).map_err(|_| "Cannot decode bytes from hex string")?))


### PR DESCRIPTION
# Description

‼️ This PR is here to show all the changes together and is not intended to be merged. Please review the partial PRs (when undrafted):
1. [data source](https://github.com/input-output-hk/partner-chains/pull/40)
2. [inherent data provider](https://github.com/input-output-hk/partner-chains/pull/37)
3. [pallet](https://github.com/input-output-hk/partner-chains/pull/36)

A working implementation of [the native token observability design](https://miro.com/app/board/uXjVKs3q69w=/?moveToWidget=3458764596872450048&cot=14) that I shared a couple weeks ago. It:
1. observes all transactions that put utxos containing native tokens (identified by policy and asset name) into the illiquid supply validator
 (identified by an address)
2. creates an inherent data with the total count of newly "locked" tokens since the last mc hash (mc hash referenced by the parent block)
3. consumes the inherent data in the `native-token-management` pallet and runs an inherent that triggers a hook provided by the PC dev as part of the pallet's configuration.
4. The current implementation of the hook credits a dummy account (`0xaa...aa`) with the normal substrate native token, so there's some state that can be observed by SDET tests etc.

I tested this implementation manually and it works correctly, but I've used addresses provided by Radek, which unfortunately have only one utxo with the native tokens.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

