### PR TITLE
change: ETCM-7811 native token management pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5668,6 +5668,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-native-token-management"
+version = "0.1.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sidechain-domain",
+ "sp-io",
+ "sp-native-token-management",
+]
+
+[[package]]
 name = "pallet-partner-chains-session"
 version = "1.0.0"
 source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
@@ -9041,6 +9055,7 @@ dependencies = [
  "pallet-balances",
  "pallet-block-rewards",
  "pallet-grandpa",
+ "pallet-native-token-management",
  "pallet-partner-chains-session",
  "pallet-session-validator-management",
  "pallet-session-validator-management-benchmarking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ members = [
     "primitives/session-manager",
     "primitives/sidechain",
 	"partner-chains-cli",
+    "pallets/native-token-management",
     "primitives/native-token-management"]
 resolver = "2"
 
@@ -191,5 +192,6 @@ authority-selection-inherents = { path = "primitives/authority-selection-inheren
 session-manager = { path = "primitives/session-manager", default-features = false }
 sp-sidechain = { path = "primitives/sidechain", default-features = false }
 chain-params = { path = "primitives/chain-params", default-features = false }
+pallet-native-token-management = { path = "pallets/native-token-management", default-features = false }
 sp-native-token-management = { path = "primitives/native-token-management", default-features = false }
 sp-partner-chains-consensus-aura = { path = "primitives/consensus/aura", default-features = false }

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,9 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 ## Fixed
 
 ## Added
+* ETCM-7811 - native token movement observability components: `sp-native-token-management` and
+`pallet-native-token-management` crates; data sources behind the `native-token` feature in
+`main-chain-follower-api` and `db-sync-follower` crates.
 
 # v1.0.0rc1
 

--- a/devnet/.envrc
+++ b/devnet/.envrc
@@ -15,6 +15,11 @@ export COMMITTEE_CANDIDATE_ADDRESS=$(jq -r '.addresses.CommitteeCandidateValidat
 export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' devnet/addresses.json)
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' devnet/addresses.json)
 
+# native token observability
+export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432
 export CARDANO_ACTIVE_SLOTS_COEFF=0.05

--- a/devnet/.envrc
+++ b/devnet/.envrc
@@ -16,9 +16,9 @@ export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' devnet/
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' devnet/addresses.json)
 
 # native token observability
-export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
-export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
-export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+export NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
 
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,4 +1,4 @@
-use sidechain_domain::PolicyId;
+use sidechain_domain::{AssetName, MainchainAddress, PolicyId};
 use sidechain_runtime::CrossChainPublic;
 use sidechain_runtime::{opaque::SessionKeys, AccountId, Signature, WASM_BINARY};
 use sp_core::{Pair, Public};
@@ -80,5 +80,14 @@ pub fn read_mainchain_scripts_from_env() -> Result<MainChainScripts, EnvVarReadE
 		committee_candidate_address,
 		d_parameter_policy,
 		permissioned_candidates_policy,
+	})
+}
+
+pub fn read_native_token_main_chain_scripts_from_env(
+) -> Result<sp_native_token_management::MainChainScripts, EnvVarReadError> {
+	Ok(sp_native_token_management::MainChainScripts {
+		native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
+		native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
+		illiquid_supply_address: from_var::<MainchainAddress>("ILLIQUID_SUPPLY_VALIDATOR_ADDRESS")?,
 	})
 }

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -2,10 +2,11 @@ use crate::chain_spec::get_account_id_from_seed;
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::*;
 use sidechain_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
-	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
+	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig,
+	RuntimeGenesisConfig, SessionCommitteeManagementConfig, SessionConfig, SidechainConfig,
+	SudoConfig, SystemConfig,
 };
 use sp_core::bytes::from_hex;
 use sp_core::{ed25519, sr25519};
@@ -163,6 +164,18 @@ pub fn staging_genesis(
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -167,12 +167,10 @@ pub fn staging_genesis(
 		},
 		native_token_management: NativeTokenManagementConfig {
 			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>(
-					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
-				)?,
+				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
 				illiquid_supply_address: from_var::<MainchainAddress>(
-					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
 				)?,
 			},
 			..Default::default()

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -166,13 +166,7 @@ pub fn staging_genesis(
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
-				illiquid_supply_address: from_var::<MainchainAddress>(
-					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
-				)?,
-			},
+			main_chain_scripts: read_native_token_main_chain_scripts_from_env()?,
 			..Default::default()
 		},
 	};

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -46,12 +46,10 @@ pub fn chain_spec() -> Result<ChainSpec, EnvVarReadError> {
 		},
 		native_token_management: NativeTokenManagementConfig {
 			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>(
-					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
-				)?,
+				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
 				illiquid_supply_address: from_var::<MainchainAddress>(
-					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
 				)?,
 			},
 			..Default::default()

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -1,9 +1,9 @@
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::{AssetName, MainchainAddress, MainchainAddressHash, PolicyId, UtxoId};
 use sidechain_runtime::{
-	AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
+	AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig, RuntimeGenesisConfig,
 	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
 };
 
@@ -43,6 +43,18 @@ pub fn chain_spec() -> Result<ChainSpec, EnvVarReadError> {
 			// Same as SessionConfig
 			initial_authorities: vec![],
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 	let genesis_json = serde_json::to_value(runtime_genesis_config)

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -1,7 +1,7 @@
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{AssetName, MainchainAddress, MainchainAddressHash, PolicyId, UtxoId};
+use sidechain_domain::{MainchainAddressHash, UtxoId};
 use sidechain_runtime::{
 	AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig, RuntimeGenesisConfig,
 	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
@@ -45,13 +45,7 @@ pub fn chain_spec() -> Result<ChainSpec, EnvVarReadError> {
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
-				illiquid_supply_address: from_var::<MainchainAddress>(
-					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
-				)?,
-			},
+			main_chain_scripts: read_native_token_main_chain_scripts_from_env()?,
 			..Default::default()
 		},
 	};

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -206,13 +206,7 @@ pub fn testnet_genesis(
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
-				illiquid_supply_address: from_var::<MainchainAddress>(
-					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
-				)?,
-			},
+			main_chain_scripts: read_native_token_main_chain_scripts_from_env()?,
 			..Default::default()
 		},
 	};

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -1,10 +1,11 @@
 use crate::chain_spec::*;
 use chain_params::SidechainParams;
 use sc_service::ChainType;
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::*;
 use sidechain_runtime::{
-	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, RuntimeGenesisConfig,
-	SessionCommitteeManagementConfig, SessionConfig, SidechainConfig, SudoConfig, SystemConfig,
+	AccountId, AuraConfig, BalancesConfig, GrandpaConfig, NativeTokenManagementConfig,
+	RuntimeGenesisConfig, SessionCommitteeManagementConfig, SessionConfig, SidechainConfig,
+	SudoConfig, SystemConfig,
 };
 use sidechain_slots::SlotsPerEpoch;
 use sp_core::bytes::from_hex;
@@ -203,6 +204,18 @@ pub fn testnet_genesis(
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: read_mainchain_scripts_from_env()?,
+		},
+		native_token_management: NativeTokenManagementConfig {
+			main_chain_scripts: sp_native_token_management::MainChainScripts {
+				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>(
+					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
+				)?,
+				illiquid_supply_address: from_var::<MainchainAddress>(
+					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+				)?,
+			},
+			..Default::default()
 		},
 	};
 

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -207,12 +207,10 @@ pub fn testnet_genesis(
 		},
 		native_token_management: NativeTokenManagementConfig {
 			main_chain_scripts: sp_native_token_management::MainChainScripts {
-				native_token_policy: from_var::<PolicyId>("PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID")?,
-				native_token_asset_name: from_var::<AssetName>(
-					"PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME",
-				)?,
+				native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
+				native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
 				illiquid_supply_address: from_var::<MainchainAddress>(
-					"PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
+					"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
 				)?,
 			},
 			..Default::default()

--- a/pallets/native-token-management/Cargo.toml
+++ b/pallets/native-token-management/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pallet-native-token-management"
+version = "0.1.0"
+edition = "2021"
+description = "Pallet responsible for handling changes to the illiquid supply of the native token on main chain."
+
+[dependencies]
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+log = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-native-token-management = { workspace = true, features = ["serde"] }
+sidechain-domain = { workspace = true }
+
+[dev-dependencies]
+sp-io = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "frame-support/std",
+    "frame-system/std",
+    "log/std",
+    "scale-info/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sp-native-token-management/std"
+]

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -127,7 +127,7 @@ pub mod pallet {
 			data: &InherentData,
 		) -> Option<TokenTransferData> {
 			data.get_data::<TokenTransferData>(&INHERENT_IDENTIFIER)
-				.expect("Token transfer data not correctly encoded")
+				.expect("Token transfer data is not encoded correctly")
 		}
 	}
 

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -96,7 +96,7 @@ pub mod pallet {
 
 		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
 			Self::get_transfered_tokens_from_inherent_data(data)
-				.filter(|data| !data.token_amount.0 > 0)
+				.filter(|data| data.token_amount.0 > 0)
 				.map(|data| Call::transfer_tokens { token_amount: data.token_amount })
 		}
 

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -104,9 +104,7 @@ pub mod pallet {
 			let Some(token_transfer) = Self::get_transfered_tokens_from_inherent_data(data) else {
 				return Err(InherentError::UnexpectedTokenTransferInherent);
 			};
-			let Call::transfer_tokens { token_amount } = call else {
-				unreachable!("There is no other extrinsic in this pallet");
-			};
+			let Call::transfer_tokens { token_amount } = call else { return Ok(()) };
 			if token_transfer.token_amount != *token_amount {
 				return Err(InherentError::IncorrectTokenNumberTransfered);
 			}

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -1,0 +1,175 @@
+//! Pallet allowing Partner Chains to support movement of their native token from Cardano.
+//!
+//! Partner Chains Smart Contracts establish a notion of liquid and illiquid supply of the native
+//! token on Cardano, represented as native tokens being either freely available in user accounts
+//! or locked under a designated illiquid supply address. Movement of native tokens into the illiquid
+//! supply on Cardano signals that an equivalent amount of tokens should be made available on the
+//! Partner Chain.
+//!
+//! This pallet consumes inherent data containing information on the amount of native tokens newly
+//! locked on Cardano and produces an inherent extrinsic to handle their movement. The specific
+//! logic releasing the tokens is left for the Partner Chain developer to implement and is configured
+//! in the pallet via the `TokenTransferHandler`.
+//!
+//! IMPORTANT: The mechanism implemented via the pallet in this crate is only concerned with the
+//!            amount of tokens moved and does not attach any metadata to the transfers. In particular
+//!            it is not a fully-featured token bridge and needs to be combined with a separate
+//!            sender-receiver metadata channel to implement one.
+//!
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use frame_support::inherent::IsFatalError;
+use frame_support::pallet_prelude::*;
+use frame_system::pallet_prelude::*;
+pub use pallet::*;
+use sidechain_domain::*;
+use sp_native_token_management::*;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(any(test, feature = "mock"))]
+mod mock;
+
+#[derive(Encode, Debug, PartialEq)]
+pub enum InherentError {
+	TokenTransferNotHandled,
+	IncorrectTokenNumberTransfered,
+	UnexpectedTokenTransferInherent,
+}
+
+impl IsFatalError for InherentError {
+	fn is_fatal_error(&self) -> bool {
+		true
+	}
+}
+
+/// Interface for user-provided logic to handle native token transfers into the illiquid supply on the main chain.
+///
+/// The handler will be called with **the total sum** of transfers since the previous partner chain block.
+pub trait TokenTransferHandler {
+	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult;
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		type TokenTransferHandler: TokenTransferHandler;
+	}
+
+	#[pallet::event]
+	pub enum Event<T: Config> {
+		TokensTransfered(NativeTokenAmount),
+	}
+
+	#[pallet::storage]
+	pub type MainChainScriptsConfiguration<T: Config> =
+		StorageValue<_, sp_native_token_management::MainChainScripts, ValueQuery>;
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
+		pub main_chain_scripts: sp_native_token_management::MainChainScripts,
+		pub _marker: PhantomData<T>,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			MainChainScriptsConfiguration::<T>::put(self.main_chain_scripts.clone());
+		}
+	}
+
+	#[pallet::inherent]
+	impl<T: Config> ProvideInherent for Pallet<T> {
+		type Call = Call<T>;
+		type Error = InherentError;
+		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
+
+		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
+			Self::get_transfered_tokens_from_inherent_data(data)
+				.filter(|data| !data.token_amount.0 > 0)
+				.map(|data| Call::transfer_tokens { token_amount: data.token_amount })
+		}
+
+		fn check_inherent(call: &Self::Call, data: &InherentData) -> Result<(), Self::Error> {
+			let Some(token_transfer) = Self::get_transfered_tokens_from_inherent_data(data) else {
+				return Err(InherentError::UnexpectedTokenTransferInherent);
+			};
+			let Call::transfer_tokens { token_amount } = call else {
+				unreachable!("There is no other extrinsic in this pallet");
+			};
+			if token_transfer.token_amount != *token_amount {
+				return Err(InherentError::IncorrectTokenNumberTransfered);
+			}
+
+			Ok(())
+		}
+
+		fn is_inherent(call: &Self::Call) -> bool {
+			matches!(call, Call::transfer_tokens { .. })
+		}
+
+		fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
+			Ok(Self::get_transfered_tokens_from_inherent_data(data)
+				.map(|_| InherentError::TokenTransferNotHandled))
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		fn get_transfered_tokens_from_inherent_data(
+			data: &InherentData,
+		) -> Option<TokenTransferData> {
+			data.get_data::<TokenTransferData>(&INHERENT_IDENTIFIER)
+				.expect("Token transfer data not correctly encoded")
+		}
+	}
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(0)]
+		#[pallet::weight((0, DispatchClass::Mandatory))]
+		pub fn transfer_tokens(
+			origin: OriginFor<T>,
+			token_amount: NativeTokenAmount,
+		) -> DispatchResult {
+			ensure_none(origin)?;
+			T::TokenTransferHandler::handle_token_transfer(token_amount)
+		}
+
+		/// Changes the main chain scripts used for observing native token transfers.
+		///
+		/// This extrinsic must be run either using `sudo` or some other chain governance mechanism.
+		#[pallet::call_index(1)]
+		#[pallet::weight((1, DispatchClass::Normal))]
+		pub fn set_main_chain_scripts(
+			origin: OriginFor<T>,
+			native_token_policy: PolicyId,
+			native_token_asset_name: AssetName,
+			illiquid_supply_address: MainchainAddress,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			let new_scripts = sp_native_token_management::MainChainScripts {
+				native_token_policy,
+				native_token_asset_name,
+				illiquid_supply_address,
+			};
+			MainChainScriptsConfiguration::<T>::put(new_scripts);
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		pub fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+			MainChainScriptsConfiguration::<T>::get()
+		}
+	}
+}

--- a/pallets/native-token-management/src/mock.rs
+++ b/pallets/native-token-management/src/mock.rs
@@ -1,12 +1,10 @@
 use crate::mock::sp_runtime::testing::H256;
-use crate::DispatchResult;
-use crate::TokenTransferHandler;
-use frame_support::sp_runtime::traits::BlakeTwo256;
-use frame_support::sp_runtime::traits::IdentityLookup;
-use frame_support::sp_runtime::BuildStorage;
-use frame_support::traits::ConstU16;
-use frame_support::traits::ConstU32;
-use frame_support::traits::ConstU64;
+use crate::{DispatchResult, TokenTransferHandler};
+use frame_support::sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	BuildStorage,
+};
+use frame_support::traits::{ConstU16, ConstU32, ConstU64};
 use frame_support::*;
 use sidechain_domain::*;
 

--- a/pallets/native-token-management/src/mock.rs
+++ b/pallets/native-token-management/src/mock.rs
@@ -1,0 +1,92 @@
+use crate::mock::sp_runtime::testing::H256;
+use crate::DispatchResult;
+use crate::TokenTransferHandler;
+use frame_support::sp_runtime::traits::BlakeTwo256;
+use frame_support::sp_runtime::traits::IdentityLookup;
+use frame_support::sp_runtime::BuildStorage;
+use frame_support::traits::ConstU16;
+use frame_support::traits::ConstU32;
+use frame_support::traits::ConstU64;
+use frame_support::*;
+use sidechain_domain::*;
+
+use self::mock_pallet::LastTokenTransfer;
+
+type AccountId = u64;
+type Block = frame_system::mocking::MockBlock<Test>;
+
+#[frame_support::pallet]
+pub mod mock_pallet {
+	use frame_support::pallet_prelude::*;
+	use sidechain_domain::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::storage]
+	pub type LastTokenTransfer<T: Config> = StorageValue<_, NativeTokenAmount, OptionQuery>;
+}
+
+impl<T: mock_pallet::Config> TokenTransferHandler for mock_pallet::Pallet<T> {
+	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult {
+		LastTokenTransfer::<T>::put(token_amount);
+		Ok(())
+	}
+}
+
+frame_support::construct_runtime!(
+	pub enum Test {
+		System: frame_system,
+		NativeTokenManagement: crate::pallet,
+		Mock: mock_pallet,
+	}
+);
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = frame_support::traits::Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Hash = H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+	type Nonce = u64;
+	type Block = Block;
+	type RuntimeTask = RuntimeTask;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+}
+
+impl crate::pallet::Config for Test {
+	type RuntimeEvent = RuntimeEvent;
+	type TokenTransferHandler = Mock;
+}
+
+impl mock_pallet::Config for Test {}
+
+pub fn new_test_ext() -> sp_io::TestExternalities {
+	RuntimeGenesisConfig { system: Default::default(), native_token_management: Default::default() }
+		.build_storage()
+		.unwrap()
+		.into()
+}

--- a/pallets/native-token-management/src/tests.rs
+++ b/pallets/native-token-management/src/tests.rs
@@ -1,9 +1,10 @@
+use self::mock::NativeTokenManagement;
 use self::mock::{RuntimeOrigin, Test};
-	use self::mock::NativeTokenManagement;
 use crate::mock::mock_pallet;
 use crate::mock::new_test_ext;
 use crate::*;
 use frame_support::traits::UnfilteredDispatchable;
+use sp_native_token_management::InherentError;
 
 mod create_inherent {
 	use super::*;
@@ -52,7 +53,10 @@ mod check_inherent {
 
 			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
 
-			assert_eq!(result, Err(InherentError::IncorrectTokenNumberTransfered))
+			assert_eq!(
+				result,
+				Err(InherentError::IncorrectTokenNumberTransfered(1002.into(), 9999.into()))
+			)
 		})
 	}
 	#[test]
@@ -63,7 +67,7 @@ mod check_inherent {
 
 			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
 
-			assert_eq!(result, Err(InherentError::UnexpectedTokenTransferInherent));
+			assert_eq!(result, Err(InherentError::UnexpectedTokenTransferInherent(1002.into())));
 		})
 	}
 }
@@ -79,7 +83,7 @@ mod is_inherent_required {
 				.expect("Check should successfully run.")
 				.expect("Check should return an error object.");
 
-			assert_eq!(error, InherentError::TokenTransferNotHandled);
+			assert_eq!(error, InherentError::TokenTransferNotHandled(1001.into()));
 		})
 	}
 

--- a/pallets/native-token-management/src/tests.rs
+++ b/pallets/native-token-management/src/tests.rs
@@ -1,0 +1,135 @@
+use self::mock::{RuntimeOrigin, Test};
+	use self::mock::NativeTokenManagement;
+use crate::mock::mock_pallet;
+use crate::mock::new_test_ext;
+use crate::*;
+use frame_support::traits::UnfilteredDispatchable;
+
+mod create_inherent {
+	use super::*;
+
+	#[test]
+	fn creates_inherent_from_inherent_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1001);
+
+			let result = NativeTokenManagement::create_inherent(&inherent_data);
+
+			assert_eq!(result, Some(Call::transfer_tokens { token_amount: 1001.into() }))
+		})
+	}
+	#[test]
+	fn skips_inherent_if_no_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+
+			let result = NativeTokenManagement::create_inherent(&inherent_data);
+
+			assert_eq!(result, None)
+		})
+	}
+}
+
+mod check_inherent {
+	use super::*;
+
+	#[test]
+	fn pass_when_inherent_matches_data() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1002);
+			let inherent = Call::transfer_tokens { token_amount: 1002.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Ok(()))
+		})
+	}
+	#[test]
+	fn fail_when_token_amount_mismatch() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1002);
+			let inherent = Call::transfer_tokens { token_amount: 9999.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Err(InherentError::IncorrectTokenNumberTransfered))
+		})
+	}
+	#[test]
+	fn fail_when_unexpected_inherent() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+			let inherent = Call::transfer_tokens { token_amount: 1002.into() };
+
+			let result = NativeTokenManagement::check_inherent(&inherent, &inherent_data);
+
+			assert_eq!(result, Err(InherentError::UnexpectedTokenTransferInherent));
+		})
+	}
+}
+
+mod is_inherent_required {
+	use super::*;
+
+	#[test]
+	fn yes_when_data_present() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(1001);
+			let error = NativeTokenManagement::is_inherent_required(&inherent_data)
+				.expect("Check should successfully run.")
+				.expect("Check should return an error object.");
+
+			assert_eq!(error, InherentError::TokenTransferNotHandled);
+		})
+	}
+
+	#[test]
+	fn no_when_data_absent() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = InherentData::new();
+			let result = NativeTokenManagement::is_inherent_required(&inherent_data)
+				.expect("Check should successfully run.");
+
+			assert!(result.is_none());
+		})
+	}
+}
+
+mod inherent {
+	use super::*;
+
+	#[test]
+	fn succeeds_and_calls_transfer_handler() {
+		new_test_ext().execute_with(|| {
+			let inherent: Call<Test> = Call::transfer_tokens { token_amount: 1000.into() };
+
+			let _ = inherent.dispatch_bypass_filter(RuntimeOrigin::none()).unwrap();
+
+			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get().unwrap().0, 1000)
+		})
+	}
+
+	#[test]
+	fn fails_when_not_root() {
+		new_test_ext().execute_with(|| {
+			let inherent: Call<Test> = Call::transfer_tokens { token_amount: 1000.into() };
+
+			let result = inherent.dispatch_bypass_filter(RuntimeOrigin::signed(Default::default()));
+
+			assert_eq!(result.unwrap_err().error, DispatchError::BadOrigin);
+
+			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get(), None)
+		})
+	}
+}
+
+fn test_inherent_data(token_amount: u128) -> InherentData {
+	let mut inherent_data = InherentData::new();
+	inherent_data
+		.put_data(
+			INHERENT_IDENTIFIER,
+			&TokenTransferData { token_amount: NativeTokenAmount(token_amount) },
+		)
+		.unwrap();
+	inherent_data
+}

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,6 +70,7 @@ sidechain-domain = { workspace = true, features = ["serde"] }
 chain-params = { workspace = true, features = ["serde"] }
 sidechain-slots = { workspace = true }
 session-manager = { workspace = true }
+pallet-native-token-management = { workspace = true }
 sp-native-token-management = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
@@ -141,6 +142,7 @@ std = [
 	"sidechain-domain/std",
 	"sp-inherents/std",
 	"chain-params/std",
+	"pallet-native-token-management/std",
 	"sp-native-token-management/std"
 ]
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -16,6 +16,8 @@ use authority_selection_inherents::filter_invalid_candidates::{
 use authority_selection_inherents::select_authorities::select_authorities;
 use chain_params::SidechainParams;
 use frame_support::genesis_builder_helper::{build_state, get_preset};
+use frame_support::traits::fungible::Balanced;
+use frame_support::traits::tokens::Precision;
 use frame_support::BoundedVec;
 pub use frame_support::{
 	construct_runtime, parameter_types,
@@ -30,6 +32,7 @@ pub use frame_support::{
 	PalletId, StorageValue,
 };
 pub use frame_system::Call as SystemCall;
+use hex_literal::hex;
 use opaque::SessionKeys;
 pub use pallet_balances::Call as BalancesCall;
 use pallet_grandpa::AuthorityId as GrandpaId;
@@ -38,8 +41,8 @@ pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 use session_manager::ValidatorManagementSessionManager;
 use sidechain_domain::{
-	MainchainPublicKey, PermissionedCandidateData, RegistrationData, ScEpochNumber, ScSlotNumber,
-	StakeDelegation,
+	MainchainPublicKey, NativeTokenAmount, PermissionedCandidateData, RegistrationData,
+	ScEpochNumber, ScSlotNumber, StakeDelegation,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -47,6 +50,7 @@ use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_partner_chains_session::CurrentSessionIndex;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
+use sp_runtime::DispatchResult;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
@@ -317,6 +321,31 @@ impl frame_system::Config for Runtime {
 	type PostTransactions = ();
 }
 
+pub struct TokenTransferHandler;
+
+impl pallet_native_token_management::TokenTransferHandler for TokenTransferHandler {
+	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult {
+		// Mint the "transfered" tokens into a dummy address.
+		// This is done for visibility in tests only.
+		// Despite using the `Balances` pallet to do the transfer here, the account balance
+		// is stored (and can be observed) in the `System` pallet's storage.
+		let _ = Balances::deposit(
+			&AccountId::from(hex!(
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+			)),
+			token_amount.0.into(),
+			Precision::Exact,
+		)?;
+		log::info!("💸 Registered transfer of {} native tokens", token_amount.0);
+		Ok(())
+	}
+}
+
+impl pallet_native_token_management::Config for Runtime {
+	type RuntimeEvent = RuntimeEvent;
+	type TokenTransferHandler = TokenTransferHandler;
+}
+
 impl pallet_aura::Config for Runtime {
 	type AuthorityId = AuraId;
 	type DisabledValidators = ();
@@ -476,6 +505,7 @@ construct_runtime!(
 		BlockRewards: pallet_block_rewards,
 		// The order matters!! Session pallet needs to come last for correct initialization order
 		Session: pallet_partner_chains_session,
+		NativeTokenManagement: pallet_native_token_management,
 	}
 );
 
@@ -833,11 +863,7 @@ impl_runtime_apis! {
 
 	impl sp_native_token_management::NativeTokenManagementApi<Block> for Runtime {
 		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
-			sp_native_token_management::MainChainScripts {
-				native_token_policy: Default::default(),
-				native_token_asset_name: Default::default(),
-				illiquid_supply_address: Default::default(),
-			}
+			NativeTokenManagement::get_main_chain_scripts()
 		}
 	}
 }

--- a/staging/.envrc
+++ b/staging/.envrc
@@ -15,6 +15,11 @@ export COMMITTEE_CANDIDATE_ADDRESS=$(jq -r '.addresses.CommitteeCandidateValidat
 export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' staging/addresses.json)
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' staging/addresses.json)
 
+# native token observability
+export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432
 export CARDANO_ACTIVE_SLOTS_COEFF=0.05

--- a/staging/.envrc
+++ b/staging/.envrc
@@ -16,9 +16,9 @@ export D_PARAMETER_POLICY_ID=$(jq -r '.mintingPolicies.DParameterPolicy' staging
 export PERMISSIONED_CANDIDATES_POLICY_ID=$(jq -r '.mintingPolicies.PermissionedCandidatesPolicy' staging/addresses.json)
 
 # native token observability
-export PARTNER_CHAIN_NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
-export PARTNER_CHAIN_NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
-export PARTNER_CHAIN_ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
+export NATIVE_TOKEN_POLICY_ID='ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4'
+export NATIVE_TOKEN_ASSET_NAME='5043546f6b656e44656d6f'
+export ILLIQUID_SUPPLY_VALIDATOR_ADDRESS='addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz'
 
 # Preview parameters
 export CARDANO_SECURITY_PARAMETER=432


### PR DESCRIPTION
# Description

The pallet that consumes inherent data about number of tokens moved into illiquid supply on main chain and calls a Partner Chain's custom handler.

This is the last PR of the native token observability. You can see the changes from all the PR together in [this draft PR](https://github.com/input-output-hk/partner-chains/pull/22). 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

