### PR TITLE
Feat/process compose multi network

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -86,15 +86,14 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ],
-        "systems": "systems"
+        ]
       },
       "locked": {
-        "lastModified": 1701787589,
-        "narHash": "sha256-ce+oQR4Zq9VOsLoh9bZT8Ip9PaMLcjjBUHVPzW5d7Cw=",
+        "lastModified": 1722113426,
+        "narHash": "sha256-Yo/3loq572A8Su6aY5GP56knpuKYRvM2a1meP9oJZCw=",
         "owner": "numtide",
         "repo": "devshell",
-        "rev": "44ddedcbcfc2d52a76b64fb6122f209881bd3e1e",
+        "rev": "67cce7359e4cd3c45296fb4aaf6a19e2a9c757ae",
         "type": "github"
       },
       "original": {
@@ -111,11 +110,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1702448575,
-        "narHash": "sha256-Gm8lI5vumDEryeUI+bT8w0AIvbolZIGh0F/E0mQSLcw=",
+        "lastModified": 1724826636,
+        "narHash": "sha256-hz8Szf5J9oQg6EeMhHE/eKuexoHPiDbmOZTPvijYwyM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "dcf3ca909bd069e6a5737461b64c8d894c6dee85",
+        "rev": "3454a665ff4dd29cf618e6a2e53065370876297f",
         "type": "github"
       },
       "original": {
@@ -146,11 +145,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
         "type": "github"
       },
       "original": {
@@ -161,11 +160,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1712122226,
-        "narHash": "sha256-pmgwKs8Thu1WETMqCrWUm0CkN1nmCKX3b51+EXsAZyY=",
+        "lastModified": 1724479785,
+        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "08b9151ed40350725eb40b1fe96b0b86304a654b",
+        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
         "type": "github"
       },
       "original": {
@@ -177,29 +176,23 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
-        "type": "github"
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
     "process-compose": {
       "locked": {
-        "lastModified": 1701368682,
-        "narHash": "sha256-YkZbzfOkv68YOX4fK6VQvNHpysyZ/x3gePL3wbo8giA=",
+        "lastModified": 1724606023,
+        "narHash": "sha256-rdGeNa/lCS8E1lXzPqgl+vZUUvnbEZT11Bqkx5jfYug=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "8edcd4de7c631eac2ce5f8e2a0782e0ca606da9b",
+        "rev": "f6ce9481df9aec739e4e06b67492401a5bb4f0b1",
         "type": "github"
       },
       "original": {
@@ -228,11 +221,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1702418101,
-        "narHash": "sha256-XyrXFAiMS5r9Kl4lPpmkTTclPKGwJBxln6enERe5nvk=",
+        "lastModified": 1724761543,
+        "narHash": "sha256-G4z3E2PbuAIJ4CSss6Fxs0HMSpnaxMMUFCdyVahAppg=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "b3af1916ccfb85233571ce9ecb45a3a7c74ba0fb",
+        "rev": "8db40df2a3c1c3b18402c4844643d2fb6dce87d6",
         "type": "github"
       },
       "original": {
@@ -244,11 +237,11 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1723336031,
-        "narHash": "sha256-FJOvmGACkAPnnOQE02xxhUg913V5g+XoRrXWt40t/fQ=",
+        "lastModified": 1724770693,
+        "narHash": "sha256-xJweq5KMqqbCfXWnJg3QEfHFUN5/+d3Fx53t20FBDAI=",
         "owner": "juspay",
         "repo": "services-flake",
-        "rev": "034722b4046bf687e8fafa6626a88890abfad33f",
+        "rev": "dcb5db918288ccb5319f2f78a69e851559103c0a",
         "type": "github"
       },
       "original": {
@@ -270,21 +263,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "partner-chains-smart-contracts",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -244,15 +244,15 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1701369356,
-        "narHash": "sha256-dG76HIfz72mChsNa7ZDFYHlK/PzyU7tUtBIskaMdR9E=",
-        "owner": "tgunnoe",
+        "lastModified": 1723336031,
+        "narHash": "sha256-FJOvmGACkAPnnOQE02xxhUg913V5g+XoRrXWt40t/fQ=",
+        "owner": "juspay",
         "repo": "services-flake",
-        "rev": "292e978eae9d0db205f6e0cfdf8fa798c964fabb",
+        "rev": "034722b4046bf687e8fafa6626a88890abfad33f",
         "type": "github"
       },
       "original": {
-        "owner": "tgunnoe",
+        "owner": "juspay",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -32,23 +32,6 @@
         "type": "github"
       }
     },
-    "cardano-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1723187995,
-        "narHash": "sha256-tzDJrakcsxzUN5IXJ6UkpPg/udbsqLnsrjNLZMNohgg=",
-        "owner": "tgunnoe",
-        "repo": "cardano.nix",
-        "rev": "9f88a5ba4e61e0278943081c0b1b093ab1eafcd8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "tgunnoe",
-        "ref": "add-darwin",
-        "repo": "cardano.nix",
-        "type": "github"
-      }
-    },
     "cardano-node": {
       "flake": false,
       "locked": {
@@ -158,6 +141,23 @@
         "type": "github"
       }
     },
+    "kupo": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1721405349,
+        "narHash": "sha256-s6NVXrtjyoeSQpT5BEiM/Dkal9IXhdQJYFLyPQLWiPA=",
+        "owner": "CardanoSolutions",
+        "repo": "kupo",
+        "rev": "61ad7e47f40d577b741cd1689dc08db7ea8d2c79",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CardanoSolutions",
+        "ref": "v2.9.0",
+        "repo": "kupo",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1724479785,
@@ -186,6 +186,23 @@
         "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
       }
     },
+    "ogmios": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1725966092,
+        "narHash": "sha256-c+5SikopKEylvxIZfp36qmdgElkTR7n95YCtLUZ78Q4=",
+        "owner": "CardanoSolutions",
+        "repo": "ogmios",
+        "rev": "9619c8ff017844f6c0f1dcad4f6bcf9f24f12ebd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "CardanoSolutions",
+        "ref": "v6.6.2",
+        "repo": "ogmios",
+        "type": "github"
+      }
+    },
     "process-compose": {
       "locked": {
         "lastModified": 1724606023,
@@ -205,14 +222,15 @@
       "inputs": {
         "blank": "blank",
         "cardano-dbsync": "cardano-dbsync",
-        "cardano-nix": "cardano-nix",
         "cardano-node": "cardano-node",
         "configurations": "configurations",
         "devshell": "devshell",
         "fenix": "fenix",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
+        "kupo": "kupo",
         "nixpkgs": "nixpkgs",
+        "ogmios": "ogmios",
         "process-compose": "process-compose",
         "services-flake": "services-flake",
         "smart-contracts": "smart-contracts"

--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     "cardano-node": {
       "flake": false,
       "locked": {
-        "lastModified": 1721843629,
-        "narHash": "sha256-F5wgRA820x16f+8c/LlEEBG0rMJIA1XWw6X0ZwX5UWs=",
+        "lastModified": 1727221818,
+        "narHash": "sha256-i582YpBy+hBth73JqfcjGFsJrTQeDG0NJ7vN8JLWeoI=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "176f99e51155cb3eaa0711db1c3c969d67438958",
+        "rev": "5d3da8ac771ee5ed424d6c78473c11deabb7a1f3",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.1.1",
+        "ref": "9.2.1",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -36,8 +36,12 @@
       url = "github:IntersectMBO/cardano-db-sync/13.5.0.2";
       flake = false;
     };
-    cardano-nix = {
-      url = "github:tgunnoe/cardano.nix/add-darwin";
+    kupo = {
+      url = "github:CardanoSolutions/kupo/v2.9.0";
+      flake = false;
+    };
+    ogmios = {
+      url = "github:CardanoSolutions/ogmios/v6.6.2";
       flake = false;
     };
     configurations = {
@@ -57,7 +61,7 @@
         inputs.devshell.flakeModule
         inputs.process-compose.flakeModule
         ./nix/shell.nix
-        ./nix/packages.nix
+        ./nix/packages
         ./nix/processes.nix
       ];
       flake.lib = import ./nix/lib.nix {inherit (nixpkgs) lib;};

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
     };
     blank.url = "github:input-output-hk/empty-flake";
     process-compose.url = "github:Platonic-Systems/process-compose-flake";
-    services-flake.url = "github:tgunnoe/services-flake";
+    services-flake.url = "github:juspay/services-flake";
 
     # Partner Chains deps
     smart-contracts = {

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
       flake = false;
     };
     cardano-node = {
-      url = "github:IntersectMBO/cardano-node/9.1.1";
+      url = "github:IntersectMBO/cardano-node/9.2.1";
       flake = false;
     };
     cardano-dbsync = {

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -12,24 +12,22 @@
     system,
     ...
   }: let
-
-    # These need to be specified because cardano.nix provides multiples
     kupoVersion = "2.9.0";
-    ogmiosVersion = "6.5.0";
+    ogmiosVersion = "6.6.2";
 
     flake-compat = import inputs.flake-compat;
     cardanoPackages = (flake-compat { src = inputs.cardano-node; }).defaultNix.packages.${system};
     dbSyncPackages = (flake-compat { src = inputs.cardano-dbsync; }).defaultNix.packages.${system};
     smartContractsPkgs = (flake-compat { src = inputs.smart-contracts; }).defaultNix.packages.${system};
-    cardanoExtraPkgs = (flake-compat { src = inputs.cardano-nix; }).defaultNix.packages.${system};
+    #cardanoExtraPkgs = (flake-compat { src = inputs.cardano-nix; }).defaultNix.packages.${system};
 
   in {
     packages = {
       inherit (smartContractsPkgs) pc-contracts-cli;
       inherit (cardanoPackages) cardano-node cardano-cli cardano-testnet;
       inherit (dbSyncPackages) "cardano-db-sync:exe:cardano-db-sync";
-      kupo = cardanoExtraPkgs."kupo-${kupoVersion}";
-      ogmios = cardanoExtraPkgs."ogmios-${ogmiosVersion}";
+      kupo = pkgs.callPackage ./kupo.nix { version = kupoVersion; };
+      ogmios = pkgs.callPackage ./ogmios.nix { version = ogmiosVersion; };
       partnerchains-stack = pkgs.stdenv.mkDerivation {
         name = "partnerchains-stack";
         phases = [ "installPhase" ];

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -27,6 +27,9 @@
       inherit (dbSyncPackages) "cardano-db-sync:exe:cardano-db-sync";
       kupo = pkgs.callPackage ./kupo.nix { version = kupoVersion; };
       ogmios = pkgs.callPackage ./ogmios.nix { version = ogmiosVersion; };
+      process-compose = pkgs.process-compose.overrideAttrs (oldAttrs: {
+        patches = [ ./pc.patch ];
+      });
       partnerchains-stack = pkgs.callPackage ./partnerchains-stack { inherit (self'.packages) partnerchains-stack-unwrapped; };
 
     };

--- a/nix/packages/default.nix
+++ b/nix/packages/default.nix
@@ -20,7 +20,6 @@
     dbSyncPackages = (flake-compat { src = inputs.cardano-dbsync; }).defaultNix.packages.${system};
     smartContractsPkgs = (flake-compat { src = inputs.smart-contracts; }).defaultNix.packages.${system};
     #cardanoExtraPkgs = (flake-compat { src = inputs.cardano-nix; }).defaultNix.packages.${system};
-
   in {
     packages = {
       inherit (smartContractsPkgs) pc-contracts-cli;
@@ -28,18 +27,8 @@
       inherit (dbSyncPackages) "cardano-db-sync:exe:cardano-db-sync";
       kupo = pkgs.callPackage ./kupo.nix { version = kupoVersion; };
       ogmios = pkgs.callPackage ./ogmios.nix { version = ogmiosVersion; };
-      partnerchains-stack = pkgs.stdenv.mkDerivation {
-        name = "partnerchains-stack";
-        phases = [ "installPhase" ];
-        nativeBuildInputs = [ pkgs.makeWrapper ];
-        installPhase = ''
-          mkdir -p $out/bin
-          cp ${self'.packages.partnerchains-stack-unwrapped}/bin/partnerchains-stack-unwrapped \
-            $out/bin/partnerchains-stack
-          wrapProgram $out/bin/partnerchains-stack \
-            --run "cd \$(${pkgs.git}/bin/git rev-parse --show-toplevel) || exit 1"
-        '';
-      };
+      partnerchains-stack = pkgs.callPackage ./partnerchains-stack { inherit (self'.packages) partnerchains-stack-unwrapped; };
+
     };
   };
 }

--- a/nix/packages/kupo.nix
+++ b/nix/packages/kupo.nix
@@ -1,0 +1,24 @@
+{ fetchzip, stdenv, version, ... }:
+
+let
+
+  kupoLinux = fetchzip {
+    url = "https://github.com/CardanoSolutions/kupo/releases/download/v2.9/kupo-v${version}-x86_64-linux.zip";
+    hash = "sha256:sEfaFPph1qBuPrxQzFeTKU/9i9w0KF/v7GpxxmorPWQ=";
+    stripRoot = false;
+    version = "${version}";
+    name = "kupo-${version}";
+    postFetch = "chmod +x $out/bin/kupo";
+  };
+
+  kupoDarwin = fetchzip {
+    url = "https://github.com/CardanoSolutions/kupo/releases/download/v2.9/kupo-v${version}-aarch64-macos.zip";
+    hash = "sha256:1d18mpvmjiafy56pjljf46r1nh7ma44k29jzwk3bpr22ra9dvi0x";
+    stripRoot = false;
+    version = "${version}";
+    name = "kupo-${version}";
+    postFetch = "chmod +x $out/bin/kupo";
+  };
+
+in
+if stdenv.isDarwin then kupoDarwin else kupoLinux

--- a/nix/packages/ogmios.nix
+++ b/nix/packages/ogmios.nix
@@ -1,0 +1,22 @@
+{ fetchzip, stdenv, version, ... }:
+let
+  ogmiosLinux = fetchzip {
+    url = "https://github.com/CardanoSolutions/ogmios/releases/download/v${version}/ogmios-v${version}-x86_64-linux.zip";
+    hash = "sha256-KHOna+zDFJDVD20M2dTD71dcDKWMSXmqOPWMAYef9/4=";
+    stripRoot = false;
+    version = "${version}";
+    name = "ogmios-${version}";
+    postFetch = "chmod +x $out/bin/ogmios";
+  };
+
+  ogmiosDarwin = fetchzip {
+    url = "https://github.com/CardanoSolutions/ogmios/releases/download/v${version}/ogmios-v${version}-aarch64-macos.zip";
+    hash = "sha256-eoL8aLwZlBd7R/1REYjN56Bk0t+NBNBTFg7KyGr78PE=";
+    stripRoot = false;
+    version = "${version}";
+    name = "ogmios-${version}";
+    postFetch = "chmod +x $out/bin/ogmios";
+  };
+
+in
+if stdenv.isLinux then ogmiosLinux else ogmiosDarwin

--- a/nix/packages/partnerchains-stack/default.nix
+++ b/nix/packages/partnerchains-stack/default.nix
@@ -1,0 +1,23 @@
+{ partnerchains-stack-unwrapped, git, stdenv }:
+
+stdenv.mkDerivation {
+  pname = "partnerchains-stack";
+  version = "1.0.0"; # Replace with your actual version
+
+  # Specify dependencies
+  nativeBuildInputs = [ git ];
+
+  # Define the build phases
+  phases = [ "installPhase" ];
+
+  installPhase = ''
+    mkdir -p $out/bin
+
+    cp ${partnerchains-stack-unwrapped}/bin/partnerchains-stack-unwrapped \
+      $out/bin/partnerchains-stack-unwrapped
+
+    cp ${./wrapper.sh} $out/bin/partnerchains-stack
+
+    chmod +x $out/bin/partnerchains-stack
+  '';
+}

--- a/nix/packages/partnerchains-stack/wrapper.sh
+++ b/nix/packages/partnerchains-stack/wrapper.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+DIR="$(dirname "$0")"
+
+# Make sure we're running in the root project dir
+cd "$(git rev-parse --show-toplevel)" || exit 1
+
+NAMESPACE_FLAGS=""
+OTHER_ARGS=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -n|--namespace)
+      # Check if the next argument exists and is not another flag
+      if [ -n "$2" ] && [ "${2#--}" = "$2" ]; then
+        NAMESPACE_FLAGS="$NAMESPACE_FLAGS --namespace $2"
+        shift 2
+      else
+        echo "Error: $1 requires a non-empty argument." >&2
+        exit 1
+      fi
+      ;;
+    *)
+      OTHER_ARGS="$OTHER_ARGS $1"
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$NAMESPACE_FLAGS" ]; then
+  NAMESPACE_FLAGS="--namespace preview"
+fi
+
+set -- $NAMESPACE_FLAGS $OTHER_ARGS
+
+exec "$DIR/partnerchains-stack-unwrapped" "$@"

--- a/nix/packages/pc.patch
+++ b/nix/packages/pc.patch
@@ -1,0 +1,38 @@
+diff --git a/Makefile b/Makefile
+index b2cb4b1..0a810d6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -7,13 +7,13 @@ DATE       ?= $(shell TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:
+ NUMVER = $(shell echo ${VERSION} | cut -d"v" -f 2)
+ PKG = github.com/f1bonacc1/${NAME}
+ SHELL := /bin/bash
+-PROJ_NAME := Process Compose
++PROJ_NAME := Partner Chains
+ DOCS_DIR  := www/docs/cli
+ LD_FLAGS := -ldflags="-X ${PKG}/src/config.Version=${VERSION} \
+             -X ${PKG}/src/config.CheckForUpdates=true \
+             -X ${PKG}/src/config.Commit=${GIT_REV} \
+             -X ${PKG}/src/config.Date=${DATE} \
+-            -X '${PKG}/src/config.ProjectName=${PROJ_NAME} 🔥' \
++            -X '${PKG}/src/config.ProjectName=₳ ${PROJ_NAME} 🤠' \
+             -X '${PKG}/src/config.RemoteProjectName=${PROJ_NAME} ⚡' \
+             -s -w"
+ ifeq ($(OS),Windows_NT)
+@@ -87,4 +87,3 @@ docs:
+ 	./bin/process-compose docs ${DOCS_DIR}
+ 	for f in ${DOCS_DIR}/*.md ; do sed -i 's/${USER}/<user>/g' $$f ; done
+ 	for f in ${DOCS_DIR}/*.md ; do sed -i 's/process-compose-[0-9]\+.sock/process-compose-<pid>.sock/g' $$f ; done
+-
+diff --git a/src/cmd/root.go b/src/cmd/root.go
+index 28f6429..aed83ff 100644
+--- a/src/cmd/root.go
++++ b/src/cmd/root.go
+@@ -85,7 +85,7 @@ func init() {
+ 	rootCmd.PersistentFlags().IntVarP(pcFlags.PortNum, "port", "p", *pcFlags.PortNum, "port number (env: "+config.EnvVarNamePort+")")
+ 	rootCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
+ 	rootCmd.Flags().StringArrayVarP(&opts.EnvFileNames, "env", "e", []string{".env"}, "path to env files to load")
+-	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default all)")
++	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default preview)")
+ 	rootCmd.PersistentFlags().StringVarP(pcFlags.LogFile, "log-file", "L", *pcFlags.LogFile, "Specify the log file path (env: "+config.LogPathEnvVarName+")")
+ 	rootCmd.PersistentFlags().BoolVar(pcFlags.IsReadOnlyMode, "read-only", *pcFlags.IsReadOnlyMode, "enable read-only mode (env: "+config.EnvVarReadOnlyMode+")")
+ 	rootCmd.Flags().BoolVar(pcFlags.DisableDotEnv, "disable-dotenv", *pcFlags.DisableDotEnv, "disable .env file loading (env: "+config.EnvVarDisableDotEnv+"=1)")

--- a/nix/packages/pc.patch
+++ b/nix/packages/pc.patch
@@ -1,30 +1,5 @@
-diff --git a/Makefile b/Makefile
-index b2cb4b1..0a810d6 100644
---- a/Makefile
-+++ b/Makefile
-@@ -7,13 +7,13 @@ DATE       ?= $(shell TZ=UTC0 git show --quiet --date='format-local:%Y-%m-%dT%H:
- NUMVER = $(shell echo ${VERSION} | cut -d"v" -f 2)
- PKG = github.com/f1bonacc1/${NAME}
- SHELL := /bin/bash
--PROJ_NAME := Process Compose
-+PROJ_NAME := Partner Chains
- DOCS_DIR  := www/docs/cli
- LD_FLAGS := -ldflags="-X ${PKG}/src/config.Version=${VERSION} \
-             -X ${PKG}/src/config.CheckForUpdates=true \
-             -X ${PKG}/src/config.Commit=${GIT_REV} \
-             -X ${PKG}/src/config.Date=${DATE} \
--            -X '${PKG}/src/config.ProjectName=${PROJ_NAME} 🔥' \
-+            -X '${PKG}/src/config.ProjectName=₳ ${PROJ_NAME} 🤠' \
-             -X '${PKG}/src/config.RemoteProjectName=${PROJ_NAME} ⚡' \
-             -s -w"
- ifeq ($(OS),Windows_NT)
-@@ -87,4 +87,3 @@ docs:
- 	./bin/process-compose docs ${DOCS_DIR}
- 	for f in ${DOCS_DIR}/*.md ; do sed -i 's/${USER}/<user>/g' $$f ; done
- 	for f in ${DOCS_DIR}/*.md ; do sed -i 's/process-compose-[0-9]\+.sock/process-compose-<pid>.sock/g' $$f ; done
--
 diff --git a/src/cmd/root.go b/src/cmd/root.go
-index 28f6429..aed83ff 100644
+index 28f6429..86f60ad 100644
 --- a/src/cmd/root.go
 +++ b/src/cmd/root.go
 @@ -85,7 +85,7 @@ func init() {
@@ -32,7 +7,22 @@ index 28f6429..aed83ff 100644
  	rootCmd.Flags().StringArrayVarP(&opts.FileNames, "config", "f", config.GetConfigDefault(), "path to config files to load (env: "+config.EnvVarNameConfig+")")
  	rootCmd.Flags().StringArrayVarP(&opts.EnvFileNames, "env", "e", []string{".env"}, "path to env files to load")
 -	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default all)")
-+	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default preview)")
++	rootCmd.Flags().StringArrayVarP(&nsAdmitter.EnabledNamespaces, "namespace", "n", nil, "run only specified namespaces (default: preview, supported: preview, preprod, sanchonet, mainnet)")
  	rootCmd.PersistentFlags().StringVarP(pcFlags.LogFile, "log-file", "L", *pcFlags.LogFile, "Specify the log file path (env: "+config.LogPathEnvVarName+")")
  	rootCmd.PersistentFlags().BoolVar(pcFlags.IsReadOnlyMode, "read-only", *pcFlags.IsReadOnlyMode, "enable read-only mode (env: "+config.EnvVarReadOnlyMode+")")
  	rootCmd.Flags().BoolVar(pcFlags.DisableDotEnv, "disable-dotenv", *pcFlags.DisableDotEnv, "disable .env file loading (env: "+config.EnvVarDisableDotEnv+"=1)")
+diff --git a/src/config/config.go b/src/config/config.go
+index d076810..76ec6e1 100644
+--- a/src/config/config.go
++++ b/src/config/config.go
+@@ -18,8 +18,8 @@ var (
+ 	CheckForUpdates   = "false"
+ 	License           = "Apache-2.0"
+ 	Discord           = "https://discord.gg/S4xgmRSHdC"
+-	ProjectName       = "Process Compose 🔥"
+-	RemoteProjectName = "Process Compose ⚡"
++	ProjectName       = "🤠 Partner Chains (₳)"
++	RemoteProjectName = "🤠 Partner Chains (₳)⚡"
+ 
+ 	scFiles = []string{
+ 		"shortcuts.yaml",

--- a/nix/processes.nix
+++ b/nix/processes.nix
@@ -66,7 +66,7 @@
           exec = {
             command = ''
               while true; do
-                if  [ -S ${node-socket} ] && nc -U -z -w 1 ${node-socket}; then
+                if  [ -S ${node-socket} ] && ${pkgs.netcat}/bin/nc -U -z -w 1 ${node-socket}; then
                   exit 0
                 fi
                 sleep 5

--- a/nix/processes.nix
+++ b/nix/processes.nix
@@ -11,23 +11,221 @@
     system,
     ...
   }: let
-    data-dir = "./.run";
-    node-socket = "${data-dir}/cardano-node/node.socket";
-    configs-dir = "${inputs.configurations}/network/preview";
-    node-config = "${configs-dir}/cardano-node/config.json";
-  in {
-    process-compose."partnerchains-stack-unwrapped" = {
-      imports = [
-        inputs.services-flake.processComposeModules.default
-      ];
-      tui = true;
-      #port = 8081;
-      services.postgres."postgres" = {
+    mkStack = network: let
+      data-dir = "./.run/${network}";
+      node-socket = "${data-dir}/cardano-node/node.socket";
+      configs-dir = "${inputs.configurations}/network/${network}";
+      node-config = "${configs-dir}/cardano-node/config.json";
+      magic = if network == "preview" then "2" else "1";
+    in {
+      "tip-status-${network}" = {
+        namespace = network;
+        command = ''
+          export CARDANO_NODE_SOCKET_PATH=${node-socket}
+          while true; do
+            ${self'.packages.cardano-cli}/bin/cardano-cli \
+              query tip --testnet-magic ${magic};
+            sleep 10
+          done
+        '';
+        depends_on = {
+          "cardano-node-${network}".condition = "process_healthy";
+        };
+
+        readiness_probe = {
+          exec = {
+            command = ''
+              export CARDANO_NODE_SOCKET_PATH=${node-socket}
+              ${self'.packages.cardano-cli}/bin/cardano-cli \
+              query tip --testnet-magic ${magic} \
+              | jq -e '.syncProgress == "100.00" | not' && exit 1 || exit 0
+            '';
+          };
+          initial_delay_seconds = 25;
+          period_seconds = 30;
+          timeout_seconds = 10;
+          success_threshold = 1;
+          failure_threshold = 1000;
+        };
+      };
+      "cardano-node-${network}" = {
+        namespace = network;
+        liveness_probe = {
+          exec = {
+            command = ''
+              pgrep -f cardano-node
+            '';
+          };
+          initial_delay_seconds = 5;
+          period_seconds = 2;
+          timeout_seconds = 5;
+          success_threshold = 5;
+          failure_threshold = 3;
+        };
+        readiness_probe = {
+          exec = {
+            command = ''
+              while true; do
+                if  [ -S ${node-socket} ] && nc -U -z -w 1 ${node-socket}; then
+                  exit 0
+                fi
+                sleep 5
+              done
+            '';
+          };
+          initial_delay_seconds = 25;
+          period_seconds = 5;
+          timeout_seconds = 20;
+          success_threshold = 1;
+          failure_threshold = 1000;
+        };
+        availability.restart = "on_failure";
+        shutdown = {
+          signal = 2;
+        };
+        command = ''
+          ${self'.packages.cardano-node}/bin/cardano-node run +RTS -N -RTS \
+          --topology ${configs-dir}/cardano-node/topology.json \
+          --database-path ${data-dir}/cardano-node/data \
+          --socket-path ${node-socket} \
+          --host-addr 0.0.0.0 \
+          --port ${if network == "preview" then "3030" else "3031"} \
+          --config ${node-config}
+        '';
+        environment = {
+          NETWORK = network;
+          CARDANO_NODE_SOCKET_PATH = node-socket;
+        };
+      };
+      "db-sync-${network}" = let
+        pgpass = pkgs.writeText "pgpass-mainnet" ''
+          127.0.0.1:${if network == "preview" then "5432" else "5433"}:cexplorer:postgres:password123
+        '';
+      in {
+        namespace = network;
+        command = pkgs.writeShellApplication {
+          name = "cardano-db-sync";
+          runtimeInputs = [pkgs.postgresql];
+          text = ''
+            ${self'.packages."cardano-db-sync:exe:cardano-db-sync"}/bin/cardano-db-sync \
+              --config ${configs-dir}/cardano-db-sync/config.json \
+              --socket-path ${node-socket} \
+              --state-dir ${data-dir}/db-sync/ledger-state \
+              --schema-dir  ${inputs.cardano-dbsync}/schema/
+          '';
+        };
+        depends_on = {
+          "postgres-${network}".condition = "process_healthy";
+          "cardano-node-${network}".condition = "process_healthy";
+        };
+        liveness_probe = {
+          exec = {
+            command = ''
+              pgrep -f cardano-db-sync
+            '';
+          };
+        };
+        availability.restart = "on_failure";
+        environment = {
+          NETWORK = network;
+          PGPASSFILE = "${pgpass}";
+          POSTGRES_HOST = "127.0.0.1";
+          POSTGRES_PORT = if network == "preview" then "5432" else "5433";
+          POSTGRES_DB = "cexplorer";
+          POSTGRES_USER = "postgres";
+          POSTGRES_PASSWORD = "password123";
+        };
+      };
+      "ogmios-${network}" = {
+        namespace = network;
+        command = ''
+          ${self'.packages.ogmios}/bin/ogmios \
+            --host 0.0.0.0 \
+            --node-config ${node-config} \
+            --node-socket ${node-socket} \
+            --port ${if network == "preview" then "1337" else "1338"}
+        '';
+        environment = {
+          DATA_DIR = "${data-dir}/ogmios";
+          OGMIOS_PORT = if network == "preview" then "1337" else "1338";
+        };
+        liveness_probe = {
+          exec = {
+            command = ''
+              pgrep -f ogmios
+            '';
+          };
+          initial_delay_seconds = 5;
+          period_seconds = 2;
+          timeout_seconds = 5;
+          success_threshold = 5;
+          failure_threshold = 3;
+        };
+        readiness_probe = {
+          http_get = {
+            host = "0.0.0.0";
+            port = if network == "preview" then 1337 else 1338;
+          };
+          initial_delay_seconds = 5;
+          period_seconds = 5;
+          timeout_seconds = 20;
+          success_threshold = 1;
+          failure_threshold = 1000;
+        };
+        availability.restart = "on_failure";
+        depends_on."cardano-node-${network}".condition = "process_healthy";
+      };
+      "kupo-${network}" = {
+        namespace = network;
+        command = ''
+          ${self'.packages.kupo}/bin/kupo \
+            --node-socket ${node-socket} \
+            --node-config ${node-config} \
+            --host 0.0.0.0 \
+            --workdir ${data-dir}/kupo \
+            --match "*" \
+            --since origin \
+            --port ${if network == "preview" then "1442" else "1443"}
+        '';
+        liveness_probe = {
+          exec = {
+            command = ''
+              pgrep -f kupo
+            '';
+          };
+          initial_delay_seconds = 5;
+          period_seconds = 2;
+          timeout_seconds = 5;
+          success_threshold = 5;
+          failure_threshold = 3;
+        };
+        readiness_probe = {
+          http_get = {
+            host = "0.0.0.0";
+            port = if network == "preview" then 1442 else 1443;
+            path = "/matches";
+          };
+          initial_delay_seconds = 5;
+          period_seconds = 5;
+          timeout_seconds = 20;
+          success_threshold = 1;
+          failure_threshold = 20;
+        };
+        availability.restart = "on_failure";
+        depends_on."cardano-node-${network}".condition = "process_healthy";
+      };
+    };
+    mkService = network: let
+      data-dir = "./.run/${network}";
+    in {
+      "postgres-${network}" = {
         enable = true;
-        port = 5432;
+        namespace = network;
+        port = if network == "preview" then 5432 else 5433;
         dataDir = "${data-dir}/db-sync/database";
         listen_addresses = "127.0.0.1";
         initialDatabases = [{name = "cexplorer";}];
+        superuser = "postgres";
         initdbArgs = [
           "--locale=C"
           "--encoding=UTF8"
@@ -35,200 +233,15 @@
           "--pwfile=${pkgs.writeText "password" "password123"}"
         ];
       };
-      settings = {
-        processes = {
-          tip-status = {
-            namespace = "cardano-node";
-            command = ''
-              export CARDANO_NODE_SOCKET_PATH=${node-socket}
-              while true; do
-                ${self'.packages.cardano-cli}/bin/cardano-cli \
-                  query tip --testnet-magic 2;
-                sleep 10
-              done
-            '';
-            #is_tty = true;
-            depends_on = {
-              cardano-node.condition = "process_healthy";
-            };
-
-            readiness_probe = {
-              exec = {
-                command = ''
-                  export CARDANO_NODE_SOCKET_PATH=${node-socket}
-                  ${self'.packages.cardano-cli}/bin/cardano-cli \
-                  query tip --testnet-magic 2 \
-                  | jq -e '.syncProgress == "100.00" | not' && exit 1 || exit 0
-                '';
-              };
-              initial_delay_seconds = 25;
-              period_seconds = 30;
-              timeout_seconds = 10;
-              success_threshold = 1;
-              failure_threshold = 1000;
-            };
-          };
-          cardano-node = {
-            namespace = "cardano-node";
-            liveness_probe = {
-              exec = {
-                command = ''
-                  pgrep -f cardano-node
-                '';
-              };
-              initial_delay_seconds = 5;
-              period_seconds = 2;
-              timeout_seconds = 5;
-              success_threshold = 5;
-              failure_threshold = 3;
-            };
-            readiness_probe = {
-              exec = {
-                command = ''
-                  while true; do
-                    if  [ -S ${node-socket} ] && nc -U -z -w 1 ${node-socket}; then
-                      exit 0
-                    fi
-                    sleep 5
-                  done
-                '';
-              };
-              initial_delay_seconds = 25;
-              period_seconds = 5;
-              timeout_seconds = 20;
-              success_threshold = 1;
-              failure_threshold = 1000;
-            };
-            availability.restart = "on_failure";
-            shutdown = {
-              signal = 2;
-            };
-            command = ''
-              ${self'.packages.cardano-node}/bin/cardano-node run +RTS -N -RTS \
-              --topology ${configs-dir}/cardano-node/topology.json \
-              --database-path ${data-dir}/cardano-node/data \
-              --socket-path ${node-socket} \
-              --host-addr 0.0.0.0 \
-              --port 3030 \
-              --config ${node-config}
-            '';
-            environment = {
-              NETWORK = "preview";
-              CARDANO_NODE_SOCKET_PATH = node-socket;
-            };
-          };
-          db-sync = let
-            pgpass = pkgs.writeText "pgpass-mainnet" ''
-              127.0.0.1:5432:cexplorer:postgres:password123
-            '';
-          in {
-            command = pkgs.writeShellApplication {
-              name = "cardano-db-sync";
-              runtimeInputs = [pkgs.postgresql];
-              text = ''
-                ${self'.packages."cardano-db-sync:exe:cardano-db-sync"}/bin/cardano-db-sync \
-                  --config ${configs-dir}/cardano-db-sync/config.json \
-                  --socket-path ${node-socket} \
-                  --state-dir ${data-dir}/db-sync/ledger-state \
-                  --schema-dir  ${inputs.cardano-dbsync}/schema/
-              '';
-            };
-            depends_on = {
-              "postgres".condition = "process_healthy";
-              cardano-node.condition = "process_healthy";
-            };
-            liveness_probe = {
-              exec = {
-                command = ''
-                  pgrep -f cardano-db-sync
-                '';
-              };
-            };
-            availability.restart = "on_failure";
-            environment = {
-              NETWORK = "preview";
-              PGPASSFILE = "${pgpass}";
-              POSTGRES_HOST = "127.0.0.1";
-              POSTGRES_PORT = "5432";
-              POSTGRES_DB = "cexplorer";
-              POSTGRES_USER = "postgres";
-              POSTGRES_PASSWORD = "password123";
-            };
-          };
-          ogmios = {
-            command = ''
-              ${self'.packages.ogmios}/bin/ogmios \
-                --host 0.0.0.0 --node-config ${node-config} --node-socket ${node-socket}
-          #   '';
-            environment = {
-              DATA_DIR = "${data-dir}/ogmios";
-              OGMIOS_PORT = "1337";
-            };
-            liveness_probe = {
-              exec = {
-                command = ''
-                  pgrep -f ogmios
-                '';
-              };
-              initial_delay_seconds = 5;
-              period_seconds = 2;
-              timeout_seconds = 5;
-              success_threshold = 5;
-              failure_threshold = 3;
-            };
-            readiness_probe = {
-              http_get = {
-                host = "0.0.0.0";
-                port = 1337;
-              };
-              initial_delay_seconds = 5;
-              period_seconds = 5;
-              timeout_seconds = 20;
-              success_threshold = 1;
-              failure_threshold = 1000;
-            };
-            availability.restart = "on_failure";
-            depends_on.cardano-node.condition = "process_healthy";
-          };
-          kupo = {
-            command = ''
-              ${self'.packages.kupo}/bin/kupo \
-                --node-socket ${node-socket} \
-                --node-config ${node-config} \
-                --host 0.0.0.0 \
-                --workdir ${data-dir}/kupo \
-                --match "*" \
-                --since origin
-            '';
-            liveness_probe = {
-              exec = {
-                command = ''
-                  pgrep -f kupo
-                '';
-              };
-              initial_delay_seconds = 5;
-              period_seconds = 2;
-              timeout_seconds = 5;
-              success_threshold = 5;
-              failure_threshold = 3;
-            };
-            readiness_probe = {
-              http_get = {
-                host = "0.0.0.0";
-                port = 1442;
-                path = "/matches";
-              };
-              initial_delay_seconds = 5;
-              period_seconds = 5;
-              timeout_seconds = 20;
-              success_threshold = 1;
-              failure_threshold = 20;
-            };
-            availability.restart = "on_failure";
-            depends_on.cardano-node.condition = "process_healthy";
-          };
-        };
-      };
+    };
+  in {
+    process-compose."partnerchains-stack-unwrapped" = {
+      imports = [
+        inputs.services-flake.processComposeModules.default
+      ];
+      tui = true;
+      settings.processes = mkStack "preview" // mkStack "preprod";
+      services.postgres = mkService "preview" // mkService "preprod";
     };
   };
 }

--- a/nix/processes.nix
+++ b/nix/processes.nix
@@ -259,7 +259,7 @@
       imports = [
         inputs.services-flake.processComposeModules.default
       ];
-      #package = self'.packages.process-compose;
+      package = self'.packages.process-compose;
       tui = true;
       settings.processes = mkStack "preview" // mkStack "preprod" // mkStack "mainnet";
       services.postgres = mkService "preview" // mkService "preprod" // mkService "mainnet";

--- a/nix/processes.nix
+++ b/nix/processes.nix
@@ -267,6 +267,10 @@
       ];
       package = self'.packages.process-compose;
       tui = true;
+      httpServer = {
+        enable = true;
+        port = 8081;
+      };
       settings.processes = mkStack "preview" // mkStack "preprod" // mkStack "sanchonet"// mkStack "mainnet";
       services.postgres = mkService "preview" // mkService "preprod" // mkService "sanchonet" // mkService "mainnet";
     };

--- a/nix/processes.nix
+++ b/nix/processes.nix
@@ -24,11 +24,17 @@
         ogmios = 1338;
         kupo = 1443;
       };
-      mainnet = {
+      sanchonet = {
         node = 3032;
         postgres = 5434;
         ogmios = 1339;
         kupo = 1444;
+      };
+      mainnet = {
+        node = 3033;
+        postgres = 5435;
+        ogmios = 1340;
+        kupo = 1445;
       };
     }."${network}";
     mkStack = network: let
@@ -261,8 +267,8 @@
       ];
       package = self'.packages.process-compose;
       tui = true;
-      settings.processes = mkStack "preview" // mkStack "preprod" // mkStack "mainnet";
-      services.postgres = mkService "preview" // mkService "preprod" // mkService "mainnet";
+      settings.processes = mkStack "preview" // mkStack "preprod" // mkStack "sanchonet"// mkStack "mainnet";
+      services.postgres = mkService "preview" // mkService "preprod" // mkService "sanchonet" // mkService "mainnet";
     };
   };
 }

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -106,7 +106,7 @@
         pkgs = [
           {
             name = "cardano-cli";
-            help = "CLI v9.1.1 that is used in partner-chains dependency stack";
+            help = "CLI v9.2.1 that is used in partner-chains dependency stack";
             # This command has some eval because of IFD
             command = "${self'.packages.cardano-cli}/bin/cardano-cli $@";
           }
@@ -121,7 +121,7 @@
           pkgs = [
             {
               name = "partnerchains-stack";
-              help = "Run a process-compose stack of all of the dependencies";
+              help = "Run a containerless stack of all of the dependencies. Use -n <network> to specify networks";
               command = ''
                 ${self'.packages.partnerchains-stack}/bin/partnerchains-stack $@
               '';


### PR DESCRIPTION
# Description
This adds preprod and mainnet to the process compose stack, and updates nixpkgs/process-compose to the latest versions. The data has been properly sorted within `.run` by network.

to use the shell, add 
`NIX_SHELL=".#process-compose"`
to your `.envrc.local` file.
and run `direnv reload`

to use one network over the other, run
`partnerchains-stack --namespace preprod`
or to use multiple:
`partnerchains-stack --n preprod -n mainnet -n preview`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

