### PR TITLE
Disable macos nix builds

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        os: [nixos, macos]
+        os: [nixos]
     runs-on:
       - self-hosted
       - ${{ matrix.os }}
@@ -36,10 +36,6 @@ jobs:
         run: echo "${{ secrets.NIX_SIGNING_KEY }}" > "${{ runner.temp }}/nix-key"
       - name: Run nixci to build/test all outputs
         run: |
-          args=()
-          if [[ ${{ matrix.os }} == "macos" ]]; then
-            args+=("--systems" "x86_64-darwin")
-          fi
           nix run github:srid/nixci -- -v build ${args[@]} > /tmp/outputs
       - name: Copy nix scopes to nix cache
         run: |


### PR DESCRIPTION
# Description

Don't run macos nix builds for now - they are currently causing some troubles but aren't required for building our release artifacts

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

