### PR TITLE
change: Add a set_main_chain_scripts extrinsic to validator-management pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5800,6 +5800,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
+ "sidechain-domain",
  "sp-core",
  "sp-io",
  "sp-runtime",

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 `pallet-native-token-management` crates; data sources behind the `native-token` feature in
 `main-chain-follower-api` and `db-sync-follower` crates.
 * added helper functions to `SidechainParams` and all `MainChainScripts` types to read them from environment
+* Extrinsic `set_main_chain_scripts` for migrating to new committee selection main chain scripts
 
 # v1.0.0rc1
 

--- a/pallets/session-validator-management/Cargo.toml
+++ b/pallets/session-validator-management/Cargo.toml
@@ -20,6 +20,7 @@ sp-runtime = { workspace = true }
 sp-core = { workspace = true }
 sp-session-validator-management = { workspace = true }
 sp-io = { workspace = true, optional = true }
+sidechain-domain = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }

--- a/pallets/session-validator-management/src/lib.rs
+++ b/pallets/session-validator-management/src/lib.rs
@@ -21,6 +21,7 @@ pub mod pallet {
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
 	use log::{info, warn};
+	use sidechain_domain::{MainchainAddress, PolicyId};
 	use sp_runtime::traits::{One, Zero};
 	use sp_session_validator_management::*;
 	use sp_std::fmt::Display;
@@ -250,6 +251,27 @@ pub mod pallet {
 				epoch: for_epoch_number,
 				committee: validators,
 			});
+			Ok(())
+		}
+
+		/// Changes the main chain scripts used for committee rotation.
+		///
+		/// This extrinsic must be run either using `sudo` or some other chain governance mechanism.
+		#[pallet::call_index(1)]
+		#[pallet::weight(T::WeightInfo::set(1))]
+		pub fn set_main_chain_scripts(
+			origin: OriginFor<T>,
+			committee_candidate_address: MainchainAddress,
+			d_parameter_policy_id: PolicyId,
+			permissioned_candidates_policy_id: PolicyId,
+		) -> DispatchResult {
+			ensure_root(origin)?;
+			let new_scripts = MainChainScripts {
+				committee_candidate_address,
+				d_parameter_policy_id,
+				permissioned_candidates_policy_id,
+			};
+			MainChainScriptsConfiguration::<T>::put(new_scripts);
 			Ok(())
 		}
 	}


### PR DESCRIPTION
# Description

Just an extrinsic to change the MC addresses for registrations/d-param, so we can easily migrate whenever these change due to PCSC upgrade.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

