### PR TITLE
change: ETCM-7811 native token inherent data provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6098,6 +6098,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-keyring",
+ "sp-native-token-management",
  "sp-runtime",
  "sp-session-validator-management",
  "sp-session-validator-management-query",
@@ -8984,6 +8985,7 @@ dependencies = [
  "async-trait",
  "main-chain-follower-api",
  "sidechain-domain",
+ "sp-blockchain",
  "sp-consensus",
  "sp-consensus-slots",
  "sp-inherents",
@@ -9043,6 +9045,7 @@ dependencies = [
  "sp-inherents",
  "sp-io",
  "sp-keyring",
+ "sp-native-token-management",
  "sp-offchain",
  "sp-partner-chains-session",
  "sp-runtime",
@@ -9589,6 +9592,25 @@ dependencies = [
  "scale-info",
  "sp-api",
  "sp-application-crypto",
+]
+
+[[package]]
+name = "sp-native-token-management"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "main-chain-follower-api",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sidechain-domain",
+ "sidechain-mc-hash",
+ "sp-api",
+ "sp-blockchain",
+ "sp-inherents",
+ "sp-runtime",
+ "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,8 @@ members = [
 	"primitives/session-validator-management/query",
     "primitives/session-manager",
     "primitives/sidechain",
-	"partner-chains-cli"
-]
+	"partner-chains-cli",
+    "primitives/native-token-management"]
 resolver = "2"
 
 [profile.release]
@@ -188,3 +188,4 @@ authority-selection-inherents = { path = "primitives/authority-selection-inheren
 session-manager = { path = "primitives/session-manager", default-features = false }
 sp-sidechain = { path = "primitives/sidechain", default-features = false }
 chain-params = { path = "primitives/chain-params", default-features = false }
+sp-native-token-management = { path = "primitives/native-token-management", default-features = false }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -87,6 +87,7 @@ frame-benchmarking-cli = { workspace = true }
 # Local Dependencies
 sidechain-runtime = { workspace = true }
 sidechain-mc-hash = { workspace = true, features = ["mock"] }
+sp-native-token-management = { workspace = true }
 main-chain-follower-api = { workspace = true }
 db-sync-follower = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }
 main-chain-follower-mock = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }

--- a/primitives/native-token-management/Cargo.toml
+++ b/primitives/native-token-management/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "sp-native-token-management"
+version = "0.1.0"
+edition = "2021"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+async-trait = { workspace = true, optional = true }
+main-chain-follower-api = { workspace = true, optional = true, features = ["native-token"] }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sidechain-domain = { workspace = true }
+sidechain-mc-hash = { workspace = true, optional = true }
+sp-api = { workspace = true }
+sp-blockchain = { workspace = true, optional = true }
+sp-inherents = { workspace = true }
+sp-runtime = { workspace = true }
+thiserror = { workspace = true, optional = true }
+serde = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "async-trait",
+    "main-chain-follower-api/std",
+    "parity-scale-codec/std",
+    "scale-info/std",
+    "sidechain-domain/std",
+    "sidechain-mc-hash",
+    "sp-api/std",
+    "sp-blockchain",
+    "sp-inherents/std",
+    "sp-runtime/std",
+    "thiserror"
+]
+serde = [
+	"dep:serde",
+	"scale-info/serde",
+	"sidechain-domain/serde",
+]

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -1,0 +1,117 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+#[cfg(feature = "std")]
+pub use inherent_provider::*;
+
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use sidechain_domain::*;
+use sp_inherents::*;
+use sp_runtime::{scale_info::TypeInfo, traits::Block as BlockT};
+
+#[cfg(test)]
+mod tests;
+
+pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"nattoken";
+
+#[derive(Default, Debug, Clone, PartialEq, Eq, TypeInfo, Encode, Decode, MaxEncodedLen)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct MainChainScripts {
+	pub native_token_policy: PolicyId,
+	pub native_token_asset_name: AssetName,
+	pub illiquid_supply_address: MainchainAddress,
+}
+
+sp_api::decl_runtime_apis! {
+	pub trait NativeTokenManagementApi {
+		fn get_main_chain_scripts() -> MainChainScripts;
+	}
+}
+
+#[derive(Decode, Encode)]
+pub struct TokenTransferData {
+	pub token_amount: NativeTokenAmount,
+}
+
+#[cfg(feature = "std")]
+mod inherent_provider {
+	use super::*;
+	use main_chain_follower_api::{DataSourceError, NativeTokenManagementDataSource};
+	use sidechain_mc_hash::get_mc_hash_for_block;
+	use sp_api::{ApiError, ProvideRuntimeApi};
+	use sp_blockchain::HeaderBackend;
+	use std::error::Error;
+	use std::sync::Arc;
+
+	pub struct NativeTokenManagementInherentDataProvider {
+		pub token_amount: NativeTokenAmount,
+	}
+
+	#[derive(thiserror::Error, sp_runtime::RuntimeDebug)]
+	pub enum IDPCreationError {
+		#[error("Failed to read native token data from data source: {0:?}")]
+		DataSourceError(#[from] DataSourceError),
+		#[error("Failed to retrieve main chain scripts from the runtime: {0:?}")]
+		GetMainChainScriptsError(ApiError),
+		#[error("Failed to retrieve previous MC hash: {0:?}")]
+		McHashError(Box<dyn Error + Send + Sync>),
+	}
+
+	impl NativeTokenManagementInherentDataProvider {
+		pub async fn new<Block, C>(
+			client: Arc<C>,
+			data_source: &(dyn NativeTokenManagementDataSource + Send + Sync),
+			mc_hash: McBlockHash,
+			parent_hash: <Block as BlockT>::Hash,
+		) -> Result<Self, IDPCreationError>
+		where
+			Block: BlockT,
+			C: HeaderBackend<Block>,
+			C: ProvideRuntimeApi<Block> + Send + Sync,
+			C::Api: NativeTokenManagementApi<Block>,
+		{
+			let api = client.runtime_api();
+			let scripts = api
+				.get_main_chain_scripts(parent_hash)
+				.map_err(IDPCreationError::GetMainChainScriptsError)?;
+			let parent_mc_hash: Option<McBlockHash> =
+				get_mc_hash_for_block(client.as_ref(), parent_hash)
+					.map_err(IDPCreationError::McHashError)?;
+			let token_amount = data_source
+				.get_total_native_token_transfer(
+					parent_mc_hash,
+					mc_hash,
+					scripts.native_token_policy,
+					scripts.native_token_asset_name,
+					scripts.illiquid_supply_address,
+				)
+				.await?;
+
+			Ok(Self { token_amount })
+		}
+	}
+
+	#[async_trait::async_trait]
+	impl InherentDataProvider for NativeTokenManagementInherentDataProvider {
+		async fn provide_inherent_data(
+			&self,
+			inherent_data: &mut InherentData,
+		) -> Result<(), sp_inherents::Error> {
+			inherent_data.put_data(
+				INHERENT_IDENTIFIER,
+				&TokenTransferData { token_amount: self.token_amount.clone() },
+			)
+		}
+
+		async fn try_handle_error(
+			&self,
+			identifier: &InherentIdentifier,
+			_error: &[u8],
+		) -> Option<Result<(), sp_inherents::Error>> {
+			if *identifier == INHERENT_IDENTIFIER {
+				panic!("BUG: {:?} inherent shouldn't return any errors", INHERENT_IDENTIFIER)
+			} else {
+				None
+			}
+		}
+	}
+}

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -1,0 +1,148 @@
+pub(crate) mod runtime_api_mock;
+
+#[cfg(feature = "std")]
+mod inherent_provider {
+	use super::runtime_api_mock::*;
+	use crate::inherent_provider::*;
+	use crate::INHERENT_IDENTIFIER;
+	use main_chain_follower_api::mock_services::MockNativeTokenDataSource;
+	use sidechain_domain::*;
+	use sidechain_mc_hash::MC_HASH_DIGEST_ID;
+	use sp_inherents::InherentData;
+	use sp_inherents::InherentDataProvider;
+	use sp_runtime::testing::Digest;
+	use sp_runtime::testing::DigestItem;
+	use std::sync::Arc;
+
+	#[tokio::test]
+	async fn correctly_fetches_total_transfer_between_two_hashes() {
+		let parent_number = 1; // not genesis
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = Some(McBlockHash([3; 32]));
+		let total_transfered = 103;
+
+		let data_source =
+			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+	}
+
+	#[tokio::test]
+	async fn fetches_with_no_lower_bound_when_parent_is_genesis() {
+		let parent_number = 0; // genesis
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = None; // genesis doesn't refer to any mc hash
+		let total_transfered = 103;
+
+		let data_source =
+			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+	}
+
+	#[tokio::test]
+	async fn defaults_to_zero_when_no_data() {
+		let parent_number = 1;
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = Some(McBlockHash([3; 32]));
+
+		let data_source = MockNativeTokenDataSource::new([].into());
+		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount.0, 0)
+	}
+
+	#[tokio::test]
+	async fn correctly_puts_data_into_inherent_data_structure() {
+		let token_amount = 1234;
+
+		let mut inherent_data = InherentData::new();
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider {
+			token_amount: NativeTokenAmount(token_amount),
+		};
+
+		inherent_provider.provide_inherent_data(&mut inherent_data).await.unwrap();
+
+		assert_eq!(
+			inherent_data
+				.get_data::<NativeTokenAmount>(&INHERENT_IDENTIFIER)
+				.unwrap()
+				.unwrap()
+				.0,
+			token_amount
+		)
+	}
+
+	fn create_data_source(
+		parent_mc_hash: Option<McBlockHash>,
+		mc_hash: McBlockHash,
+		total_transfered: u128,
+	) -> MockNativeTokenDataSource {
+		let total_transfered = NativeTokenAmount(total_transfered);
+		MockNativeTokenDataSource::new([((parent_mc_hash, mc_hash), total_transfered)].into())
+	}
+
+	fn create_client(
+		parent_hash: Hash,
+		parent_mc_hash: Option<McBlockHash>,
+		parent_number: u32,
+	) -> Arc<TestApi> {
+		Arc::new(TestApi {
+			headers: [(
+				parent_hash.clone(),
+				Header {
+					digest: Digest {
+						logs: match parent_mc_hash {
+							None => vec![],
+							Some(parent_mc_hash) => vec![DigestItem::PreRuntime(
+								MC_HASH_DIGEST_ID,
+								parent_mc_hash.0.to_vec(),
+							)],
+						},
+					},
+					extrinsics_root: Default::default(),
+					number: parent_number,
+					parent_hash: parent_hash.clone(),
+					state_root: Default::default(),
+				},
+			)]
+			.into(),
+		})
+	}
+}

--- a/primitives/native-token-management/src/tests/runtime_api_mock.rs
+++ b/primitives/native-token-management/src/tests/runtime_api_mock.rs
@@ -1,0 +1,69 @@
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::{Block as BlockT, NumberFor};
+use std::collections::HashMap;
+
+use crate::MainChainScripts;
+
+pub type Block = sp_runtime::generic::Block<
+	sp_runtime::generic::Header<u32, sp_runtime::traits::BlakeTwo256>,
+	sp_runtime::OpaqueExtrinsic,
+>;
+
+pub type Hash = <Block as sp_runtime::traits::Block>::Hash;
+pub type Header = <Block as sp_runtime::traits::Block>::Header;
+
+#[derive(Clone)]
+pub struct TestApi {
+	pub headers: HashMap<<Block as BlockT>::Hash, <Block as BlockT>::Header>,
+}
+
+impl sp_api::ProvideRuntimeApi<Block> for TestApi {
+	type Api = TestApi;
+
+	fn runtime_api(&self) -> sp_api::ApiRef<Self::Api> {
+		self.clone().into()
+	}
+}
+
+sp_api::mock_impl_runtime_apis! {
+	impl crate::NativeTokenManagementApi<Block> for TestApi {
+		fn get_main_chain_scripts() -> MainChainScripts {
+			MainChainScripts::default()
+		}
+
+	}
+}
+
+impl HeaderBackend<Block> for TestApi {
+	fn header(
+		&self,
+		id: <Block as BlockT>::Hash,
+	) -> Result<Option<<Block as BlockT>::Header>, sp_blockchain::Error> {
+		Ok(self.headers.get(&id).cloned())
+	}
+
+	fn info(&self) -> sp_blockchain::Info<Block> {
+		unimplemented!()
+	}
+
+	fn status(
+		&self,
+		_id: <Block as BlockT>::Hash,
+	) -> Result<sp_blockchain::BlockStatus, sp_blockchain::Error> {
+		unimplemented!()
+	}
+
+	fn number(
+		&self,
+		_hash: <Block as BlockT>::Hash,
+	) -> Result<Option<NumberFor<Block>>, sp_blockchain::Error> {
+		unimplemented!()
+	}
+
+	fn hash(
+		&self,
+		_number: NumberFor<Block>,
+	) -> Result<Option<<Block as BlockT>::Hash>, sp_blockchain::Error> {
+		unimplemented!()
+	}
+}

--- a/primitives/sidechain-mc-hash/Cargo.toml
+++ b/primitives/sidechain-mc-hash/Cargo.toml
@@ -7,9 +7,10 @@ description = "Logic for putting a main chain block reference in digest and inhe
 [dependencies]
 async-trait = { workspace = true }
 main-chain-follower-api = { workspace = true, features = ["block-source"] }
-sp-consensus-slots = { workspace = true }
+sp-consensus-slots = { workspace = true, features = ["std"] }
 sidechain-domain = { workspace = true, features = ["std"] }
 sp-consensus = { workspace = true }
+sp-blockchain = { workspace = true }
 sp-inherents = { workspace = true, features = ["std"] }
 sp-runtime = { workspace = true, features = ["std"] }
 sp-timestamp = { workspace = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -70,6 +70,7 @@ sidechain-domain = { workspace = true, features = ["serde"] }
 chain-params = { workspace = true, features = ["serde"] }
 sidechain-slots = { workspace = true }
 session-manager = { workspace = true }
+sp-native-token-management = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 sp-io = { workspace = true }
@@ -140,6 +141,7 @@ std = [
 	"sidechain-domain/std",
 	"sp-inherents/std",
 	"chain-params/std",
+	"sp-native-token-management/std"
 ]
 
 runtime-benchmarks = [

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -838,6 +838,16 @@ impl_runtime_apis! {
 			validate_permissioned_candidate_data::<CrossChainPublic>(candidate).err()
 		}
 	}
+
+	impl sp_native_token_management::NativeTokenManagementApi<Block> for Runtime {
+		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+			sp_native_token_management::MainChainScripts {
+				native_token_policy: Default::default(),
+				native_token_asset_name: Default::default(),
+				illiquid_supply_address: Default::default(),
+			}
+		}
+	}
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

Adds the inherent data provider that uses the data source from the previous PR and produces inherent data containing the number of tokens moved into the illiquid supply. I wired it into the node already so the inherent data is already produced, but there is no pallet to use it yet. 

The next PR is [the pallet](https://github.com/input-output-hk/partner-chains/pull/36). You can see the changes from all the PR together in [this draft PR](https://github.com/input-output-hk/partner-chains/pull/22). 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

