### PR TITLE
bugfix: exit with return code 0 when one of partner chains commands fails

### DIFF
--- a/node/src/command/mod.rs
+++ b/node/src/command/mod.rs
@@ -314,7 +314,24 @@ async fn print_result<FIn>(command_future: FIn) -> Result<(), sc_cli::Error>
 where
 	FIn: Future<Output = Result<String, String>>,
 {
-	let result = command_future.await?;
+	let result = match command_future.await {
+		Ok(r) => r,
+		Err(e) => e,
+	};
 	println!("{}", result);
 	Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+
+	async fn some_err() -> Result<String, String> {
+		Err("some err".to_string())
+	}
+
+	#[tokio::test]
+	async fn print_async_doesnt_fail_if_result_is_error() {
+		let result = super::print_result(some_err()).await;
+		assert!(result.is_ok());
+	}
 }


### PR DESCRIPTION
# Description

Each of command returns `Result<String, String>` but the `print_result` function was failing if result was `Err`. I've introduced this defect recently.
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff


