### PR TITLE
ci: fix two recurring earthly issues

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -22,7 +22,7 @@ setup:
 
   COPY Cargo.* .rustfmt.toml rust-toolchain.toml .
   RUN rustup show
-  RUN cargo install --locked cargo-chef
+  RUN cargo install --locked cargo-chef && cp "$CARGO_HOME/bin/cargo-chef" /usr/local/bin
 
 source:
   FROM +setup

--- a/Earthfile
+++ b/Earthfile
@@ -26,7 +26,6 @@ setup:
 
 source:
   FROM +setup
-  COPY --dir +vendor/vendor +vendor/.cargo .
   ARG CRATES=$(tomlq -r .workspace.members[] Cargo.toml)
   FOR crate IN $CRATES
       COPY --dir $crate $crate
@@ -34,7 +33,7 @@ source:
   COPY --dir +build-deps/target .
 
 build-deps:
-  FROM +vendor
+  FROM +fetch-deps
   CACHE --sharing shared --id cargo $CARGO_HOME
   RUN cargo --locked chef prepare
   RUN cargo --locked chef cook --profile=$PROFILE --features=$FEATURES
@@ -122,20 +121,10 @@ mock:
       && for crate in $SRCS; do if [ ! -f $crate/lib.rs ]; then touch $crate/main.rs; fi; done \
       && touch node/src/lib.rs
 
-vendor:
+fetch-deps:
   FROM +mock
-  CACHE --sharing shared --id cargo /root/.cargo
-  RUN apt-get update && apt-get install --yes patch
-  # FIXME: setting CARGO_HOME breaks `cargo vendor` https://github.com/rust-lang/cargo/issues/8120
-  RUN --ssh \
-    export OLD=$CARGO_HOME \
-    && unset CARGO_HOME \
-	&& mkdir -p .cargo \
-    && cargo vendor --locked > .cargo/config.toml \
-    && export CARGO_HOME=$OLD \
-    && unset OLD
-  SAVE ARTIFACT vendor
-  SAVE ARTIFACT .cargo
+  CACHE --sharing shared --id cargo $CARGO_HOME
+  RUN --ssh cargo fetch --locked
 
 INSTALL:
   FUNCTION


### PR DESCRIPTION
# Description

## fix(earthly): don't use vendored dependencies

Cargo exhibits subtle differences in behavior when dependencies are vendored locally, which can sometimes lead to failure in CI, where the build suceeds on a developers local machine.

It is by no means obvious that the vendored dependencies are the cause of such breakages when they occur, further adding to the headache.

For simplicity, and to more closely match a developers workflow, we now simply fetch the dependencies, instead of vendoring. This allows us to maintain the benefits of seperating the fetch phase from the build (earthly can skip it if it hasn't changed), without the unexpected breakage.

## fix(earthly): copy cargo-chef to image layer

A `CACHE` serves as a persistent cache mount which remains popullated in between layer changes. This is very helpful for speeding up CI when there are genuine layer updates, since we can, e.g. maintain already fetched dependencies in `CARGO_HOME`, while adding whichever new ones.

However, there has been a persistent issue with `cargo-chef`, which was installed into our `CARGO_HOME` shared `CACHE`. Rarely, the `CACHE` would be cleared by a command like `earthly prune`, but the layer that installed it was still assumed to be cached (and therefore skipped), leading to a very confusing error where the installation of `cargo-chef` was incorrectly skipped, and calls to it would fail.

Copying it immediately after installation outside the persistent `CACHE`  into the layer itself, means that if this step is considered cached by earthly, and therefore skipped, that a copy of the cargo-chef binary will be guaranteed to exist in a location already defined in the system `PATH`, avoiding the confusing and unpredictable error.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.