### PR TITLE
Add a --fallback flag to nix devshells ci

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -36,7 +36,7 @@ jobs:
         run: echo "${{ secrets.NIX_SIGNING_KEY }}" > "${{ runner.temp }}/nix-key"
       - name: Run nixci to build/test all outputs
         run: |
-          nix run github:srid/nixci -- -v build > /tmp/outputs
+          nix run github:srid/nixci -- -v build -- --fallback > /tmp/outputs
       - name: Copy nix scopes to nix cache
         run: |
           nix-store --stdin -q --deriver < /tmp/outputs | nix-store --stdin -qR --include-outputs \

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,4 +1,4 @@
-name: "nix ci"
+name: "Nix Devshells CI"
 on:
   pull_request:
   push:


### PR DESCRIPTION
# Description
Never let a cache being down or unavailable fail a build

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

