### PR TITLE
change: ETCM-7811 native token data source

### DIFF
--- a/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/mainchain-follower/db-sync-follower/Cargo.toml
@@ -39,3 +39,4 @@ ctor = "0.2.5"
 default = []
 block-source = ["main-chain-follower-api/block-source"]
 candidate-source = ["main-chain-follower-api/candidate-source"]
+native-token = ["main-chain-follower-api/native-token"]

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -273,7 +273,7 @@ impl<'r> Decode<'r, Postgres> for StakeDelegation {
 }
 
 #[derive(Debug, Clone, PartialEq)]
-pub(crate) struct NativeTokenAmount(pub u64);
+pub(crate) struct NativeTokenAmount(pub u128);
 impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
 	fn from(value: NativeTokenAmount) -> Self {
 		Self(value.0)
@@ -289,7 +289,7 @@ impl sqlx::Type<Postgres> for NativeTokenAmount {
 impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
 	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
 		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
-		let i = decoded.to_u64().ok_or("NativeTokenQuantity is always a u64".to_string())?;
+		let i = decoded.to_u128().ok_or("NativeTokenQuantity is always a u128".to_string())?;
 		Ok(Self(i))
 	}
 }

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -82,6 +82,12 @@ impl Asset {
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct AssetName(pub Vec<u8>);
 
+impl From<sidechain_domain::AssetName> for AssetName {
+	fn from(name: sidechain_domain::AssetName) -> Self {
+		Self(name.0.to_vec())
+	}
+}
+
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct DistributedSetData {
 	pub utxo_id_tx_hash: [u8; 32],
@@ -198,6 +204,12 @@ pub(crate) struct MintAction {
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct PolicyId(pub Vec<u8>);
 
+impl From<sidechain_domain::PolicyId> for PolicyId {
+	fn from(id: sidechain_domain::PolicyId) -> Self {
+		Self(id.0.to_vec())
+	}
+}
+
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct StakePoolEntry {
 	pub pool_hash: [u8; 28],
@@ -256,6 +268,28 @@ impl<'r> Decode<'r, Postgres> for StakeDelegation {
 	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
 		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
 		let i = decoded.to_u64().ok_or("StakeDelegation is always a u64".to_string())?;
+		Ok(Self(i))
+	}
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct NativeTokenAmount(pub u64);
+impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
+	fn from(value: NativeTokenAmount) -> Self {
+		Self(value.0)
+	}
+}
+
+impl sqlx::Type<Postgres> for NativeTokenAmount {
+	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+		PgTypeInfo::with_name("NUMERIC")
+	}
+}
+
+impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
+	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
+		let i = decoded.to_u64().ok_or("NativeTokenQuantity is always a u64".to_string())?;
 		Ok(Self(i))
 	}
 }
@@ -352,7 +386,7 @@ LIMIT 1",
 }
 
 /// Query to get the block by its hash
-#[cfg(feature = "block-source")]
+#[cfg(any(feature = "block-source", feature = "native-token"))]
 pub(crate) async fn get_block_by_hash(
 	pool: &Pool<Postgres>,
 	hash: McBlockHash,
@@ -526,4 +560,36 @@ pub(crate) async fn index_exists(pool: &Pool<Postgres>, index_name: &str) -> boo
 		.await
 		.map(|rows| rows.len() == 1)
 		.unwrap()
+}
+
+#[cfg(feature = "native-token")]
+pub(crate) async fn get_total_native_tokens_transfered(
+	pool: &Pool<Postgres>,
+	after_slot: SlotNumber,
+	to_slot: SlotNumber,
+	asset: Asset,
+	illiquid_supply_address: Address,
+) -> Result<Option<NativeTokenAmount>, SqlxError> {
+	let query = sqlx::query_as::<_, (Option<NativeTokenAmount>,)>(
+		"
+SELECT
+    SUM(ma_tx_out.quantity)
+FROM tx_out
+LEFT JOIN ma_tx_out    ON ma_tx_out.tx_out_id = tx_out.id
+LEFT JOIN multi_asset  ON multi_asset.id = ma_tx_out.ident
+INNER JOIN tx          ON tx_out.tx_id = tx.id
+INNER JOIN block       ON tx.block_id = block.id
+WHERE address = $1
+AND multi_asset.policy = $2
+AND multi_asset.name = $3
+AND $4 < block.slot_no AND block.slot_no <= $5;
+    ",
+	)
+	.bind(&illiquid_supply_address.0)
+	.bind(&asset.policy_id.0)
+	.bind(&asset.asset_name.0)
+	.bind(after_slot)
+	.bind(to_slot);
+
+	Ok(query.fetch_one(pool).await?.0)
 }

--- a/mainchain-follower/db-sync-follower/src/lib.rs
+++ b/mainchain-follower/db-sync-follower/src/lib.rs
@@ -10,6 +10,8 @@ pub mod metrics;
 pub mod block;
 #[cfg(feature = "candidate-source")]
 pub mod candidates;
+#[cfg(feature = "native-token")]
+pub mod native_token;
 
 pub struct SqlxError(sqlx::Error);
 

--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -16,7 +16,7 @@ pub struct NativeTokenManagementDataSourceImpl {
 
 observed_async_trait!(
 impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
-	async fn get_token_transfer_events(
+	async fn get_total_native_token_transfer(
 		&self,
 		after_block: Option<McBlockHash>,
 		to_block: McBlockHash,

--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -28,15 +28,15 @@ impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
 			return Ok(NativeTokenAmount(0).into());
 		}
 
-		let (after_slot , to_slot) = futures::join!(
+		let (after_slot , to_slot) = futures::try_join!(
 			get_after_slot(after_block, &self.pool),
 			get_to_slot(to_block, &self.pool)
-		);
+		)?;
 
 		let total_transfer = crate::db_model::get_total_native_tokens_transfered(
 			&self.pool,
-			after_slot?,
-			to_slot?,
+			after_slot,
+			to_slot,
 			crate::db_model::Asset {
 				policy_id: native_token_policy_id.into(),
 				asset_name: native_token_asset_name.into(),

--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -1,11 +1,8 @@
-use crate::db_model::Address;
-use crate::db_model::NativeTokenAmount;
-use crate::db_model::SlotNumber;
+use crate::db_model::{Address, NativeTokenAmount, SlotNumber};
 use crate::metrics::McFollowerMetrics;
 use crate::observed_async_trait;
 use async_trait::async_trait;
-use main_chain_follower_api::NativeTokenManagementDataSource;
-use main_chain_follower_api::Result;
+use main_chain_follower_api::{NativeTokenManagementDataSource, Result};
 use sidechain_domain::*;
 use sqlx::PgPool;
 

--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -1,0 +1,63 @@
+use crate::db_model::Address;
+use crate::db_model::NativeTokenAmount;
+use crate::db_model::SlotNumber;
+use crate::metrics::McFollowerMetrics;
+use crate::observed_async_trait;
+use async_trait::async_trait;
+use main_chain_follower_api::NativeTokenManagementDataSource;
+use main_chain_follower_api::Result;
+use sidechain_domain::*;
+use sqlx::PgPool;
+
+#[cfg(test)]
+mod tests;
+
+pub struct NativeTokenManagementDataSourceImpl {
+	pub pool: PgPool,
+	pub metrics_opt: Option<McFollowerMetrics>,
+}
+
+observed_async_trait!(
+impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
+	async fn get_token_transfer_events(
+		&self,
+		after_block: Option<McBlockHash>,
+		to_block: McBlockHash,
+		native_token_policy_id: PolicyId,
+		native_token_asset_name: AssetName,
+		illiquid_supply_address: MainchainAddress,
+	) -> Result<sidechain_domain::NativeTokenAmount> {
+		if after_block == Some(to_block.clone()) {
+			return Ok(NativeTokenAmount(0).into());
+		}
+
+		let after_slot = match after_block {
+			None => SlotNumber(0),
+			Some(after_block) => {
+				crate::db_model::get_block_by_hash(&self.pool, after_block)
+					.await?
+					.expect("Parent MC hash is valid")
+					.slot_no
+			},
+		};
+		let to_slot = crate::db_model::get_block_by_hash(&self.pool, to_block)
+			.await?
+			.expect("current MC hash is valid")
+			.slot_no;
+
+		let total_transfer = crate::db_model::get_total_native_tokens_transfered(
+			&self.pool,
+			after_slot,
+			to_slot,
+			crate::db_model::Asset {
+				policy_id: native_token_policy_id.into(),
+				asset_name: native_token_asset_name.into(),
+			},
+			Address(illiquid_supply_address.to_string()),
+		)
+		.await?;
+
+		Ok(total_transfer.unwrap_or(NativeTokenAmount(0)).into())
+	}
+}
+);

--- a/mainchain-follower/db-sync-follower/src/native_token/tests.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/tests.rs
@@ -38,7 +38,7 @@ async fn defaults_to_zero_when_there_are_no_transfers(pool: PgPool) {
 	let after_block = None;
 	let to_block = genesis_hash();
 	let result = source
-		.get_token_transfer_events(
+		.get_total_native_token_transfer(
 			after_block,
 			to_block,
 			native_token_policy_id(),
@@ -57,7 +57,7 @@ async fn gets_sum_of_all_transfers_when_queried_up_to_latest_block(pool: PgPool)
 	let after_block = None;
 	let to_block = block_hash(5);
 	let result = source
-		.get_token_transfer_events(
+		.get_total_native_token_transfer(
 			after_block,
 			to_block,
 			native_token_policy_id(),
@@ -76,7 +76,7 @@ async fn gets_sum_of_transfers_in_range(pool: PgPool) {
 	let after_block = Some(block_hash(1));
 	let to_block = block_hash(5);
 	let result = source
-		.get_token_transfer_events(
+		.get_total_native_token_transfer(
 			after_block,
 			to_block,
 			native_token_policy_id(),

--- a/mainchain-follower/db-sync-follower/src/native_token/tests.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/tests.rs
@@ -1,0 +1,90 @@
+use super::NativeTokenManagementDataSourceImpl;
+use main_chain_follower_api::NativeTokenManagementDataSource;
+use sidechain_domain::{AssetName, MainchainAddress, McBlockHash, PolicyId};
+use sqlx::PgPool;
+use std::str::FromStr;
+
+fn native_token_policy_id() -> PolicyId {
+	PolicyId::from_hex_unsafe("6c969320597b755454ff3653ad09725d590c570827a129aeb4385526")
+}
+
+fn native_token_asset_name() -> AssetName {
+	AssetName::from_hex_unsafe("546573744275647a507265766965775f3335")
+}
+
+fn illiquid_supply_address() -> MainchainAddress {
+	MainchainAddress::from_str("addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz")
+		.unwrap()
+}
+
+fn block_hash(i: u32) -> McBlockHash {
+	McBlockHash::from_str(&format!(
+		"b00000000000000000000000000000000000000000000000000000000000000{i}"
+	))
+	.unwrap()
+}
+
+pub fn genesis_hash() -> McBlockHash {
+	block_hash(0)
+}
+
+fn make_source(pool: PgPool) -> NativeTokenManagementDataSourceImpl {
+	NativeTokenManagementDataSourceImpl { pool, metrics_opt: None }
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn defaults_to_zero_when_there_are_no_transfers(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = None;
+	let to_block = genesis_hash();
+	let result = source
+		.get_token_transfer_events(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 0)
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn gets_sum_of_all_transfers_when_queried_up_to_latest_block(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = None;
+	let to_block = block_hash(5);
+	let result = source
+		.get_token_transfer_events(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 11 + 12 + 13 + 14)
+}
+
+#[sqlx::test(migrations = "./testdata/native-token/migrations")]
+async fn gets_sum_of_transfers_in_range(pool: PgPool) {
+	let source = make_source(pool);
+	let after_block = Some(block_hash(1));
+	let to_block = block_hash(5);
+	let result = source
+		.get_token_transfer_events(
+			after_block,
+			to_block,
+			native_token_policy_id(),
+			native_token_asset_name(),
+			illiquid_supply_address(),
+		)
+		.await
+		.unwrap();
+
+	assert_eq!(result.0, 12 + 13 + 14)
+}

--- a/mainchain-follower/db-sync-follower/testdata/native-token/migrations/1_create_schema.sql
+++ b/mainchain-follower/db-sync-follower/testdata/native-token/migrations/1_create_schema.sql
@@ -1,0 +1,212 @@
+CREATE DOMAIN hash28type AS bytea CONSTRAINT flyway_needs_this CHECK (octet_length(VALUE) = 28);
+
+CREATE DOMAIN hash32type AS bytea CONSTRAINT flyway_needs_this CHECK(octet_length(VALUE) = 32);
+
+CREATE DOMAIN "uinteger" AS integer CONSTRAINT flyway_needs_this CHECK (VALUE >= 0);
+
+CREATE DOMAIN "lovelace" AS numeric(20,0) CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
+
+CREATE DOMAIN "word64type" AS numeric(20,0)	CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
+
+CREATE DOMAIN word63type AS bigint CONSTRAINT word63type_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN word31type AS integer CONSTRAINT word31type_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN txindex AS smallint CONSTRAINT txindex_check CHECK ((VALUE >= 0));
+
+CREATE DOMAIN asset32type AS bytea CHECK (octet_length (VALUE) <= 32);
+
+CREATE DOMAIN int65type AS numeric (20, 0) CHECK (VALUE >= -18446744073709551615 AND VALUE <= 18446744073709551615);
+
+CREATE TYPE scriptpurposetype AS ENUM ('spend', 'mint', 'cert', 'reward');
+
+CREATE TABLE epoch_param (
+	id bigserial NOT NULL,
+	epoch_no "uinteger" NOT NULL,
+	min_fee_a "uinteger" NOT NULL,
+	min_fee_b "uinteger" NOT NULL,
+	max_block_size "uinteger" NOT NULL,
+	max_tx_size "uinteger" NOT NULL,
+	max_bh_size "uinteger" NOT NULL,
+	key_deposit "lovelace" NOT NULL,
+	pool_deposit "lovelace" NOT NULL,
+	max_epoch "uinteger" NOT NULL,
+	optimal_pool_count "uinteger" NOT NULL,
+	influence float8 NOT NULL,
+	monetary_expand_rate float8 NOT NULL,
+	treasury_growth_rate float8 NOT NULL,
+	decentralisation float8 NOT NULL,
+	entropy hash32type NULL,
+	protocol_major "uinteger" NOT NULL,
+	protocol_minor "uinteger" NOT NULL,
+	min_utxo_value "lovelace" NOT NULL,
+	min_pool_cost "lovelace" NOT NULL,
+	nonce hash32type NULL,
+	coins_per_utxo_word "lovelace" NULL,
+	cost_model_id int8 NULL,
+	price_mem float8 NULL,
+	price_step float8 NULL,
+	max_tx_ex_mem "word64type" NULL,
+	max_tx_ex_steps "word64type" NULL,
+	max_block_ex_mem "word64type" NULL,
+	max_block_ex_steps "word64type" NULL,
+	max_val_size "word64type" NULL,
+	collateral_percent "uinteger" NULL,
+	max_collateral_inputs "uinteger" NULL,
+	block_id int8 NOT NULL,
+	CONSTRAINT epoch_param_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_epoch_param UNIQUE (epoch_no, block_id)
+);
+CREATE INDEX idx_epoch_param_block_id ON epoch_param USING btree (block_id);
+
+CREATE TABLE pool_hash (
+	id bigserial NOT NULL,
+	hash_raw hash28type NOT NULL,
+	"view" varchar NOT NULL,
+	CONSTRAINT pool_hash_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_pool_hash UNIQUE (hash_raw)
+);
+
+
+CREATE TABLE epoch_stake (
+	id SERIAL PRIMARY KEY,
+	addr_id int8 NOT NULL,
+	pool_id int8 NOT NULL,
+	amount "lovelace" NOT NULL,
+	epoch_no "uinteger" NOT NULL,
+	CONSTRAINT unique_stake UNIQUE (epoch_no, addr_id, pool_id)
+);
+CREATE INDEX idx_epoch_stake_addr_id ON epoch_stake USING btree (addr_id);
+CREATE INDEX idx_epoch_stake_epoch_no ON epoch_stake USING btree (epoch_no);
+CREATE INDEX idx_epoch_stake_pool_id ON epoch_stake USING btree (pool_id);
+
+CREATE TABLE block (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    epoch_no word31type,
+    slot_no word63type,
+    epoch_slot_no word31type,
+    block_no word31type,
+    previous_id bigint,
+    slot_leader_id bigint NOT NULL,
+    size word31type NOT NULL,
+    "time" timestamp without time zone NOT NULL,
+    tx_count bigint NOT NULL,
+    proto_major word31type NOT NULL,
+    proto_minor word31type NOT NULL,
+    vrf_key character varying,
+    op_cert hash32type,
+    op_cert_counter word63type,
+    CONSTRAINT block_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE datum (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    tx_id bigint NOT NULL,
+    value JSONB,
+    CONSTRAINT datum_id PRIMARY KEY (id)
+);
+
+CREATE TABLE tx (
+    id bigint NOT NULL,
+    hash hash32type NOT NULL,
+    block_id bigint NOT NULL,
+    block_index word31type NOT NULL,
+    out_sum lovelace NOT NULL,
+    fee lovelace NOT NULL,
+    deposit bigint NOT NULL,
+    size word31type NOT NULL,
+    invalid_before word64type,
+    invalid_hereafter word64type,
+    valid_contract boolean NOT NULL,
+    script_size word31type NOT NULL,
+    CONSTRAINT tx_pkey PRIMARY KEY (id),
+     -- this constraint unique_tx_block_index does not exist in the real database but it ensure we put
+     -- consistent data in our database
+	  CONSTRAINT unique_tx_block_index UNIQUE (block_id, block_index)
+);
+
+CREATE TABLE redeemer_data (
+	id bigserial NOT NULL,
+	hash public.hash32type NOT NULL,
+	tx_id int8 NOT NULL,
+	value jsonb NULL,
+	CONSTRAINT redeemer_data_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_redeemer_data UNIQUE (hash)
+);
+CREATE INDEX redeemer_data_tx_id_idx ON public.redeemer_data USING btree (tx_id);
+
+ALTER TABLE public.redeemer_data ADD CONSTRAINT redeemer_data_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+CREATE TABLE tx_in (
+    id bigint NOT NULL,
+    tx_in_id bigint NOT NULL,
+    tx_out_id bigint NOT NULL,
+    tx_out_index txindex NOT NULL,
+    redeemer_id bigint,
+    CONSTRAINT tx_in_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE tx_out (
+    id bigint NOT NULL,
+    tx_id bigint NOT NULL,
+    index txindex NOT NULL,
+    address character varying NOT NULL,
+    address_raw bytea NOT NULL,
+    address_has_script boolean NOT NULL,
+    payment_cred hash28type,
+    stake_address_id bigint,
+    value lovelace NOT NULL,
+    data_hash hash32type
+);
+
+CREATE TABLE redeemer (
+    id bigint PRIMARY KEY,
+    tx_id bigint NOT NULL,
+    unit_mem word63type NOT NULL,
+    unit_steps word63type NOT NULL,
+    fee lovelace NOT NULL,
+    purpose scriptpurposetype NOT NULL,
+    index uinteger NOT NULL,
+    script_hash hash28type NULL,
+    redeemer_data_id bigint NOT NULL
+);
+ALTER TABLE redeemer ADD CONSTRAINT unique_redeemer UNIQUE(tx_id, purpose, index);
+ALTER TABLE redeemer ADD CONSTRAINT redeemer_tx_id_fkey FOREIGN KEY(tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE redeemer ADD CONSTRAINT redeemer_datum_id_fkey FOREIGN KEY(redeemer_data_id) REFERENCES redeemer_data(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+
+CREATE TABLE multi_asset (
+    id bigint PRIMARY KEY,
+    policy hash28type NOT NULL,
+    name asset32type NOT NULL,
+    fingerprint varchar NOT NULL
+);
+ALTER TABLE multi_asset ADD CONSTRAINT unique_multi_asset UNIQUE (policy, name);
+
+CREATE TABLE ma_tx_mint (
+    id bigint PRIMARY KEY,
+    quantity int65type NOT NULL,
+    tx_id bigint NOT NULL,
+    ident bigint NOT NULL
+);
+ALTER TABLE ma_tx_mint ADD CONSTRAINT unique_ma_tx_mint UNIQUE(ident, tx_id);
+CREATE UNIQUE INDEX idx_ma_tx_mint_tx_id ON ma_tx_mint(tx_id);
+
+ALTER TABLE epoch_stake ADD CONSTRAINT epoch_stake_pool_id_fkey FOREIGN KEY (pool_id) REFERENCES pool_hash(id) ON DELETE CASCADE ON UPDATE RESTRICT;
+ALTER TABLE ONLY tx
+    ADD CONSTRAINT unique_tx UNIQUE (hash);
+ALTER TABLE ONLY tx
+    ADD CONSTRAINT tx_block_id_fkey FOREIGN KEY (block_id) REFERENCES block(id) ON UPDATE RESTRICT ON DELETE CASCADE;
+
+CREATE TABLE public.ma_tx_out (
+	id bigserial NOT NULL,
+	quantity public."word64type" NOT NULL,
+	tx_out_id int8 NOT NULL,
+	ident int8 NOT NULL,
+	CONSTRAINT ma_tx_out_pkey PRIMARY KEY (id),
+	CONSTRAINT unique_ma_tx_out UNIQUE (ident, tx_out_id),
+	CONSTRAINT ma_tx_out_ident_fkey FOREIGN KEY (ident) REFERENCES public.multi_asset(id) ON DELETE CASCADE ON UPDATE RESTRICT
+	-- CONSTRAINT ma_tx_out_tx_out_id_fkey FOREIGN KEY (tx_out_id) REFERENCES public.tx_out(id) ON DELETE CASCADE ON UPDATE RESTRICT
+);
+CREATE INDEX idx_ma_tx_out_tx_out_id ON public.ma_tx_out USING btree (tx_out_id);

--- a/mainchain-follower/db-sync-follower/testdata/native-token/migrations/2_data.sql
+++ b/mainchain-follower/db-sync-follower/testdata/native-token/migrations/2_data.sql
@@ -1,0 +1,94 @@
+do $$
+declare
+    policy_id integer := 1001;
+    policy hash28type := decode('6c969320597b755454ff3653ad09725d590c570827a129aeb4385526', 'hex');
+    policy_name asset32type :=  '\x546573744275647a507265766965775f3335';
+    validator_addr text := 'addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz';
+
+    genesis_hash hash32type := decode('b000000000000000000000000000000000000000000000000000000000000000','hex');
+    block_hash_1 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000001','hex');
+    block_hash_2 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000002','hex');
+    block_hash_3 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000003','hex');
+    block_hash_4 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000004','hex');
+    block_hash_5 hash32type := decode('b000000000000000000000000000000000000000000000000000000000000005','hex');
+
+    transfer_tx_id_1 integer := 1;
+    transfer_tx_id_2 integer := 2;
+    irrelevant_tx_id integer := 3;
+    transfer_tx_id_3 integer := 4;
+    transfer_tx_id_4 integer := 5;
+
+    transfer_tx_hash_1 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000001','hex');
+    transfer_tx_hash_2 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000002','hex');
+    irrelevant_tx_hash hash32type := decode('f000000000000000000000000000000000000000000000000000000000000003','hex');
+    transfer_tx_hash_3 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000004','hex');
+    transfer_tx_hash_4 hash32type := decode('f000000000000000000000000000000000000000000000000000000000000005','hex');
+
+    transfer_utxo_id_1   integer := 0;
+    transfer_utxo_id_2   integer := 1;
+    irrelevant_utxo_id_1 integer := 2;
+    irrelevant_utxo_id_2 integer := 3;
+    transfer_utxo_id_3   integer := 4;
+    transfer_utxo_id_4   integer := 5;
+begin
+
+insert into multi_asset
+(id       , policy,                                                      "name",                                   fingerprint)
+values
+(0        , '\xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad01', '\xbadbadbadbadbadbadbadbadbadbadbad001', 'asset1thisassetshouldbeignoredbythequeries01'),
+(policy_id, policy                                                      , policy_name                             , 'asset1yedvsfmkxu27zaaa37lw44pa8ql9favqlyclnm'),
+(2        , '\xbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbad02', '\xbadbadbadbadbadbadbadbadbadbadbad002', 'asset1thisassetshouldbeignoredbythequeries02')
+;
+
+-- the integration test assume a securityParameter of 50, epoch duration of 1000 slots and a coeff of 1
+
+INSERT INTO block
+(id, hash        , epoch_no, slot_no , epoch_slot_no, block_no, previous_id, slot_leader_id, size, "time"                     , tx_count, proto_major, proto_minor, vrf_key, op_cert, op_cert_counter)
+VALUES
+(0 , genesis_hash, 189     , 189410, 410            , 0       , NULL       , 0             , 1024, '2022-04-21T16:28:00Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(1 , block_hash_1, 190     , 190400, 400            , 1       , NULL       , 0             , 1024, '2022-04-21T16:44:30Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(2 , block_hash_2, 190     , 190500, 500            , 2       , NULL       , 0             , 1024, '2022-04-21T16:46:10Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(3 , block_hash_3, 191     , 191500, 500            , 3       , NULL       , 0             , 1024, '2022-04-21T17:02:50Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(4 , block_hash_4, 192     , 192500, 500            , 4       , NULL       , 0             , 1024, '2022-04-21T17:19:30Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           ),
+(5 , block_hash_5, 193     , 193500, 500            , 5       , NULL       , 0             , 1024, '2022-04-21T17:36:10Z'     , 1       , 0          , 0          , ''     , NULL   , NULL           )
+;
+-- sometimes the block number can be null so we add this block just to handle that case
+INSERT INTO block
+(id , hash                                                                            , epoch_no, slot_no, epoch_slot_no, block_no, previous_id, slot_leader_id, "size", "time"                   , tx_count, proto_major, proto_minor, vrf_key, op_cert, op_cert_counter)
+VALUES
+(100, decode('b000000000000000000000000000000000000000000000000000000000000BAD','hex'), NULL    , NULL   , NULL         , NULL    , NULL       , 1             , 0     , '2022-06-06 23:00:00.000', 0       , 0          , 0          , NULL   , NULL   , NULL           )
+;
+
+
+INSERT INTO tx
+( id               , hash               , block_id, block_index, out_sum, fee, deposit, size, invalid_before, invalid_hereafter, valid_contract, script_size )
+VALUES
+( transfer_tx_id_1 , transfer_tx_hash_1 , 1       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_2 , transfer_tx_hash_2 , 3       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( irrelevant_tx_id , irrelevant_tx_hash , 3       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_3 , transfer_tx_hash_3 , 5       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        ),
+( transfer_tx_id_4 , transfer_tx_hash_4 , 5       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
+;
+
+INSERT INTO tx_out
+( id                   , tx_id           , index, address        , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash )
+VALUES
+( transfer_utxo_id_1   , transfer_tx_id_1, 0    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_2   , transfer_tx_id_2, 1    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( irrelevant_utxo_id_1 , irrelevant_tx_id, 0    , 'other_addr'   , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( irrelevant_utxo_id_2 , irrelevant_tx_id, 1    , 'another_addr' , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_3   , transfer_tx_id_3, 2    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( transfer_utxo_id_4   , transfer_tx_id_4, 0    , validator_addr , ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
+;
+
+INSERT INTO ma_tx_out
+(id   , quantity , tx_out_id , ident)
+VALUES
+(3001 , 11       , transfer_utxo_id_1      ,  policy_id),
+(3002 , 12       , transfer_utxo_id_2      ,  policy_id),
+(3003 , 13       , transfer_utxo_id_3      ,  policy_id),
+(3004 , 14       , transfer_utxo_id_4      ,  policy_id),
+(3005 , 100      , irrelevant_utxo_id_1    ,  0)
+;
+
+end $$;

--- a/mainchain-follower/main-chain-follower-api/Cargo.toml
+++ b/mainchain-follower/main-chain-follower-api/Cargo.toml
@@ -34,7 +34,9 @@ std = [
 serde = []
 block-source = ["std"]
 candidate-source = ["std"]
+native-token= ["std"]
 all-sources = [
     "block-source",
     "candidate-source",
+    "native-token"
 ]

--- a/mainchain-follower/main-chain-follower-api/src/lib.rs
+++ b/mainchain-follower/main-chain-follower-api/src/lib.rs
@@ -19,6 +19,11 @@ pub mod candidate;
 #[cfg(feature = "candidate-source")]
 pub use candidate::CandidateDataSource;
 
+#[cfg(feature = "native-token")]
+pub mod native_token;
+#[cfg(feature = "native-token")]
+pub use native_token::NativeTokenManagementDataSource;
+
 #[cfg(feature = "std")]
 pub mod mock_services;
 

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -170,12 +170,51 @@ mod candidates {
 	}
 }
 
+#[cfg(feature = "native-token")]
+pub use native_token::*;
+
+#[cfg(feature = "native-token")]
+mod native_token {
+	use super::*;
+	use crate::native_token::*;
+	use derive_new::new;
+	use std::collections::HashMap;
+
+	#[derive(new)]
+	pub struct MockNativeTokenDataSource {
+		transfers: HashMap<(Option<McBlockHash>, McBlockHash), NativeTokenAmount>,
+	}
+
+	impl Default for MockNativeTokenDataSource {
+		fn default() -> Self {
+			Self { transfers: Default::default() }
+		}
+	}
+
+	#[async_trait]
+	impl NativeTokenManagementDataSource for MockNativeTokenDataSource {
+		async fn get_token_transfer_events(
+			&self,
+			after_block: Option<McBlockHash>,
+			to_block: McBlockHash,
+			_native_token_policy_id: PolicyId,
+			_native_token_asset_name: AssetName,
+			_illiquid_supply_address: MainchainAddress,
+		) -> Result<NativeTokenAmount> {
+			println!("Called with {after_block:?} and {to_block:?}");
+			Ok(self.transfers.get(&(after_block, to_block)).cloned().unwrap_or_default())
+		}
+	}
+}
+
 #[derive(Clone)]
 pub struct TestDataSources {
 	#[cfg(feature = "block-source")]
 	pub block: Arc<dyn BlockDataSource + Send + Sync>,
 	#[cfg(feature = "candidate-source")]
 	pub candidate: Arc<dyn CandidateDataSource + Send + Sync>,
+	#[cfg(feature = "native-token")]
+	pub native_token: Arc<dyn NativeTokenManagementDataSource + Send + Sync>,
 }
 
 impl Default for TestDataSources {
@@ -191,6 +230,8 @@ impl TestDataSources {
 			block: Arc::from(MockBlockDataSource::default()),
 			#[cfg(feature = "candidate-source")]
 			candidate: Arc::from(MockCandidateDataSource::default()),
+			#[cfg(feature = "native-token")]
+			native_token: Arc::from(MockNativeTokenDataSource::default()),
 		}
 	}
 

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -180,15 +180,9 @@ mod native_token {
 	use derive_new::new;
 	use std::collections::HashMap;
 
-	#[derive(new)]
+	#[derive(new, Default)]
 	pub struct MockNativeTokenDataSource {
 		transfers: HashMap<(Option<McBlockHash>, McBlockHash), NativeTokenAmount>,
-	}
-
-	impl Default for MockNativeTokenDataSource {
-		fn default() -> Self {
-			Self { transfers: Default::default() }
-		}
 	}
 
 	#[async_trait]

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -201,7 +201,6 @@ mod native_token {
 			_native_token_asset_name: AssetName,
 			_illiquid_supply_address: MainchainAddress,
 		) -> Result<NativeTokenAmount> {
-			println!("Called with {after_block:?} and {to_block:?}");
 			Ok(self.transfers.get(&(after_block, to_block)).cloned().unwrap_or_default())
 		}
 	}

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -193,7 +193,7 @@ mod native_token {
 
 	#[async_trait]
 	impl NativeTokenManagementDataSource for MockNativeTokenDataSource {
-		async fn get_token_transfer_events(
+		async fn get_total_native_token_transfer(
 			&self,
 			after_block: Option<McBlockHash>,
 			to_block: McBlockHash,

--- a/mainchain-follower/main-chain-follower-api/src/native_token.rs
+++ b/mainchain-follower/main-chain-follower-api/src/native_token.rs
@@ -5,7 +5,7 @@ use sidechain_domain::*;
 #[async_trait]
 pub trait NativeTokenManagementDataSource {
 	/// Retrieves total of native token transfers into the illiquid supply in the range (after_block, to_block]
-	async fn get_token_transfer_events(
+	async fn get_total_native_token_transfer(
 		&self,
 		after_block: Option<McBlockHash>,
 		to_block: McBlockHash,

--- a/mainchain-follower/main-chain-follower-api/src/native_token.rs
+++ b/mainchain-follower/main-chain-follower-api/src/native_token.rs
@@ -1,0 +1,16 @@
+use crate::Result;
+use async_trait::async_trait;
+use sidechain_domain::*;
+
+#[async_trait]
+pub trait NativeTokenManagementDataSource {
+	/// Retrieves total of native token transfers into the illiquid supply in the range (after_block, to_block]
+	async fn get_token_transfer_events(
+		&self,
+		after_block: Option<McBlockHash>,
+		to_block: McBlockHash,
+		native_token_policy_id: PolicyId,
+		native_token_asset_name: AssetName,
+		illiquid_supply_address: MainchainAddress,
+	) -> Result<NativeTokenAmount>;
+}

--- a/mainchain-follower/mock/Cargo.toml
+++ b/mainchain-follower/mock/Cargo.toml
@@ -17,7 +17,7 @@ serde_json = { workspace = true }
 sidechain-domain = { workspace = true }
 
 [features]
-default = [ "std", "block-source", "candidate-source" ]
+default = [ "std", "block-source", "candidate-source", "native-token" ]
 std = [
 	"serde_json/std",
 	"sidechain-domain/std",
@@ -27,3 +27,4 @@ std = [
 ]
 block-source = ["main-chain-follower-api/block-source"]
 candidate-source = ["main-chain-follower-api/candidate-source"]
+native-token = ["main-chain-follower-api/native-token"]

--- a/mainchain-follower/mock/src/lib.rs
+++ b/mainchain-follower/mock/src/lib.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 pub mod block;
 #[cfg(feature = "candidate-source")]
 pub mod candidate;
+#[cfg(feature = "native-token")]
+pub mod native_token;
 
 #[allow(unused)]
 pub(crate) struct UnimplementedMocks;

--- a/mainchain-follower/mock/src/native_token.rs
+++ b/mainchain-follower/mock/src/native_token.rs
@@ -1,0 +1,27 @@
+use async_trait::async_trait;
+pub use main_chain_follower_api::block::*;
+use main_chain_follower_api::native_token::*;
+use main_chain_follower_api::*;
+use sidechain_domain::*;
+
+pub struct NativeTokenDataSourceMock;
+
+impl NativeTokenDataSourceMock {
+	pub fn new() -> Self {
+		Self
+	}
+}
+
+#[async_trait]
+impl NativeTokenManagementDataSource for NativeTokenDataSourceMock {
+	async fn get_token_transfer_events(
+		&self,
+		_after_block: Option<McBlockHash>,
+		_to_block: McBlockHash,
+		_native_token_policy_id: PolicyId,
+		_native_token_asset_name: AssetName,
+		_illiquid_supply_address: MainchainAddress,
+	) -> Result<NativeTokenAmount> {
+		Ok(NativeTokenAmount(1000))
+	}
+}

--- a/mainchain-follower/mock/src/native_token.rs
+++ b/mainchain-follower/mock/src/native_token.rs
@@ -14,7 +14,7 @@ impl NativeTokenDataSourceMock {
 
 #[async_trait]
 impl NativeTokenManagementDataSource for NativeTokenDataSourceMock {
-	async fn get_token_transfer_events(
+	async fn get_total_native_token_transfer(
 		&self,
 		_after_block: Option<McBlockHash>,
 		_to_block: McBlockHash,

--- a/mainchain-follower/mock/src/native_token.rs
+++ b/mainchain-follower/mock/src/native_token.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-pub use main_chain_follower_api::block::*;
 use main_chain_follower_api::native_token::*;
 use main_chain_follower_api::*;
 use sidechain_domain::*;

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -88,8 +88,8 @@ frame-benchmarking-cli = { workspace = true }
 sidechain-runtime = { workspace = true }
 sidechain-mc-hash = { workspace = true, features = ["mock"] }
 main-chain-follower-api = { workspace = true }
-db-sync-follower = { workspace = true, features = ["block-source", "candidate-source"] }
-main-chain-follower-mock = { workspace = true, features = ["block-source", "candidate-source"] }
+db-sync-follower = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }
+main-chain-follower-mock = { workspace = true, features = ["block-source", "candidate-source", "native-token"] }
 tokio = { workspace = true }
 cli-commands = { workspace = true }
 

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -1,10 +1,16 @@
+use db_sync_follower::native_token::NativeTokenManagementDataSourceImpl;
 use db_sync_follower::{
 	block::{BlockDataSourceImpl, DbSyncBlockDataSourceConfig},
 	candidates::{cached::CandidateDataSourceCached, CandidatesDataSourceImpl},
 	metrics::McFollowerMetrics,
 };
-use main_chain_follower_api::{BlockDataSource, CandidateDataSource};
-use main_chain_follower_mock::{block::BlockDataSourceMock, candidate::MockCandidateDataSource};
+use main_chain_follower_api::{
+	BlockDataSource, CandidateDataSource, NativeTokenManagementDataSource,
+};
+use main_chain_follower_mock::{
+	block::BlockDataSourceMock, candidate::MockCandidateDataSource,
+	native_token::NativeTokenDataSourceMock,
+};
 use sc_service::error::Error as ServiceError;
 use std::error::Error;
 use std::sync::Arc;
@@ -13,6 +19,7 @@ use std::sync::Arc;
 pub struct DataSources {
 	pub block: Arc<dyn BlockDataSource + Send + Sync>,
 	pub candidate: Arc<dyn CandidateDataSource + Send + Sync>,
+	pub native_token: Arc<dyn NativeTokenManagementDataSource + Send + Sync>,
 }
 
 pub(crate) async fn create_cached_main_chain_follower_data_sources(
@@ -46,6 +53,7 @@ pub fn create_mock_data_sources(
 	Ok(DataSources {
 		block: Arc::new(BlockDataSourceMock),
 		candidate: Arc::new(MockCandidateDataSource::from_env()?),
+		native_token: Arc::new(NativeTokenDataSourceMock::new()),
 	})
 }
 
@@ -67,5 +75,6 @@ pub async fn create_cached_data_sources(
 			CandidatesDataSourceImpl::from_config(pool.clone(), metrics_opt.clone()).await?,
 			CANDIDATES_FOR_EPOCH_CACHE_SIZE,
 		)?),
+		native_token: Arc::new(NativeTokenManagementDataSourceImpl { pool, metrics_opt }),
 	})
 }

--- a/node/src/tests/mock.rs
+++ b/node/src/tests/mock.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 impl From<TestDataSources> for DataSources {
 	fn from(value: TestDataSources) -> Self {
-		Self { block: value.block, candidate: value.candidate }
+		Self { block: value.block, candidate: value.candidate, native_token: value.native_token }
 	}
 }
 

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -57,6 +57,23 @@ impl StakeDelegation {
 	}
 }
 
+#[derive(
+	Default,
+	Clone,
+	Copy,
+	Debug,
+	Encode,
+	Decode,
+	TypeInfo,
+	ToDatum,
+	PartialEq,
+	Eq,
+	From,
+	MaxEncodedLen,
+)]
+#[cfg_attr(feature = "serde", derive(Serialize))]
+pub struct NativeTokenAmount(pub u64);
+
 /// A main chain block number. In range [0, 2^31-1].
 #[derive(
 	Default,
@@ -162,6 +179,12 @@ const POLICY_ID_LEN: usize = 28;
 #[derive(Clone, Default, PartialEq, Eq, Encode, Decode, ToDatum, TypeInfo, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct PolicyId(pub [u8; POLICY_ID_LEN]);
+
+pub const MAX_ASSET_NAME_LEN: u32 = 32;
+
+#[derive(Clone, Default, PartialEq, Eq, Encode, Decode, ToDatum, TypeInfo, MaxEncodedLen)]
+#[byte_string(debug, hex_serialize, hex_deserialize, decode_hex)]
+pub struct AssetName(pub BoundedVec<u8, ConstU32<MAX_ASSET_NAME_LEN>>);
 
 const MAINCHAIN_PUBLIC_KEY_LEN: usize = 32;
 
@@ -389,7 +412,7 @@ impl TryFrom<Vec<u8>> for McTxHash {
 	}
 }
 
-#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen)]
+#[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct McBlockHash(pub [u8; 32]);
 

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -72,7 +72,7 @@ impl StakeDelegation {
 	MaxEncodedLen,
 )]
 #[cfg_attr(feature = "serde", derive(Serialize))]
-pub struct NativeTokenAmount(pub u64);
+pub struct NativeTokenAmount(pub u128);
 
 /// A main chain block number. In range [0, 2^31-1].
 #[derive(

--- a/utils/byte-string-derivation/src/lib.rs
+++ b/utils/byte-string-derivation/src/lib.rs
@@ -203,6 +203,14 @@ fn gen_from_hex(name: &syn::Ident, ty: &SupportedType, generics: &Generics) -> i
 				Ok(#name(value))
 			}
 		},
+		SupportedType::BoundedVec(ty) => quote! {
+			pub fn decode_hex(s: &str) -> Result<Self, &'static str> {
+				let bytes = sp_core::bytes::from_hex(s).map_err(|_| "Cannot decode bytes from hex string")?;
+				let value = <#ty>::try_from(bytes).map_err(|_| "Invalid length")?;
+				Ok(#name(value))
+			}
+
+		},
 		_ => quote! {
 			pub fn decode_hex(s: &str) -> Result<Self, &'static str> {
 				Ok(#name(sp_core::bytes::from_hex(s).map_err(|_| "Cannot decode bytes from hex string")?))


### PR DESCRIPTION
# Description

Data source that provides observability of native token movement _into_ the illiquid supply on the main chain. There is no metadata attached to the tokens moved, so we ovserve the total sum of tokens that went into the illiquid supply since the last mc-hash referenced by our chain.

I wired the data source in the node in this PR, but it is left unused for now. The next PR is [the inherent data provider](https://github.com/input-output-hk/partner-chains/pull/37). You can see the changes from all the PR together in [this draft PR](https://github.com/input-output-hk/partner-chains/pull/22).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

