### PR TITLE
Disable macos build in nix.yml

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,11 +36,7 @@ jobs:
         run: echo "${{ secrets.NIX_SIGNING_KEY }}" > "${{ runner.temp }}/nix-key"
       - name: Run nixci to build/test all outputs
         run: |
-          args=()
-          if [[ ${{ matrix.os }} == "macos" ]]; then
-            args+=("--systems" "x86_64-darwin")
-          fi
-          nix run github:srid/nixci -- -v build ${args[@]} > /tmp/outputs
+          nix run github:srid/nixci -- -v build > /tmp/outputs
       - name: Copy nix scopes to nix cache
         run: |
           nix-store --stdin -q --deriver < /tmp/outputs | nix-store --stdin -qR --include-outputs \


### PR DESCRIPTION
# Description

Disable the macos build in the nix.yml workflow which is currently causing problems but isn't vital to build a valid `partner-chains` release

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

