### PR TITLE
feat: remove use 'storage::getter' in partner-chains pallets

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * polkadot-sdk dependency updated to partnerchains-stable2407 (stable2407 is v1.15.0 in the previous scheme)
 * remove Relay docker build files
 * changed the inner type of `McBlockHash` from Vec to an array
+* removed usage of 'storage::getter' macros, following polkadot-sdk changes
 
 ## Removed
 

--- a/pallets/session-validator-management/src/lib.rs
+++ b/pallets/session-validator-management/src/lib.rs
@@ -97,7 +97,6 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn current_committee_storage)]
 	pub type CurrentCommittee<T: Config> = StorageValue<
 		_,
 		CommitteeInfo<T::ScEpochNumber, T::AuthorityId, T::AuthorityKeys, T::MaxValidators>,
@@ -105,7 +104,6 @@ pub mod pallet {
 	>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn next_committee_storage)]
 	pub type NextCommittee<T: Config> = StorageValue<
 		_,
 		CommitteeInfo<T::ScEpochNumber, T::AuthorityId, T::AuthorityKeys, T::MaxValidators>,
@@ -278,6 +276,17 @@ pub mod pallet {
 				.get(index)
 				.map(|authority| authority.0.clone())
 				.clone()
+		}
+
+		pub fn current_committee_storage(
+		) -> CommitteeInfo<T::ScEpochNumber, T::AuthorityId, T::AuthorityKeys, T::MaxValidators> {
+			CurrentCommittee::<T>::get()
+		}
+
+		pub fn next_committee_storage() -> Option<
+			CommitteeInfo<T::ScEpochNumber, T::AuthorityId, T::AuthorityKeys, T::MaxValidators>,
+		> {
+			NextCommittee::<T>::get()
 		}
 
 		/// This function's result should be always defined after inherent call of 1st block of each epoch

--- a/pallets/session-validator-management/src/mock.rs
+++ b/pallets/session-validator-management/src/mock.rs
@@ -31,7 +31,6 @@ pub mod mock_pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::storage]
-	#[pallet::getter(fn current_epoch)]
 	pub type CurrentEpoch<T: Config> = StorageValue<_, u64, ValueQuery>;
 }
 
@@ -202,5 +201,5 @@ pub fn create_inherent_set_validators_call(
 }
 
 pub(crate) fn current_epoch_number() -> u64 {
-	Mock::current_epoch()
+	mock_pallet::CurrentEpoch::<Test>::get()
 }

--- a/pallets/sidechain/src/lib.rs
+++ b/pallets/sidechain/src/lib.rs
@@ -32,11 +32,9 @@ pub mod pallet {
 	}
 
 	#[pallet::storage]
-	#[pallet::getter(fn epoch_number)]
 	pub(super) type EpochNumber<T: Config> = StorageValue<_, ScEpochNumber, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn slots_per_epoch)]
 	pub(super) type SlotsPerEpoch<T: Config> =
 		StorageValue<_, sidechain_slots::SlotsPerEpoch, ValueQuery>;
 
@@ -52,6 +50,10 @@ pub mod pallet {
 			let current_slot = T::current_slot_number();
 			let slots_per_epoch = Self::slots_per_epoch();
 			slots_per_epoch.epoch_number_from_sc_slot(current_slot)
+		}
+
+		pub fn slots_per_epoch() -> sidechain_slots::SlotsPerEpoch {
+			SlotsPerEpoch::<T>::get()
 		}
 	}
 

--- a/pallets/sidechain/src/mock.rs
+++ b/pallets/sidechain/src/mock.rs
@@ -27,15 +27,12 @@ pub(crate) mod mock_pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::storage]
-	#[pallet::getter(fn current_epoch)]
 	pub type CurrentEpoch<T: Config> = StorageValue<_, ScEpochNumber, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn current_slot)]
 	pub type CurrentSlot<T: Config> = StorageValue<_, ScSlotNumber, ValueQuery>;
 
 	#[pallet::storage]
-	#[pallet::getter(fn on_new_epoch_call_count)]
 	pub type OnNewEpochCallCount<T: Config> = StorageValue<_, u32, ValueQuery>;
 
 	impl<T: Config> OnNewEpoch for Pallet<T> {
@@ -97,7 +94,7 @@ impl frame_system::Config for Test {
 
 impl pallet::Config for Test {
 	fn current_slot_number() -> ScSlotNumber {
-		Mock::current_slot()
+		mock_pallet::CurrentSlot::<Test>::get()
 	}
 	type OnNewEpoch = Mock;
 	type SidechainParams = u64;

--- a/pallets/sidechain/src/tests.rs
+++ b/pallets/sidechain/src/tests.rs
@@ -7,11 +7,11 @@ fn on_new_epoch_is_triggered_by_epoch_change() {
 	new_test_ext().execute_with(|| {
 		Mock::set_slot(4);
 		Sidechain::on_initialize(1);
-		assert_eq!(Mock::on_new_epoch_call_count(), 0);
+		assert_eq!(mock_pallet::OnNewEpochCallCount::<Test>::get(), 0);
 
 		Mock::set_slot(MOCK_SLOTS_PER_EPOCH.0.into());
 		Sidechain::on_initialize(3);
-		assert_eq!(Mock::on_new_epoch_call_count(), 1);
+		assert_eq!(mock_pallet::OnNewEpochCallCount::<Test>::get(), 1);
 	})
 }
 
@@ -23,7 +23,7 @@ fn on_new_epoch_is_not_triggered_without_epoch_change() {
 		Sidechain::on_initialize(2);
 		Mock::set_slot(u64::from(MOCK_SLOTS_PER_EPOCH.0) - 1);
 		Sidechain::on_initialize(3);
-		assert_eq!(Mock::on_new_epoch_call_count(), 0);
+		assert_eq!(mock_pallet::OnNewEpochCallCount::<Test>::get(), 0);
 	})
 }
 


### PR DESCRIPTION
See: https://github.com/pari…tytech/polkadot-sdk/issues/223#issue-1865177650

JIRA: ETCM-8126

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

