### PR TITLE
change: Calculate key hash without cardano-cli in prepare-chain-params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8958,6 +8958,7 @@ dependencies = [
 name = "sidechain-domain"
 version = "0.0.1"
 dependencies = [
+ "blake2b_simd",
  "byte-string-derive",
  "derive_more",
  "hex",

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * remove Relay docker build files
 * changed the inner type of `McBlockHash` from Vec to an array
 * removed usage of 'storage::getter' macros, following polkadot-sdk changes
+* governance authority key hash is now calculated in `prepare-configuration` without using external `cardano-cli`
 
 ## Removed
 

--- a/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -7,7 +7,6 @@ use async_trait::async_trait;
 use itertools::Itertools;
 use log::error;
 use main_chain_follower_api::candidate::{AriadneParameters, RawPermissionedCandidateData};
-use main_chain_follower_api::common::blake2b_28;
 use main_chain_follower_api::{CandidateDataSource, DataSourceError::*, Result};
 use num_traits::ToPrimitive;
 use plutus::Datum;
@@ -234,7 +233,7 @@ impl CandidatesDataSourceImpl {
 		} else {
 			Some(
 				stake_map
-					.get(&MainchainAddressHash(blake2b_28(&mainchain_pub_key.0)))
+					.get(&MainchainAddressHash::from_vkey(mainchain_pub_key.0))
 					.cloned()
 					.unwrap_or(StakeDelegation(0)),
 			)

--- a/mainchain-follower/main-chain-follower-api/src/common.rs
+++ b/mainchain-follower/main-chain-follower-api/src/common.rs
@@ -1,6 +1,5 @@
 #[cfg(feature = "serde")]
 use derive_more::FromStr;
-use sidechain_domain::*;
 use std::fmt::{Debug, Display, Formatter};
 
 extern crate alloc;
@@ -20,13 +19,4 @@ impl From<u64> for Timestamp {
 	fn from(value: u64) -> Self {
 		Timestamp(value)
 	}
-}
-
-pub fn blake2b_28(data: &[u8]) -> [u8; MAINCHAIN_ADDRESS_HASH_LEN] {
-	blake2b_simd::Params::new()
-		.hash_length(MAINCHAIN_ADDRESS_HASH_LEN)
-		.hash(data)
-		.as_bytes()
-		.try_into()
-		.expect("hash output always has expected length")
 }

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -135,7 +135,8 @@ fn get_key_hash_from_file(
 mod tests {
 	use crate::config::config_fields::{
 		CARDANO_PAYMENT_VERIFICATION_KEY_FILE, CHAIN_ID, GENESIS_COMMITTEE_UTXO,
-		GOVERNANCE_AUTHORITY, THRESHOLD_DENOMINATOR, THRESHOLD_NUMERATOR,
+		GOVERNANCE_AUTHORITY as GOVERNANCE_AUTHORITY_FIELD, THRESHOLD_DENOMINATOR,
+		THRESHOLD_NUMERATOR,
 	};
 	use crate::config::RESOURCES_CONFIG_FILE_PATH;
 	use crate::prepare_configuration::prepare_chain_params::tests::scenarios::silently_fill_legacy_chain_params;
@@ -151,7 +152,7 @@ mod tests {
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
 	use std::str::FromStr;
 
-	const GOV_AUTH: &str = "0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9";
+	const GOVERNANCE_AUTHORITY: &str = "0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9";
 
 	fn test_vkey_file_json() -> serde_json::Value {
 		serde_json::json!({
@@ -196,7 +197,7 @@ mod tests {
 				scenarios::show_intro(),
 				prompt_and_save_to_existing_file(CARDANO_PAYMENT_VERIFICATION_KEY_FILE, "payment.vkey"),
 				MockIO::file_read("payment.vkey"),
-				save_to_new_file(GOVERNANCE_AUTHORITY, GOV_AUTH),
+				save_to_new_file(GOVERNANCE_AUTHORITY_FIELD, GOVERNANCE_AUTHORITY),
 				MockIO::eprint("Governance authority has been set to 0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"),
 				MockIO::eprint(CHAIN_ID_PROMPT),
 				prompt_and_save_to_existing_file(CHAIN_ID, "0"),
@@ -215,7 +216,7 @@ mod tests {
 
 		let initial_chain_config = serde_json::json!({
 			"chain_parameters": {
-				"governance_authority": GOV_AUTH,
+				"governance_authority": GOVERNANCE_AUTHORITY,
 			}
 		});
 
@@ -224,12 +225,12 @@ mod tests {
 			.with_json_file("payment.vkey", test_vkey_file_json())
 			.with_json_file(CHAIN_CONFIG_PATH, initial_chain_config).with_expected_io(vec![
 				scenarios::show_intro(),
-				MockIO::file_read(GOVERNANCE_AUTHORITY.config_file),
-				MockIO::eprint(&GOVERNANCE_AUTHORITY.loaded_from_config_msg(&MainchainAddressHash::from_hex_unsafe(GOV_AUTH))),
+				MockIO::file_read(GOVERNANCE_AUTHORITY_FIELD.config_file),
+				MockIO::eprint(&GOVERNANCE_AUTHORITY_FIELD.loaded_from_config_msg(&MainchainAddressHash::from_hex_unsafe(GOVERNANCE_AUTHORITY))),
 				MockIO::prompt_yes_no(&is_gov_auth_valid_prompt(), true, false),
 				prompt_and_save_to_existing_file(CARDANO_PAYMENT_VERIFICATION_KEY_FILE, "payment.vkey"),
 				MockIO::file_read("payment.vkey"),
-				save_to_existing_file(GOVERNANCE_AUTHORITY, GOV_AUTH),
+				save_to_existing_file(GOVERNANCE_AUTHORITY_FIELD, GOVERNANCE_AUTHORITY),
 				MockIO::eprint("Governance authority has been set to 0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"),
 				MockIO::eprint(CHAIN_ID_PROMPT),
 				prompt_and_save_to_existing_file(CHAIN_ID, "0"),
@@ -246,7 +247,8 @@ mod tests {
 	#[test]
 	fn happy_path_without_overwriting_governance_authority() {
 		let mut final_chain_config = test_chain_config();
-		if let Some(gov_auth) = final_chain_config.pointer_mut(&GOVERNANCE_AUTHORITY.json_pointer())
+		if let Some(gov_auth) =
+			final_chain_config.pointer_mut(&GOVERNANCE_AUTHORITY_FIELD.json_pointer())
 		{
 			*gov_auth = "76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9".into();
 		}
@@ -263,11 +265,10 @@ mod tests {
 			.with_json_file(CHAIN_CONFIG_PATH, initial_chain_config)
 			.with_expected_io(vec![
 				scenarios::show_intro(),
-				MockIO::file_read(GOVERNANCE_AUTHORITY.config_file),
-				MockIO::eprint(
-					&GOVERNANCE_AUTHORITY
-						.loaded_from_config_msg(&MainchainAddressHash::from_hex_unsafe(GOV_AUTH)),
-				),
+				MockIO::file_read(GOVERNANCE_AUTHORITY_FIELD.config_file),
+				MockIO::eprint(&GOVERNANCE_AUTHORITY_FIELD.loaded_from_config_msg(
+					&MainchainAddressHash::from_hex_unsafe(GOVERNANCE_AUTHORITY),
+				)),
 				MockIO::prompt_yes_no(&is_gov_auth_valid_prompt(), true, true),
 				MockIO::eprint(CHAIN_ID_PROMPT),
 				prompt_and_save_to_existing_file(CHAIN_ID, "0"),
@@ -299,10 +300,10 @@ mod tests {
 			.with_file(RESOURCES_CONFIG_FILE_PATH, "{}")
 			.with_json_file(CHAIN_ID.config_file, initial_chain_config).with_expected_io(vec![
 				scenarios::show_intro(),
-				MockIO::file_read(GOVERNANCE_AUTHORITY.config_file),
+				MockIO::file_read(GOVERNANCE_AUTHORITY_FIELD.config_file),
 				prompt_and_save_to_existing_file(CARDANO_PAYMENT_VERIFICATION_KEY_FILE, "payment.vkey"),
 				MockIO::file_read("payment.vkey"),
-				save_to_existing_file(GOVERNANCE_AUTHORITY, GOV_AUTH),
+				save_to_existing_file(GOVERNANCE_AUTHORITY_FIELD, GOVERNANCE_AUTHORITY),
 				MockIO::eprint("Governance authority has been set to 0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"),
 				MockIO::eprint(CHAIN_ID_PROMPT),
 				prompt_with_default_and_save_to_existing_file(CHAIN_ID, Some("1"),"2"),
@@ -346,10 +347,10 @@ mod tests {
 			.with_json_file("payment.vkey", test_vkey_file_json())
 			.with_expected_io(vec![
 				scenarios::show_intro(),
-				MockIO::file_read(GOVERNANCE_AUTHORITY.config_file),
+				MockIO::file_read(GOVERNANCE_AUTHORITY_FIELD.config_file),
 				prompt_and_save_to_existing_file(CARDANO_PAYMENT_VERIFICATION_KEY_FILE, "payment.vkey"),
 				MockIO::file_read("payment.vkey"),
-				save_to_existing_file(GOVERNANCE_AUTHORITY, GOV_AUTH),
+				save_to_existing_file(GOVERNANCE_AUTHORITY_FIELD, GOVERNANCE_AUTHORITY),
 				MockIO::eprint("Governance authority has been set to 0x76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"),
 				MockIO::eprint(CHAIN_ID_PROMPT),
 				MockIO::file_read(CHAIN_ID.config_file),

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -205,8 +205,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.unwrap();
-		// assert!(result.is_ok());
+		assert!(result.is_ok());
 		mock_context.no_more_io_expected();
 	}
 

--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -187,9 +187,7 @@ fn sidechain_main_cli_version_prompt(version: String) -> String {
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::config::config_fields::{
-		GOVERNANCE_AUTHORITY, KUPO_PORT, KUPO_PROTOCOL, OGMIOS_PORT,
-	};
+	use crate::config::config_fields::{GOVERNANCE_AUTHORITY, KUPO_PROTOCOL};
 	use crate::prepare_configuration::prepare_cardano_params::PREPROD_CARDANO_PARAMS;
 	use crate::prepare_configuration::tests::save_to_existing_file;
 	use crate::tests::MockIO;

--- a/primitives/domain/Cargo.toml
+++ b/primitives/domain/Cargo.toml
@@ -20,6 +20,7 @@ num-traits = { workspace = true }
 num-derive = { workspace = true }
 sp-std = { workspace = true }
 lazy_static = { workspace = true }
+blake2b_simd = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/primitives/domain/src/crypto.rs
+++ b/primitives/domain/src/crypto.rs
@@ -1,0 +1,8 @@
+pub fn blake2b<const N: usize>(data: &[u8]) -> [u8; N] {
+	blake2b_simd::Params::new()
+		.hash_length(N)
+		.hash(data)
+		.as_bytes()
+		.try_into()
+		.expect("hash output always has expected length")
+}

--- a/primitives/domain/src/crypto.rs
+++ b/primitives/domain/src/crypto.rs
@@ -1,8 +1,10 @@
+use alloc::format;
+
 pub fn blake2b<const N: usize>(data: &[u8]) -> [u8; N] {
 	blake2b_simd::Params::new()
 		.hash_length(N)
 		.hash(data)
 		.as_bytes()
 		.try_into()
-		.expect("hash output always has expected length")
+		.expect(&format!("hash output always has expected length of {N}"))
 }

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -9,8 +9,6 @@ extern crate alloc;
 extern crate core;
 extern crate num_derive;
 
-use alloc::format;
-use alloc::string::String;
 pub use alloc::vec::Vec;
 use alloc::{str::FromStr, string::ToString, vec};
 use byte_string_derive::byte_string;
@@ -141,14 +139,11 @@ pub struct MainchainAddress(BoundedVec<u8, ConstU32<MAX_MAINCHAIN_ADDRESS_BYTES>
 
 #[cfg(feature = "serde")]
 impl FromStr for MainchainAddress {
-	type Err = String;
+	type Err = &'static str;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
 		let bytes: Vec<u8> = s.as_bytes().to_vec();
-		let len = bytes.len();
-		let bounded = BoundedVec::try_from(bytes).map_err(|_| {
-			format!("Invalid length: {len}, expected max {MAX_MAINCHAIN_ADDRESS_BYTES}")
-		})?;
+		let bounded = BoundedVec::try_from(bytes).map_err(|_| "Invalid length")?;
 		Ok(MainchainAddress(bounded))
 	}
 }


### PR DESCRIPTION
# Description

* moves existing blake2b implementation from main-chain-folower-api to new `crypto` module in domain crate
* `prepare-chain-params` now uses it to calculate the key-hash of governance authority instead of externally calling cardano-cli

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

