### PR TITLE
ETCM-8226 - move custom aura consensus, slots and inherents modifications to partner-chains

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2555,7 +2555,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "42.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2657,9 +2657,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "frame-metadata-hash-extension"
+version = "0.5.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "array-bytes",
+ "docify",
+ "frame-support",
+ "frame-system",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-runtime",
+]
+
+[[package]]
 name = "frame-support"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2700,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.2"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2719,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2731,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2740,8 +2755,8 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+version = "37.1.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2761,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2775,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2785,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -4874,6 +4889,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "merkleized-metadata"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f313fcff1d2a4bcaa2deeaa00bf7530d77d5f7bd0467a117dde2e29a75a7a17a"
+dependencies = [
+ "array-bytes",
+ "blake3",
+ "frame-metadata",
+ "parity-scale-codec",
+ "scale-decode",
+ "scale-info",
+]
+
+[[package]]
 name = "merlin"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5587,7 +5616,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aura"
 version = "36.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5603,7 +5632,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5614,9 +5643,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-babe"
+version = "37.0.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "log",
+ "pallet-authorship",
+ "pallet-session",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-application-crypto",
+ "sp-consensus-babe",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-session",
+ "sp-staking",
+]
+
+[[package]]
 name = "pallet-balances"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5647,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5684,7 +5736,7 @@ dependencies = [
 [[package]]
 name = "pallet-partner-chains-session"
 version = "1.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5703,7 +5755,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5821,7 +5873,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5836,7 +5888,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5855,7 +5907,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5870,7 +5922,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "40.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5886,7 +5938,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -6089,6 +6141,7 @@ dependencies = [
  "sc-executor",
  "sc-network",
  "sc-offchain",
+ "sc-partner-chains-consensus-aura",
  "sc-rpc",
  "sc-rpc-api",
  "sc-service",
@@ -6113,6 +6166,7 @@ dependencies = [
  "sp-io",
  "sp-keyring",
  "sp-native-token-management",
+ "sp-partner-chains-consensus-aura",
  "sp-runtime",
  "sp-session-validator-management",
  "sp-session-validator-management-query",
@@ -7562,7 +7616,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "log",
  "sp-core",
@@ -7573,7 +7627,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7595,7 +7649,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7610,7 +7664,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "docify",
@@ -7637,7 +7691,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7648,7 +7702,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.46.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7689,7 +7743,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "fnv",
  "futures",
@@ -7716,7 +7770,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7742,7 +7796,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -7766,7 +7820,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -7794,8 +7848,8 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.29.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+version = "0.29.1"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -7839,7 +7893,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.29.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -7859,7 +7913,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -7882,7 +7936,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -7905,7 +7959,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -7918,7 +7972,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "log",
  "polkavm",
@@ -7929,7 +7983,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -7947,7 +8001,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "ansi_term",
  "futures",
@@ -7964,7 +8018,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -7978,7 +8032,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -8007,7 +8061,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8058,7 +8112,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8076,7 +8130,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "ahash",
  "futures",
@@ -8095,7 +8149,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8116,7 +8170,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8151,9 +8205,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-network-test"
+version = "0.8.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "async-trait",
+ "futures",
+ "futures-timer",
+ "libp2p",
+ "log",
+ "parking_lot 0.12.3",
+ "rand",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-network",
+ "sc-network-common",
+ "sc-network-light",
+ "sc-network-sync",
+ "sc-network-types",
+ "sc-service",
+ "sc-utils",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "sp-tracing",
+ "substrate-test-runtime",
+ "substrate-test-runtime-client",
+ "tokio",
+]
+
+[[package]]
 name = "sc-network-transactions"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8172,7 +8258,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -8189,7 +8275,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8221,9 +8307,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "sc-partner-chains-consensus-aura"
+version = "1.0.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "log",
+ "parity-scale-codec",
+ "parking_lot 0.12.3",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sc-consensus-aura",
+ "sc-consensus-slots",
+ "sc-keystore",
+ "sc-network",
+ "sc-network-test",
+ "sc-telemetry",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-consensus-aura",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-partner-chains-consensus-aura",
+ "sp-runtime",
+ "sp-timestamp",
+ "sp-tracing",
+ "substrate-test-runtime-client",
+ "tempfile",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8232,7 +8357,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8264,7 +8389,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8284,7 +8409,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "16.0.2"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "forwarded-header-value",
  "futures",
@@ -8306,7 +8431,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8338,7 +8463,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.45.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "directories",
@@ -8402,7 +8527,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8413,7 +8538,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "derive_more",
  "futures",
@@ -8434,7 +8559,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "24.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "chrono",
  "futures",
@@ -8454,7 +8579,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -8484,7 +8609,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -8495,7 +8620,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -8522,7 +8647,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -8538,7 +8663,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-channel",
  "futures",
@@ -8548,6 +8673,29 @@ dependencies = [
  "parking_lot 0.12.3",
  "prometheus",
  "sp-arithmetic",
+]
+
+[[package]]
+name = "scale-bits"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
+dependencies = [
+ "parity-scale-codec",
+ "scale-type-resolver",
+]
+
+[[package]]
+name = "scale-decode"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
+dependencies = [
+ "derive_more",
+ "parity-scale-codec",
+ "scale-bits",
+ "scale-type-resolver",
+ "smallvec",
 ]
 
 [[package]]
@@ -8575,6 +8723,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "scale-type-resolver"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 
 [[package]]
 name = "schannel"
@@ -8817,11 +8971,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -9026,6 +9181,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-slots",
  "sp-inherents",
+ "sp-partner-chains-consensus-aura",
  "sp-runtime",
  "sp-timestamp",
  "thiserror",
@@ -9272,7 +9428,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "hash-db",
@@ -9294,7 +9450,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9308,7 +9464,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9320,7 +9476,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9334,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9356,8 +9512,8 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+version = "37.0.1"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9376,7 +9532,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "futures",
@@ -9391,7 +9547,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9405,9 +9561,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-babe"
+version = "0.40.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-inherents",
+ "sp-runtime",
+ "sp-timestamp",
+]
+
+[[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9424,7 +9598,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9435,7 +9609,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -9481,7 +9655,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9494,7 +9668,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -9504,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -9513,7 +9687,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9523,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9533,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9545,7 +9719,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9558,7 +9732,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "bytes",
  "docify",
@@ -9584,7 +9758,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9594,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9605,7 +9779,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9614,7 +9788,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9624,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9654,7 +9828,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9664,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9686,7 +9860,7 @@ dependencies = [
 [[package]]
 name = "sp-partner-chains-session"
 version = "4.0.0-dev"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "sp-staking",
 ]
@@ -9694,7 +9868,7 @@ dependencies = [
 [[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9704,7 +9878,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "either",
@@ -9730,7 +9904,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9749,7 +9923,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "Inflector",
  "expander",
@@ -9762,7 +9936,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "35.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9836,7 +10010,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -9849,7 +10023,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "hash-db",
  "log",
@@ -9869,7 +10043,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -9893,12 +10067,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9910,7 +10084,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9922,7 +10096,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -9933,7 +10107,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -9942,7 +10116,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9956,7 +10130,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "ahash",
  "hash-db",
@@ -9979,7 +10153,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -9996,7 +10170,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10007,7 +10181,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10019,7 +10193,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10421,7 +10595,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10433,12 +10607,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -10458,7 +10632,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
  "http-body-util",
  "hyper 1.4.1",
@@ -10470,17 +10644,115 @@ dependencies = [
 ]
 
 [[package]]
+name = "substrate-test-client"
+version = "2.0.1"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "array-bytes",
+ "async-trait",
+ "futures",
+ "parity-scale-codec",
+ "sc-client-api",
+ "sc-client-db",
+ "sc-consensus",
+ "sc-executor",
+ "sc-offchain",
+ "sc-service",
+ "serde",
+ "serde_json",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-keyring",
+ "sp-keystore",
+ "sp-runtime",
+ "sp-state-machine",
+ "tokio",
+]
+
+[[package]]
+name = "substrate-test-runtime"
+version = "2.0.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "array-bytes",
+ "frame-executive",
+ "frame-metadata-hash-extension",
+ "frame-support",
+ "frame-system",
+ "frame-system-rpc-runtime-api",
+ "log",
+ "pallet-babe",
+ "pallet-balances",
+ "pallet-timestamp",
+ "parity-scale-codec",
+ "sc-service",
+ "scale-info",
+ "serde_json",
+ "sp-api",
+ "sp-application-crypto",
+ "sp-block-builder",
+ "sp-consensus-aura",
+ "sp-consensus-babe",
+ "sp-consensus-grandpa",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-externalities",
+ "sp-genesis-builder",
+ "sp-inherents",
+ "sp-io",
+ "sp-keyring",
+ "sp-offchain",
+ "sp-runtime",
+ "sp-session",
+ "sp-state-machine",
+ "sp-transaction-pool",
+ "sp-trie",
+ "sp-version",
+ "substrate-wasm-builder",
+ "tracing",
+ "trie-db",
+]
+
+[[package]]
+name = "substrate-test-runtime-client"
+version = "2.0.0"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+dependencies = [
+ "futures",
+ "sc-block-builder",
+ "sc-client-api",
+ "sc-consensus",
+ "sp-api",
+ "sp-blockchain",
+ "sp-consensus",
+ "sp-core",
+ "sp-runtime",
+ "substrate-test-client",
+ "substrate-test-runtime",
+]
+
+[[package]]
 name = "substrate-wasm-builder"
 version = "24.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable2407#09f9af33504a159f8b7c71860032ae577e1b94ff"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
 dependencies = [
+ "array-bytes",
  "build-helper",
  "cargo_metadata",
  "console",
  "filetime",
+ "frame-metadata",
+ "merkleized-metadata",
+ "parity-scale-codec",
  "parity-wasm",
  "polkavm-linker",
+ "sc-executor",
+ "sp-core",
+ "sp-io",
  "sp-maybe-compressed-blob",
+ "sp-tracing",
+ "sp-version",
  "strum 0.26.3",
  "tempfile",
  "toml 0.8.15",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "cli/commands",
 	"cli/node-commands",
+	"client/consensus/aura",
     "node",
 	"pallets/block-rewards",
 	"pallets/sidechain",
@@ -80,7 +81,7 @@ rand = { version = "0.8.5", default-features = false }
 scale-info = { version = "2.5.0", default-features = false, features = ["derive"] }
 secp256k1 = { version = "0.28.2", default-features = false }
 serde = { version = "1.0.188", default-features = false, features = ["derive", "alloc"] }
-serde_json = { version = '1.0.113', default-features = false, features = ['alloc'] }
+serde_json = { version = '1.0.127', default-features = false, features = ['alloc'] }
 syn = "2.0.48"
 tempfile = "3.10.1"
 thiserror = { version = "1.0.30" }
@@ -96,70 +97,79 @@ blake2b_simd = { version = "1.0.2", default-features = false }
 sealed_test = { version = "1.0.0" }
 derive-new = { version = "0.6.0" }
 inquire = { version = "0.7.5" }
+parking_lot = { version = "0.12.1", default-features = false }
 
 # substrate dependencies
-frame-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-benchmarking-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-executive = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-support = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-system-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-frame-try-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-balances = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-sudo = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-pallet-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-basic-authorship = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-client-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-client-db = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-consensus-grandpa-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-executor = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-network = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-rpc-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-service = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-telemetry = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-transaction-pool-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sc-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-blockchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-core = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-crypto-hashing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-inherents = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-io = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-keyring = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-staking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-std = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-version = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-storage = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-weights = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-substrate-build-script-utils = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-substrate-frame-rpc-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-substrate-wasm-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
-sp-genesis-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag = "partnerchains-stable2407" }
+frame-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-benchmarking-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-executive = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-support = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-system-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-try-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-balances = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-sudo = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+pallet-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-basic-authorship = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-client-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-client-db = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-consensus-grandpa-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-executor = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-network = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-network-test = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-rpc-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-service = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-telemetry = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-transaction-pool-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sc-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-application-crypto = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-blockchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-core = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-crypto-hashing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-inherents = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-io = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-keyring = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-tracing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-staking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-std = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-version = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-storage = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-weights = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+substrate-build-script-utils = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+substrate-frame-rpc-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+substrate-test-runtime-client = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+substrate-wasm-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+sp-genesis-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
 
 # local dependencies
 sidechain-runtime = { path = "runtime" }
@@ -194,4 +204,5 @@ sp-sidechain = { path = "primitives/sidechain", default-features = false }
 chain-params = { path = "primitives/chain-params", default-features = false }
 pallet-native-token-management = { path = "pallets/native-token-management", default-features = false }
 sp-native-token-management = { path = "primitives/native-token-management", default-features = false }
+sc-partner-chains-consensus-aura = { path = "client/consensus/aura", default-features = false }
 sp-partner-chains-consensus-aura = { path = "primitives/consensus/aura", default-features = false }

--- a/LICENSE-GPL3-with-classpath-exception
+++ b/LICENSE-GPL3-with-classpath-exception
@@ -1,0 +1,700 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    {one line to give the program's name and a brief idea of what it does.}
+    Copyright (C) {year}  {name of author}
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    {project}  Copyright (C) {year}  {fullname}
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<http://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+
+                     "CLASSPATH" EXCEPTION TO THE GPL
+
+  Linking this library statically or dynamically with other modules is making
+a combined work based on this library. Thus, the terms and conditions of the
+GNU General Public License cover the whole combination.
+
+  As a special exception, the copyright holders of this library give you
+permission to link this library with independent modules to produce an
+executable, regardless of the license terms of these independent modules,
+and to copy and distribute the resulting executable under terms of your
+choice, provided that you also meet, for each linked independent module,
+the terms and conditions of the license of that module. An independent
+module is a module which is not derived from or based on this library.
+If you modify this library, you may extend this exception to your version
+of the library, but you are not obligated to do so. If you do not wish to
+do so, delete this exception statement from your version.
+
+                                NOTE
+
+  Individual files contain the following tag instead of the full license text.
+
+    SPDX-License-Identifier:  GPL-3.0-or-later WITH Classpath-exception-2.0
+
+  This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,10 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 * moved out some cli related code from `node` crate, in order to require less copy-paste in users nodes
 * removed USE_CHAIN_INIT code. Migration strategy is to remove copy-pasted and adapted code. It will not compile with vanilla polkadot-sdk, that we plan to use in future.
+* moved `sc-consensus-aura` from input-output-hk/polkadot-sdk fork to this repository,
+  to `sc-partner-chains-consensus-aura` and `sp-partner-chains-consensus-aura`.
+  This change requires migration of the node, PartnerChainsProposerFactory has to be used.
+  See `service.rs` in `partner-chains-node` crate for an example.
 
 ## Removed
 

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -1,0 +1,50 @@
+[package]
+name = "sc-partner-chains-consensus-aura"
+version = "1.0.0"
+description = "Partner Chains modification to the Substrate Aura consensus engine"
+authors = [ "IOG "]
+homepage = "https://iohk.io/"
+edition = "2021"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+repository = "https://github.com/input-output-hk/partner-chains/"
+readme = "README.md"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+async-trait = { workspace = true }
+parity-scale-codec = { workspace = true, default-features = true }
+futures = { workspace = true }
+log = { workspace = true, default-features = true }
+sc-client-api = { workspace = true, default-features = true }
+sc-consensus = { workspace = true, default-features = true }
+sc-consensus-aura = { workspace = true, default-features = true }
+sc-consensus-slots = { workspace = true, default-features = true }
+sc-telemetry = { workspace = true, default-features = true }
+sp-api = { workspace = true, default-features = true }
+sp-application-crypto = { workspace = true, default-features = true }
+sp-blockchain = { workspace = true, default-features = true }
+sp-block-builder = { workspace = true, default-features = true }
+sp-consensus = { workspace = true, default-features = true }
+sp-consensus-aura = { workspace = true, default-features = true }
+sp-consensus-slots = { workspace = true, default-features = true }
+sp-core = { workspace = true, default-features = true }
+sp-inherents = { workspace = true, default-features = true }
+sp-keystore = { workspace = true, default-features = true }
+sp-runtime = { workspace = true, default-features = true }
+sp-partner-chains-consensus-aura = { workspace = true, default-features = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+parking_lot = { workspace = true, default-features = true }
+tempfile = { workspace = true }
+sc-block-builder = { workspace = true, default-features = true }
+sc-keystore = { workspace = true, default-features = true }
+sc-network = { workspace = true, default-features = true }
+sc-network-test = { workspace = true }
+sp-keyring = { workspace = true, default-features = true }
+sp-timestamp = { workspace = true, default-features = true }
+sp-tracing = { workspace = true, default-features = true }
+substrate-test-runtime-client = { workspace = true }
+tokio = { workspace = true, default-features = true }

--- a/client/consensus/aura/README.md
+++ b/client/consensus/aura/README.md
@@ -1,0 +1,11 @@
+# Partner Chains Aura Workers
+
+This crate is base on the [Substrate Aura Consensus crate](https://github.com/paritytech/polkadot-sdk/tree/polkadot-stable2407/substrate/client/consensus/aura).
+It is customized for Partner Chains needs:
+* during block verification it uses block slot to call Partner Chains InherentDataProvider
+* verifies that the given block header has proper InherentDigest (digest of data from Partner Chains InherentDataProvider).
+
+Please note that it requires usage of custom `Proposer` that comes in `sp-partner-chains-consensus-aura` crate.
+See `service.rs` in the `node` crate to see how to use it.
+
+License: GPL-3.0-or-later WITH Classpath-exception-2.0

--- a/client/consensus/aura/src/import_queue.rs
+++ b/client/consensus/aura/src/import_queue.rs
@@ -1,0 +1,366 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Additional modifications by Input Output Global, Inc.
+// Copyright (C) 2024, Input Output Global, Inc.
+
+//! Module implementing the logic for verifying and importing AuRa blocks.
+
+use crate::{authorities, AuthorityId, LOG_TARGET};
+use log::{debug, info, trace};
+use parity_scale_codec::Codec;
+use sc_client_api::{backend::AuxStore, BlockOf, UsageProvider};
+use sc_consensus::{
+	block_import::{BlockImport, BlockImportParams, ForkChoiceStrategy},
+	import_queue::{BasicQueue, DefaultImportQueue, Verifier},
+};
+use sc_consensus_aura::{
+	standalone::SealVerificationError, CheckForEquivocation, CompatibilityMode, Error,
+	ImportQueueParams,
+};
+use sc_consensus_slots::{check_equivocation, CheckedHeader};
+use sc_telemetry::{telemetry, TelemetryHandle, CONSENSUS_DEBUG, CONSENSUS_TRACE};
+use sp_api::{ApiExt, ProvideRuntimeApi};
+use sp_block_builder::BlockBuilder as BlockBuilderApi;
+use sp_blockchain::HeaderBackend;
+use sp_consensus::Error as ConsensusError;
+use sp_consensus_aura::AuraApi;
+use sp_consensus_slots::Slot;
+use sp_core::crypto::Pair;
+use sp_inherents::{CreateInherentDataProviders, InherentData, InherentDataProvider};
+use sp_partner_chains_consensus_aura::{CurrentSlotProvider, InherentDigest};
+use sp_runtime::{
+	traits::{Block as BlockT, Header, NumberFor},
+	DigestItem,
+};
+use std::{fmt::Debug, marker::PhantomData, sync::Arc};
+
+/// check a header has been signed by the right key. If the slot is too far in the future, an error
+/// will be returned. If it's successful, returns the pre-header and the digest item
+/// containing the seal.
+///
+/// This digest item will always return `Some` when used with `as_aura_seal`.
+fn check_header<C, B: BlockT, P: Pair>(
+	client: &C,
+	slot_now: Slot,
+	header: B::Header,
+	hash: B::Hash,
+	authorities: &[AuthorityId<P>],
+	check_for_equivocation: CheckForEquivocation,
+) -> Result<CheckedHeader<B::Header, (Slot, DigestItem)>, Error<B>>
+where
+	P::Public: Codec,
+	P::Signature: Codec,
+	C: AuxStore,
+{
+	let check_result = sc_consensus_aura::standalone::check_header_slot_and_seal::<B, P>(
+		slot_now,
+		header,
+		authorities,
+	);
+
+	match check_result {
+		Ok((header, slot, seal)) => {
+			let expected_author =
+				sc_consensus_aura::standalone::slot_author::<P>(slot, &authorities);
+			let should_equiv_check = matches!(check_for_equivocation, CheckForEquivocation::Yes);
+			if let (true, Some(expected)) = (should_equiv_check, expected_author) {
+				if let Some(equivocation_proof) =
+					check_equivocation(client, slot_now, slot, &header, expected)
+						.map_err(Error::Client)?
+				{
+					info!(
+						target: LOG_TARGET,
+						"Slot author is equivocating at slot {} with headers {:?} and {:?}",
+						slot,
+						equivocation_proof.first_header.hash(),
+						equivocation_proof.second_header.hash(),
+					);
+				}
+			}
+
+			Ok(CheckedHeader::Checked(header, (slot, seal)))
+		},
+		Err(SealVerificationError::Deferred(header, slot)) => {
+			Ok(CheckedHeader::Deferred(header, slot))
+		},
+		Err(SealVerificationError::Unsealed) => Err(Error::HeaderUnsealed(hash)),
+		Err(SealVerificationError::BadSeal) => Err(Error::HeaderBadSeal(hash)),
+		Err(SealVerificationError::BadSignature) => Err(Error::BadSignature(hash)),
+		Err(SealVerificationError::SlotAuthorNotFound) => Err(Error::SlotAuthorNotFound),
+		Err(SealVerificationError::InvalidPreDigest(e)) => Err(Error::from(e)),
+	}
+}
+
+/// A verifier for Aura blocks, with added ID phantom type.
+pub struct AuraVerifier<C, P, CIDP, N, ID> {
+	client: Arc<C>,
+	create_inherent_data_providers: CIDP,
+	check_for_equivocation: CheckForEquivocation,
+	telemetry: Option<TelemetryHandle>,
+	compatibility_mode: CompatibilityMode<N>,
+	_phantom: PhantomData<(fn() -> P, ID)>,
+}
+
+impl<C, P, CIDP, N, ID> AuraVerifier<C, P, CIDP, N, ID> {
+	pub(crate) fn new(
+		client: Arc<C>,
+		create_inherent_data_providers: CIDP,
+		check_for_equivocation: CheckForEquivocation,
+		telemetry: Option<TelemetryHandle>,
+		compatibility_mode: CompatibilityMode<N>,
+	) -> Self {
+		Self {
+			client,
+			create_inherent_data_providers,
+			check_for_equivocation,
+			telemetry,
+			compatibility_mode,
+			_phantom: PhantomData,
+		}
+	}
+}
+
+impl<C, P, CIDP, N, ID> AuraVerifier<C, P, CIDP, N, ID>
+where
+	CIDP: Send,
+{
+	async fn check_inherents<B: BlockT>(
+		&self,
+		block: B,
+		at_hash: B::Hash,
+		inherent_data_providers: CIDP::InherentDataProviders,
+	) -> Result<(), Error<B>>
+	where
+		C: ProvideRuntimeApi<B>,
+		C::Api: BlockBuilderApi<B>,
+		CIDP: CreateInherentDataProviders<B, (Slot, <ID as InherentDigest>::Value)>,
+		ID: InherentDigest,
+	{
+		let inherent_data = create_inherent_data::<B>(&inherent_data_providers).await?;
+
+		let inherent_res = self
+			.client
+			.runtime_api()
+			.check_inherents(at_hash, block, inherent_data)
+			.map_err(|e| Error::Client(e.into()))?;
+
+		if !inherent_res.ok() {
+			for (i, e) in inherent_res.into_errors() {
+				match inherent_data_providers.try_handle_error(&i, &e).await {
+					Some(res) => res.map_err(Error::Inherent)?,
+					None => return Err(Error::UnknownInherentError(i)),
+				}
+			}
+		}
+
+		Ok(())
+	}
+}
+
+#[async_trait::async_trait]
+impl<B: BlockT, C, P, CIDP, ID> Verifier<B> for AuraVerifier<C, P, CIDP, NumberFor<B>, ID>
+where
+	C: ProvideRuntimeApi<B> + Send + Sync + AuxStore,
+	C::Api: BlockBuilderApi<B> + AuraApi<B, AuthorityId<P>> + ApiExt<B>,
+	P: Pair,
+	P::Public: Codec + Debug,
+	P::Signature: Codec,
+	CIDP: CurrentSlotProvider
+		+ CreateInherentDataProviders<B, (Slot, <ID as InherentDigest>::Value)>
+		+ Send
+		+ Sync,
+	ID: InherentDigest + Send + Sync + 'static,
+{
+	async fn verify(
+		&self,
+		mut block: BlockImportParams<B>,
+	) -> Result<BlockImportParams<B>, String> {
+		// Skip checks that include execution, if being told so or when importing only state.
+		//
+		// This is done for example when gap syncing and it is expected that the block after the gap
+		// was checked/chosen properly, e.g. by warp syncing to this block using a finality proof.
+		// Or when we are importing state only and can not verify the seal.
+		if block.with_state() || block.state_action.skip_execution_checks() {
+			// When we are importing only the state of a block, it will be the best block.
+			block.fork_choice = Some(ForkChoiceStrategy::Custom(block.with_state()));
+
+			return Ok(block);
+		}
+
+		let hash = block.header.hash();
+		let parent_hash = *block.header.parent_hash();
+		let authorities = authorities(
+			self.client.as_ref(),
+			parent_hash,
+			*block.header.number(),
+			&self.compatibility_mode,
+		)
+		.map_err(|e| format!("Could not fetch authorities at {:?}: {}", parent_hash, e))?;
+
+		let slot_now = self.create_inherent_data_providers.slot();
+
+		// we add one to allow for some small drift.
+		// FIXME #1019 in the future, alter this queue to allow deferring of
+		// headers
+		let checked_header = check_header::<C, B, P>(
+			&self.client,
+			slot_now + 1,
+			block.header.clone(),
+			hash,
+			&authorities[..],
+			self.check_for_equivocation,
+		)
+		.map_err(|e| e.to_string())?;
+		let inherent_digest = <ID as InherentDigest>::value_from_digest(
+			block.header.digest().logs(),
+		)
+		.map_err(|e| {
+			format!("Failed to retrieve inherent digest from header at {:?}: {}", parent_hash, e)
+		})?;
+		match checked_header {
+			CheckedHeader::Checked(pre_header, (slot, seal)) => {
+				// if the body is passed through, we need to use the runtime
+				// to check that the internally-set timestamp in the inherents
+				// actually matches the slot set in the seal.
+				if let Some(inner_body) = block.body.take() {
+					let new_block = B::new(pre_header.clone(), inner_body);
+
+					let inherent_data_providers = create_inherent_data_provider(
+						&self.create_inherent_data_providers,
+						parent_hash,
+						(slot, inherent_digest),
+					)
+					.await?;
+
+					// skip the inherents verification if the runtime API is old or not expected to
+					// exist.
+					if self
+						.client
+						.runtime_api()
+						.has_api_with::<dyn BlockBuilderApi<B>, _>(parent_hash, |v| v >= 2)
+						.map_err(|e| e.to_string())?
+					{
+						self.check_inherents(
+							new_block.clone(),
+							parent_hash,
+							inherent_data_providers,
+						)
+						.await
+						.map_err(|e| e.to_string())?;
+					}
+
+					let (_, inner_body) = new_block.deconstruct();
+					block.body = Some(inner_body);
+				}
+
+				trace!(target: LOG_TARGET, "Checked {:?}; importing.", pre_header);
+				telemetry!(
+					self.telemetry;
+					CONSENSUS_TRACE;
+					"aura.checked_and_importing";
+					"pre_header" => ?pre_header,
+				);
+
+				block.header = pre_header;
+				block.post_digests.push(seal);
+				block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+				block.post_hash = Some(hash);
+
+				Ok(block)
+			},
+			CheckedHeader::Deferred(a, b) => {
+				debug!(target: LOG_TARGET, "Checking {:?} failed; {:?}, {:?}.", hash, a, b);
+				telemetry!(
+					self.telemetry;
+					CONSENSUS_DEBUG;
+					"aura.header_too_far_in_future";
+					"hash" => ?hash,
+					"a" => ?a,
+					"b" => ?b,
+				);
+				Err(format!("Header {:?} rejected: too far in the future", hash))
+			},
+		}
+	}
+}
+
+/// Start an import queue for the Aura consensus algorithm.
+pub fn import_queue<P, Block, I, C, S, CIDP, ID>(
+	ImportQueueParams {
+		block_import,
+		justification_import,
+		client,
+		create_inherent_data_providers,
+		spawner,
+		registry,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	}: ImportQueueParams<Block, I, C, S, CIDP>,
+) -> Result<DefaultImportQueue<Block>, sp_consensus::Error>
+where
+	Block: BlockT,
+	C::Api: BlockBuilderApi<Block> + AuraApi<Block, AuthorityId<P>> + ApiExt<Block>,
+	C: 'static
+		+ ProvideRuntimeApi<Block>
+		+ BlockOf
+		+ Send
+		+ Sync
+		+ AuxStore
+		+ UsageProvider<Block>
+		+ HeaderBackend<Block>,
+	I: BlockImport<Block, Error = ConsensusError> + Send + Sync + 'static,
+	P: Pair + 'static,
+	P::Public: Codec + Debug,
+	P::Signature: Codec,
+	S: sp_core::traits::SpawnEssentialNamed,
+	CIDP: CurrentSlotProvider
+		+ CreateInherentDataProviders<Block, (Slot, <ID as InherentDigest>::Value)>
+		+ Sync
+		+ Send
+		+ 'static,
+	ID: InherentDigest + Send + Sync + 'static,
+{
+	let verifier = AuraVerifier::<_, P, _, _, ID>::new(
+		client,
+		create_inherent_data_providers,
+		check_for_equivocation,
+		telemetry,
+		compatibility_mode,
+	);
+
+	Ok(BasicQueue::new(verifier, Box::new(block_import), justification_import, spawner, registry))
+}
+
+async fn create_inherent_data_provider<CIDP, B: BlockT, ExtraArg>(
+	cidp: &CIDP,
+	hash: B::Hash,
+	extra_arg: ExtraArg,
+) -> Result<CIDP::InherentDataProviders, String>
+where
+	CIDP: CreateInherentDataProviders<B, ExtraArg>,
+{
+	cidp.create_inherent_data_providers(hash, extra_arg)
+		.await
+		.map_err(|e| Error::<B>::Client(sp_blockchain::Error::Application(e)).into())
+}
+
+async fn create_inherent_data<B: BlockT>(
+	provider: &impl InherentDataProvider,
+) -> Result<InherentData, Error<B>> {
+	Ok(provider.create_inherent_data().await.map_err(Error::<B>::Inherent)?)
+}

--- a/client/consensus/aura/src/lib.rs
+++ b/client/consensus/aura/src/lib.rs
@@ -1,0 +1,715 @@
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+// Additional modifications by Input Output Global, Inc.
+// Copyright (C) 2024, Input Output Global, Inc.
+
+pub mod import_queue;
+
+use futures::prelude::*;
+use parity_scale_codec::Codec;
+use sc_client_api::{backend::AuxStore, BlockOf};
+use sc_consensus::block_import::BlockImport;
+use sc_consensus::{BlockImportParams, ForkChoiceStrategy, StateAction};
+use sc_consensus_aura::{
+	find_pre_digest, BuildAuraWorkerParams, CompatibilityMode, StartAuraParams,
+};
+use sc_consensus_slots::{
+	BackoffAuthoringBlocksStrategy, InherentDataProviderExt, SimpleSlotWorkerToSlotWorker,
+	SlotInfo, SlotProportion, StorageChanges,
+};
+use sc_telemetry::TelemetryHandle;
+use sp_api::{Core, ProvideRuntimeApi};
+use sp_application_crypto::AppPublic;
+use sp_blockchain::HeaderBackend;
+use sp_consensus::{
+	BlockOrigin, Environment, Error as ConsensusError, Proposer, SelectChain, SyncOracle,
+};
+use sp_consensus_aura::AuraApi;
+use sp_consensus_slots::Slot;
+use sp_core::crypto::Pair;
+use sp_inherents::CreateInherentDataProviders;
+use sp_keystore::KeystorePtr;
+use sp_partner_chains_consensus_aura::InherentDigest;
+use sp_runtime::traits::{Block as BlockT, Header, Member, NumberFor};
+use std::{fmt::Debug, marker::PhantomData, pin::Pin, sync::Arc};
+
+type AuthorityId<P> = <P as Pair>::Public;
+
+const LOG_TARGET: &str = "aura";
+
+/// Start the aura worker. The returned future should be run in a futures executor.
+pub fn start_aura<P, B, C, SC, I, PF, SO, L, CIDP, BS, Error, ID>(
+	StartAuraParams {
+		slot_duration,
+		client,
+		select_chain,
+		block_import,
+		proposer_factory,
+		sync_oracle,
+		justification_sync_link,
+		create_inherent_data_providers,
+		force_authoring,
+		backoff_authoring_blocks,
+		keystore,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		telemetry,
+		compatibility_mode,
+	}: StartAuraParams<C, SC, I, PF, SO, L, CIDP, BS, NumberFor<B>>,
+) -> Result<impl Future<Output = ()>, ConsensusError>
+where
+	P: Pair,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	SC: SelectChain<B>,
+	I: BlockImport<B> + Send + Sync + 'static,
+	PF: Environment<B, Error = Error> + Send + Sync + 'static,
+	PF::Proposer: Proposer<B, Error = Error>,
+	SO: SyncOracle + Send + Sync + Clone,
+	L: sc_consensus::JustificationSyncLink<B>,
+	CIDP: CreateInherentDataProviders<B, ()> + Send + 'static,
+	CIDP::InherentDataProviders: InherentDataProviderExt + Send,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+	Error: std::error::Error + Send + From<ConsensusError> + 'static,
+	ID: InherentDigest + Send + Sync + 'static,
+{
+	let worker = build_aura_worker::<P, _, _, _, _, _, _, _, _, ID>(BuildAuraWorkerParams {
+		client,
+		block_import,
+		proposer_factory,
+		keystore,
+		sync_oracle: sync_oracle.clone(),
+		justification_sync_link,
+		force_authoring,
+		backoff_authoring_blocks,
+		telemetry,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		compatibility_mode,
+	});
+
+	Ok(sc_consensus_slots::start_slot_worker(
+		slot_duration,
+		select_chain,
+		SimpleSlotWorkerToSlotWorker(worker),
+		sync_oracle,
+		create_inherent_data_providers,
+	))
+}
+
+/// Build the aura worker.
+///
+/// The caller is responsible for running this worker, otherwise it will do nothing.
+pub fn build_aura_worker<P, B, C, PF, I, SO, L, BS, Error, ID>(
+	BuildAuraWorkerParams {
+		client,
+		block_import,
+		proposer_factory,
+		sync_oracle,
+		justification_sync_link,
+		backoff_authoring_blocks,
+		keystore,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		telemetry,
+		force_authoring,
+		compatibility_mode,
+	}: BuildAuraWorkerParams<C, I, PF, SO, L, BS, NumberFor<B>>,
+) -> impl sc_consensus_slots::SimpleSlotWorker<
+	B,
+	Proposer = PF::Proposer,
+	BlockImport = I,
+	SyncOracle = SO,
+	JustificationSyncLink = L,
+	Claim = P::Public,
+	AuxData = Vec<AuthorityId<P>>,
+>
+where
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + AuxStore + HeaderBackend<B> + Send + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	PF: Environment<B, Error = Error> + Send + Sync + 'static,
+	PF::Proposer: Proposer<B, Error = Error>,
+	P: Pair,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
+	I: BlockImport<B> + Send + Sync + 'static,
+	Error: std::error::Error + Send + From<ConsensusError> + 'static,
+	SO: SyncOracle + Send + Sync + Clone,
+	L: sc_consensus::JustificationSyncLink<B>,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+	ID: InherentDigest + Send + Sync + 'static,
+{
+	AuraWorker {
+		client,
+		block_import,
+		env: proposer_factory,
+		keystore,
+		sync_oracle,
+		justification_sync_link,
+		force_authoring,
+		backoff_authoring_blocks,
+		telemetry,
+		block_proposal_slot_portion,
+		max_block_proposal_slot_portion,
+		compatibility_mode,
+		_phantom: PhantomData::<(fn() -> P, ID)>,
+	}
+}
+
+struct AuraWorker<C, E, I, P, SO, L, BS, N, ID> {
+	client: Arc<C>,
+	block_import: I,
+	env: E,
+	keystore: KeystorePtr,
+	sync_oracle: SO,
+	justification_sync_link: L,
+	force_authoring: bool,
+	backoff_authoring_blocks: Option<BS>,
+	block_proposal_slot_portion: SlotProportion,
+	max_block_proposal_slot_portion: Option<SlotProportion>,
+	telemetry: Option<TelemetryHandle>,
+	compatibility_mode: CompatibilityMode<N>,
+	_phantom: PhantomData<(fn() -> P, ID)>,
+}
+
+#[async_trait::async_trait]
+impl<B, C, E, I, P, Error, SO, L, BS, ID> sc_consensus_slots::SimpleSlotWorker<B>
+	for AuraWorker<C, E, I, P, SO, L, BS, NumberFor<B>, ID>
+where
+	B: BlockT,
+	C: ProvideRuntimeApi<B> + BlockOf + HeaderBackend<B> + Sync,
+	C::Api: AuraApi<B, AuthorityId<P>>,
+	E: Environment<B, Error = Error> + Send + Sync,
+	E::Proposer: Proposer<B, Error = Error>,
+	I: BlockImport<B> + Send + Sync + 'static,
+	P: Pair,
+	P::Public: AppPublic + Member,
+	P::Signature: TryFrom<Vec<u8>> + Member + Codec,
+	SO: SyncOracle + Send + Clone + Sync,
+	L: sc_consensus::JustificationSyncLink<B>,
+	BS: BackoffAuthoringBlocksStrategy<NumberFor<B>> + Send + Sync + 'static,
+	Error: std::error::Error + Send + From<ConsensusError> + 'static,
+	ID: InherentDigest + Send + Sync + 'static,
+{
+	type BlockImport = I;
+	type SyncOracle = SO;
+	type JustificationSyncLink = L;
+	type CreateProposer =
+		Pin<Box<dyn Future<Output = Result<E::Proposer, ConsensusError>> + Send + 'static>>;
+	type Proposer = E::Proposer;
+	type Claim = P::Public;
+	type AuxData = Vec<AuthorityId<P>>;
+
+	fn logging_target(&self) -> &'static str {
+		"aura"
+	}
+
+	fn block_import(&mut self) -> &mut Self::BlockImport {
+		&mut self.block_import
+	}
+
+	fn aux_data(&self, header: &B::Header, _slot: Slot) -> Result<Self::AuxData, ConsensusError> {
+		authorities(
+			self.client.as_ref(),
+			header.hash(),
+			*header.number() + 1u32.into(),
+			&self.compatibility_mode,
+		)
+	}
+
+	fn authorities_len(&self, authorities: &Self::AuxData) -> Option<usize> {
+		Some(authorities.len())
+	}
+
+	async fn claim_slot(
+		&mut self,
+		_header: &B::Header,
+		slot: Slot,
+		authorities: &Self::AuxData,
+	) -> Option<Self::Claim> {
+		sc_consensus_aura::standalone::claim_slot::<P>(slot, authorities, &self.keystore).await
+	}
+
+	fn pre_digest_data(&self, slot: Slot, _claim: &Self::Claim) -> Vec<sp_runtime::DigestItem> {
+		vec![sc_consensus_aura::standalone::pre_digest::<P>(slot)]
+	}
+
+	async fn block_import_params(
+		&self,
+		header: B::Header,
+		header_hash: &B::Hash,
+		body: Vec<B::Extrinsic>,
+		storage_changes: StorageChanges<B>,
+		public: Self::Claim,
+		_authorities: Self::AuxData,
+	) -> Result<BlockImportParams<B>, ConsensusError> {
+		let signature_digest_item =
+			sc_consensus_aura::standalone::seal::<_, P>(header_hash, &public, &self.keystore)?;
+
+		let mut import_block = BlockImportParams::new(BlockOrigin::Own, header);
+		import_block.post_digests.push(signature_digest_item);
+		import_block.body = Some(body);
+		import_block.state_action =
+			StateAction::ApplyChanges(sc_consensus::StorageChanges::Changes(storage_changes));
+		import_block.fork_choice = Some(ForkChoiceStrategy::LongestChain);
+
+		Ok(import_block)
+	}
+
+	fn force_authoring(&self) -> bool {
+		self.force_authoring
+	}
+
+	fn should_backoff(&self, slot: Slot, chain_head: &B::Header) -> bool {
+		if let Some(ref strategy) = self.backoff_authoring_blocks {
+			if let Ok(chain_head_slot) = find_pre_digest::<B, P::Signature>(chain_head) {
+				return strategy.should_backoff(
+					*chain_head.number(),
+					chain_head_slot,
+					self.client.info().finalized_number,
+					slot,
+					self.logging_target(),
+				);
+			}
+		}
+		false
+	}
+
+	fn sync_oracle(&mut self) -> &mut Self::SyncOracle {
+		&mut self.sync_oracle
+	}
+
+	fn justification_sync_link(&mut self) -> &mut Self::JustificationSyncLink {
+		&mut self.justification_sync_link
+	}
+
+	fn proposer(&mut self, block: &B::Header) -> Self::CreateProposer {
+		self.env
+			.init(block)
+			.map_err(|e| ConsensusError::ClientImport(format!("{:?}", e)))
+			.boxed()
+	}
+
+	fn telemetry(&self) -> Option<TelemetryHandle> {
+		self.telemetry.clone()
+	}
+
+	fn proposing_remaining_duration(&self, slot_info: &SlotInfo<B>) -> std::time::Duration {
+		let parent_slot = find_pre_digest::<B, P::Signature>(&slot_info.chain_head).ok();
+
+		sc_consensus_slots::proposing_remaining_duration(
+			parent_slot,
+			slot_info,
+			&self.block_proposal_slot_portion,
+			self.max_block_proposal_slot_portion.as_ref(),
+			sc_consensus_slots::SlotLenienceType::Exponential,
+			self.logging_target(),
+		)
+	}
+}
+
+fn authorities<A, B, C>(
+	client: &C,
+	parent_hash: B::Hash,
+	context_block_number: NumberFor<B>,
+	compatibility_mode: &CompatibilityMode<NumberFor<B>>,
+) -> Result<Vec<A>, ConsensusError>
+where
+	A: Codec + Debug,
+	B: BlockT,
+	C: ProvideRuntimeApi<B>,
+	C::Api: AuraApi<B, A>,
+{
+	let runtime_api = client.runtime_api();
+
+	match compatibility_mode {
+		CompatibilityMode::None => {},
+		// Use `initialize_block` until we hit the block that should disable the mode.
+		CompatibilityMode::UseInitializeBlock { until } => {
+			if *until > context_block_number {
+				runtime_api
+					.initialize_block(
+						parent_hash,
+						&B::Header::new(
+							context_block_number,
+							Default::default(),
+							Default::default(),
+							parent_hash,
+							Default::default(),
+						),
+					)
+					.map_err(|_| ConsensusError::InvalidAuthoritiesSet)?;
+			}
+		},
+	}
+
+	runtime_api
+		.authorities(parent_hash)
+		.ok()
+		.ok_or(ConsensusError::InvalidAuthoritiesSet)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use parking_lot::Mutex;
+	use sc_block_builder::BlockBuilderBuilder;
+	use sc_client_api::BlockchainEvents;
+	use sc_consensus::BoxJustificationImport;
+	use sc_consensus_aura::{standalone::slot_duration, CheckForEquivocation};
+	use sc_consensus_slots::{BackoffAuthoringOnFinalizedHeadLagging, SimpleSlotWorker};
+	use sc_keystore::LocalKeystore;
+	use sc_network_test::{Block as TestBlock, *};
+	use sp_application_crypto::{key_types::AURA, AppCrypto};
+	use sp_consensus::{DisableProofRecording, NoNetwork as DummyOracle, Proposal};
+	use sp_consensus_aura::inherents::InherentDataProvider;
+	use sp_consensus_aura::sr25519::AuthorityPair;
+	use sp_consensus_aura::SlotDuration;
+	use sp_inherents::InherentData;
+	use sp_keyring::sr25519::Keyring;
+	use sp_keystore::Keystore;
+	use sp_partner_chains_consensus_aura::CurrentSlotProvider;
+	use sp_runtime::{
+		traits::{Block as BlockT, Header as _},
+		Digest,
+	};
+	use sp_timestamp::Timestamp;
+	use std::{
+		task::Poll,
+		time::{Duration, Instant},
+	};
+	use substrate_test_runtime_client::{
+		runtime::{Header, H256},
+		TestClient,
+	};
+
+	const SLOT_DURATION_MS: u64 = 1000;
+
+	type Error = sp_blockchain::Error;
+
+	struct DummyFactory(Arc<TestClient>);
+	struct DummyProposer(Arc<TestClient>);
+
+	impl Environment<TestBlock> for DummyFactory {
+		type Proposer = DummyProposer;
+		type CreateProposer = futures::future::Ready<Result<DummyProposer, Error>>;
+		type Error = Error;
+
+		fn init(&mut self, _: &<TestBlock as BlockT>::Header) -> Self::CreateProposer {
+			futures::future::ready(Ok(DummyProposer(self.0.clone())))
+		}
+	}
+
+	impl Proposer<TestBlock> for DummyProposer {
+		type Error = Error;
+		type Proposal = future::Ready<Result<Proposal<TestBlock, ()>, Error>>;
+		type ProofRecording = DisableProofRecording;
+		type Proof = ();
+
+		fn propose(
+			self,
+			_: InherentData,
+			digests: Digest,
+			_: Duration,
+			_: Option<usize>,
+		) -> Self::Proposal {
+			let r = BlockBuilderBuilder::new(&*self.0)
+				.on_parent_block(self.0.chain_info().best_hash)
+				.fetch_parent_block_number(&*self.0)
+				.unwrap()
+				.with_inherent_digests(digests)
+				.build()
+				.unwrap()
+				.build();
+
+			future::ready(r.map(|b| Proposal {
+				block: b.block,
+				proof: (),
+				storage_changes: b.storage_changes,
+			}))
+		}
+	}
+
+	type AuraVerifier =
+		import_queue::AuraVerifier<PeersFullClient, AuthorityPair, TestCIDP, u64, ()>;
+	type AuraPeer = Peer<(), PeersClient>;
+
+	#[derive(Default)]
+	pub struct AuraTestNet {
+		peers: Vec<AuraPeer>,
+	}
+
+	pub struct TestCIDP;
+
+	#[async_trait::async_trait]
+	impl CreateInherentDataProviders<Block, (Slot, ())> for TestCIDP {
+		type InherentDataProviders = ();
+
+		async fn create_inherent_data_providers(
+			&self,
+			_parent: <Block as BlockT>::Hash,
+			_extra_args: (Slot, ()),
+		) -> Result<Self::InherentDataProviders, Box<dyn std::error::Error + Send + Sync>> {
+			Ok(())
+		}
+	}
+
+	impl CurrentSlotProvider for TestCIDP {
+		fn slot(&self) -> Slot {
+			Slot::from_timestamp(Timestamp::current(), SlotDuration::from_millis(SLOT_DURATION_MS))
+		}
+	}
+
+	impl TestNetFactory for AuraTestNet {
+		type Verifier = AuraVerifier;
+		type PeerData = ();
+		type BlockImport = PeersClient;
+
+		fn make_verifier(&self, client: PeersClient, _peer_data: &()) -> Self::Verifier {
+			let client = client.as_client();
+			let slot_duration = slot_duration(&*client).expect("slot duration available");
+
+			assert_eq!(slot_duration.as_millis() as u64, SLOT_DURATION_MS);
+			AuraVerifier::new(
+				client,
+				TestCIDP,
+				CheckForEquivocation::Yes,
+				None,
+				CompatibilityMode::None,
+			)
+		}
+
+		fn make_block_import(
+			&self,
+			client: PeersClient,
+		) -> (
+			BlockImportAdapter<Self::BlockImport>,
+			Option<BoxJustificationImport<Block>>,
+			Self::PeerData,
+		) {
+			(client.as_block_import(), None, ())
+		}
+
+		fn peer(&mut self, i: usize) -> &mut AuraPeer {
+			&mut self.peers[i]
+		}
+
+		fn peers(&self) -> &Vec<AuraPeer> {
+			&self.peers
+		}
+
+		fn peers_mut(&mut self) -> &mut Vec<AuraPeer> {
+			&mut self.peers
+		}
+
+		fn mut_peers<F: FnOnce(&mut Vec<AuraPeer>)>(&mut self, closure: F) {
+			closure(&mut self.peers);
+		}
+	}
+
+	#[tokio::test]
+	async fn authoring_blocks() {
+		sp_tracing::try_init_simple();
+		let net = AuraTestNet::new(3);
+
+		let peers = &[(0, Keyring::Alice), (1, Keyring::Bob), (2, Keyring::Charlie)];
+
+		let net = Arc::new(Mutex::new(net));
+		let mut import_notifications = Vec::new();
+		let mut aura_futures = Vec::new();
+
+		let mut keystore_paths = Vec::new();
+		for (peer_id, key) in peers {
+			let mut net = net.lock();
+			let peer = net.peer(*peer_id);
+			let client = peer.client().as_client();
+			let select_chain = peer.select_chain().expect("full client has a select chain");
+			let keystore_path = tempfile::tempdir().expect("Creates keystore path");
+			let keystore = Arc::new(
+				LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore."),
+			);
+
+			keystore
+				.sr25519_generate_new(AURA, Some(&key.to_seed()))
+				.expect("Creates authority key");
+			keystore_paths.push(keystore_path);
+
+			let environ = DummyFactory(client.clone());
+			import_notifications.push(
+				client
+					.import_notification_stream()
+					.take_while(|n| {
+						future::ready(!(n.origin != BlockOrigin::Own && n.header.number() < &5))
+					})
+					.for_each(move |_| future::ready(())),
+			);
+
+			let slot_duration = slot_duration(&*client).expect("slot duration available");
+
+			aura_futures.push(
+				start_aura::<AuthorityPair, _, _, _, _, _, _, _, _, _, _, ()>(StartAuraParams {
+					slot_duration,
+					block_import: client.clone(),
+					select_chain,
+					client,
+					proposer_factory: environ,
+					sync_oracle: DummyOracle,
+					justification_sync_link: (),
+					create_inherent_data_providers: |_, _| async {
+						let slot = InherentDataProvider::from_timestamp_and_slot_duration(
+							Timestamp::current(),
+							SlotDuration::from_millis(SLOT_DURATION_MS),
+						);
+
+						Ok((slot,))
+					},
+					force_authoring: false,
+					backoff_authoring_blocks: Some(
+						BackoffAuthoringOnFinalizedHeadLagging::default(),
+					),
+					keystore,
+					block_proposal_slot_portion: SlotProportion::new(0.5),
+					max_block_proposal_slot_portion: None,
+					telemetry: None,
+					compatibility_mode: CompatibilityMode::None,
+				})
+				.expect("Starts aura"),
+			);
+		}
+
+		future::select(
+			future::poll_fn(move |cx| {
+				net.lock().poll(cx);
+				Poll::<()>::Pending
+			}),
+			future::select(future::join_all(aura_futures), future::join_all(import_notifications)),
+		)
+		.await;
+	}
+
+	#[tokio::test]
+	async fn current_node_authority_should_claim_slot() {
+		let net = AuraTestNet::new(4);
+
+		let mut authorities = vec![
+			Keyring::Alice.public().into(),
+			Keyring::Bob.public().into(),
+			Keyring::Charlie.public().into(),
+		];
+
+		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
+		let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
+		let public = keystore
+			.sr25519_generate_new(AuthorityPair::ID, None)
+			.expect("Key should be created");
+		authorities.push(public.into());
+
+		let net = Arc::new(Mutex::new(net));
+
+		let mut net = net.lock();
+		let peer = net.peer(3);
+		let client = peer.client().as_client();
+		let environ = DummyFactory(client.clone());
+
+		let mut worker = AuraWorker {
+			client: client.clone(),
+			block_import: client,
+			env: environ,
+			keystore: keystore.into(),
+			sync_oracle: DummyOracle,
+			justification_sync_link: (),
+			force_authoring: false,
+			backoff_authoring_blocks: Some(BackoffAuthoringOnFinalizedHeadLagging::default()),
+			telemetry: None,
+			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
+			compatibility_mode: Default::default(),
+			_phantom: PhantomData::<(fn() -> AuthorityPair, ())>,
+		};
+
+		let head = Header::new(
+			1,
+			H256::from_low_u64_be(0),
+			H256::from_low_u64_be(0),
+			Default::default(),
+			Default::default(),
+		);
+		assert!(worker.claim_slot(&head, 0.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 1.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 2.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 3.into(), &authorities).await.is_some());
+		assert!(worker.claim_slot(&head, 4.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 5.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 6.into(), &authorities).await.is_none());
+		assert!(worker.claim_slot(&head, 7.into(), &authorities).await.is_some());
+	}
+
+	#[tokio::test]
+	async fn on_slot_returns_correct_block() {
+		let net = AuraTestNet::new(4);
+
+		let keystore_path = tempfile::tempdir().expect("Creates keystore path");
+		let keystore = LocalKeystore::open(keystore_path.path(), None).expect("Creates keystore.");
+		keystore
+			.sr25519_generate_new(AuthorityPair::ID, Some(&Keyring::Alice.to_seed()))
+			.expect("Key should be created");
+
+		let net = Arc::new(Mutex::new(net));
+
+		let mut net = net.lock();
+		let peer = net.peer(3);
+		let client = peer.client().as_client();
+		let environ = DummyFactory(client.clone());
+
+		let mut worker = AuraWorker {
+			client: client.clone(),
+			block_import: client.clone(),
+			env: environ,
+			keystore: keystore.into(),
+			sync_oracle: DummyOracle,
+			justification_sync_link: (),
+			force_authoring: false,
+			backoff_authoring_blocks: Option::<()>::None,
+			telemetry: None,
+			block_proposal_slot_portion: SlotProportion::new(0.5),
+			max_block_proposal_slot_portion: None,
+			compatibility_mode: Default::default(),
+			_phantom: PhantomData::<(fn() -> AuthorityPair, ())>,
+		};
+
+		let head = client.expect_header(client.info().genesis_hash).unwrap();
+
+		let res = worker
+			.on_slot(SlotInfo {
+				slot: 0.into(),
+				ends_at: Instant::now() + Duration::from_secs(100),
+				create_inherent_data: Box::new(()),
+				duration: Duration::from_millis(1000),
+				chain_head: head,
+				block_size_limit: None,
+			})
+			.await
+			.unwrap();
+
+		// The returned block should be imported and we should be able to get its header by now.
+		assert!(client.header(res.block.hash()).unwrap().is_some());
+	}
+}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -32,7 +32,9 @@ sc-transaction-pool = { workspace = true }
 sc-transaction-pool-api = { workspace = true }
 sc-offchain = { workspace = true }
 sc-consensus-aura = { workspace = true }
+sc-partner-chains-consensus-aura = { workspace = true }
 sp-consensus-aura = { workspace = true }
+sp-partner-chains-consensus-aura = { workspace = true }
 sp-consensus = { workspace = true }
 sc-consensus = { workspace = true }
 sc-consensus-grandpa = { workspace = true }

--- a/node/src/inherent_data.rs
+++ b/node/src/inherent_data.rs
@@ -4,7 +4,7 @@ use authority_selection_inherents::authority_selection_inputs::AuthoritySelectio
 use derive_new::new;
 use epoch_derivation::EpochConfig;
 use jsonrpsee::core::async_trait;
-use sc_consensus_aura::{find_pre_digest, standalone::CurrentSlotProvider, SlotDuration};
+use sc_consensus_aura::{find_pre_digest, SlotDuration};
 use sc_service::Arc;
 use sidechain_domain::{McBlockHash, ScEpochNumber};
 use sidechain_mc_hash::McHashInherentDataProvider as McHashIDP;
@@ -24,6 +24,7 @@ use sp_inherents::CreateInherentDataProviders;
 use sp_native_token_management::{
 	NativeTokenManagementApi, NativeTokenManagementInherentDataProvider as NativeTokenIDP,
 };
+use sp_partner_chains_consensus_aura::CurrentSlotProvider;
 use sp_runtime::traits::{Block as BlockT, Header, Zero};
 use sp_session_validator_management::SessionValidatorManagementApi;
 use sp_timestamp::{InherentDataProvider as TimestampIDP, Timestamp};

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -11,12 +11,14 @@ use sc_client_api::{Backend, BlockBackend};
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};
 use sc_consensus_grandpa::SharedVoterState;
 pub use sc_executor::WasmExecutor;
+use sc_partner_chains_consensus_aura::import_queue as partner_chains_aura_import_queue;
 use sc_service::{error::Error as ServiceError, Configuration, TaskManager, WarpSyncParams};
 use sc_telemetry::{Telemetry, TelemetryWorker};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
 use sidechain_mc_hash::McHashInherentDigest;
 use sidechain_runtime::{self, opaque::Block, RuntimeApi};
 use sp_consensus_aura::sr25519::AuthorityPair as AuraPair;
+use sp_partner_chains_consensus_aura::block_proposal::PartnerChainsProposerFactory;
 use sp_runtime::traits::Block as BlockT;
 use std::{sync::Arc, time::Duration};
 use time_source::SystemTimeSource;
@@ -120,24 +122,29 @@ pub async fn new_partial(
 	let epoch_config = EpochConfig::read().map_err(|err| ServiceError::Application(err.into()))?;
 	let inherent_config = CreateInherentDataConfig::new(epoch_config, sc_slot_config, time_source);
 
-	let import_queue =
-		sc_consensus_aura::import_queue::<AuraPair, _, _, _, _, _, McHashInherentDigest>(
-			ImportQueueParams {
-				block_import: grandpa_block_import.clone(),
-				justification_import: Some(Box::new(grandpa_block_import.clone())),
-				client: client.clone(),
-				create_inherent_data_providers: VerifierCIDP::new(
-					inherent_config,
-					client.clone(),
-					data_sources.clone(),
-				),
-				spawner: &task_manager.spawn_essential_handle(),
-				registry: config.prometheus_registry(),
-				check_for_equivocation: Default::default(),
-				telemetry: telemetry.as_ref().map(|x| x.handle()),
-				compatibility_mode: Default::default(),
-			},
-		)?;
+	let import_queue = partner_chains_aura_import_queue::import_queue::<
+		AuraPair,
+		_,
+		_,
+		_,
+		_,
+		_,
+		McHashInherentDigest,
+	>(ImportQueueParams {
+		block_import: grandpa_block_import.clone(),
+		justification_import: Some(Box::new(grandpa_block_import.clone())),
+		client: client.clone(),
+		create_inherent_data_providers: VerifierCIDP::new(
+			inherent_config,
+			client.clone(),
+			data_sources.clone(),
+		),
+		spawner: &task_manager.spawn_essential_handle(),
+		registry: config.prometheus_registry(),
+		check_for_equivocation: Default::default(),
+		telemetry: telemetry.as_ref().map(|x| x.handle()),
+		compatibility_mode: Default::default(),
+	})?;
 
 	Ok(sc_service::PartialComponents {
 		client,
@@ -289,13 +296,15 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 	})?;
 
 	if role.is_authority() {
-		let proposer_factory = sc_basic_authorship::ProposerFactory::new(
+		let basic_authorship_proposer_factory = sc_basic_authorship::ProposerFactory::new(
 			task_manager.spawn_handle(),
 			client.clone(),
 			transaction_pool.clone(),
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|x| x.handle()),
 		);
+		let proposer_factory: PartnerChainsProposerFactory<_, _, McHashInherentDigest> =
+			PartnerChainsProposerFactory::new(basic_authorship_proposer_factory);
 
 		let sc_slot_config = sidechain_slots::runtime_api_client::slot_config(&*client)
 			.map_err(sp_blockchain::Error::from)?;
@@ -304,7 +313,7 @@ pub async fn new_full<Network: sc_network::NetworkBackend<Block, <Block as Block
 			EpochConfig::read().map_err(|err| ServiceError::Application(err.into()))?;
 		let inherent_config =
 			CreateInherentDataConfig::new(epoch_config, sc_slot_config.clone(), time_source);
-		let aura = sc_consensus_aura::start_aura::<
+		let aura = sc_partner_chains_consensus_aura::start_aura::<
 			AuraPair,
 			_,
 			_,

--- a/primitives/sidechain-mc-hash/Cargo.toml
+++ b/primitives/sidechain-mc-hash/Cargo.toml
@@ -7,7 +7,8 @@ description = "Logic for putting a main chain block reference in digest and inhe
 [dependencies]
 async-trait = { workspace = true }
 main-chain-follower-api = { workspace = true, features = ["block-source"] }
-sp-consensus-slots = { workspace = true, features = ["std"] }
+sp-consensus-slots = { workspace = true }
+sp-partner-chains-consensus-aura = { workspace = true, features = ["std"] }
 sidechain-domain = { workspace = true, features = ["std"] }
 sp-consensus = { workspace = true }
 sp-blockchain = { workspace = true }

--- a/primitives/sidechain-mc-hash/src/lib.rs
+++ b/primitives/sidechain-mc-hash/src/lib.rs
@@ -5,7 +5,8 @@ use main_chain_follower_api::{
 use sidechain_domain::{byte_string::ByteString, McBlockHash, McBlockNumber, McEpochNumber};
 use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::{Slot, SlotDuration};
-use sp_inherents::{InherentData, InherentDataProvider, InherentDigest, InherentIdentifier};
+use sp_inherents::{InherentData, InherentDataProvider, InherentIdentifier};
+use sp_partner_chains_consensus_aura::inherent_digest::InherentDigest;
 use sp_runtime::{
 	traits::{Block as BlockT, Header as HeaderT, Zero},
 	DigestItem,

--- a/primitives/sidechain-mc-hash/src/test.rs
+++ b/primitives/sidechain-mc-hash/src/test.rs
@@ -1,7 +1,7 @@
 mod inherent_digest_tests {
 	use crate::mock::*;
 	use crate::*;
-	use sp_inherents::InherentDigest;
+	use sp_partner_chains_consensus_aura::inherent_digest::InherentDigest;
 
 	#[tokio::test]
 	async fn from_inherent_data_works() {


### PR DESCRIPTION
# Description

Moves PC modifications of sc-consensus-aura to this repo, in order to eventually get rid of PC fork of polkadot-sdk.

Added crates still depend on polkadot-sdk sp-consensus-aura and its primitives. Only modified code and necessary private functions were moved from our fork.

Based on partnerchains-stable-2407-1 with Aura modifications reverted, see: https://github.com/input-output-hk/polkadot-sdk/pull/10 .


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff



