### PR TITLE
change: ETCM-8262 move reading of config env vars out of the node crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ name = "chain-params"
 version = "1.0.0"
 dependencies = [
  "clap",
+ "envy",
  "hex-literal",
  "parity-scale-codec",
  "plutus",
@@ -2259,6 +2260,15 @@ name = "environmental"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
+
+[[package]]
+name = "envy"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f47e0157f2cb54f5ae1bd371b30a2ae4311e1c028f575cd4e81de7353215965"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "epoch-derivation"
@@ -6119,6 +6129,7 @@ dependencies = [
  "cli-commands",
  "db-sync-follower",
  "derive-new",
+ "envy",
  "epoch-derivation",
  "frame-benchmarking",
  "frame-benchmarking-cli",
@@ -9269,6 +9280,7 @@ dependencies = [
 name = "sidechain-slots"
 version = "0.1.0"
 dependencies = [
+ "envy",
  "parity-scale-codec",
  "proptest",
  "scale-info",
@@ -9821,6 +9833,7 @@ name = "sp-native-token-management"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "envy",
  "main-chain-follower-api",
  "parity-scale-codec",
  "scale-info",
@@ -9953,6 +9966,7 @@ dependencies = [
 name = "sp-session-validator-management"
 version = "0.1.0"
 dependencies = [
+ "envy",
  "epoch-derivation",
  "parity-scale-codec",
  "scale-info",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ members = [
     "primitives/sidechain",
 	"partner-chains-cli",
     "pallets/native-token-management",
-    "primitives/native-token-management"]
+    "primitives/native-token-management"
+]
 resolver = "2"
 
 [profile.release]
@@ -100,6 +101,7 @@ sealed_test = { version = "1.0.0" }
 derive-new = { version = "0.6.0" }
 inquire = { version = "0.7.5" }
 parking_lot = { version = "0.12.1", default-features = false }
+envy = { version = "0.4.2" }
 
 # substrate dependencies
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2407-2" }

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * ETCM-7811 - native token movement observability components: `sp-native-token-management` and
 `pallet-native-token-management` crates; data sources behind the `native-token` feature in
 `main-chain-follower-api` and `db-sync-follower` crates.
+* added helper functions to `SidechainParams` and all `MainChainScripts` types to read them from environment
 
 # v1.0.0rc1
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -71,6 +71,7 @@ thiserror = { workspace = true }
 time-source = { workspace = true }
 derive-new = { workspace = true }
 partner-chains-node-commands = { workspace = true }
+envy = { workspace = true }
 
 # These dependencies are used for the node template's RPCs
 jsonrpsee = { workspace = true }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -1,20 +1,11 @@
-use sidechain_domain::{AssetName, MainchainAddress, PolicyId};
-use sidechain_runtime::CrossChainPublic;
-use sidechain_runtime::{opaque::SessionKeys, AccountId, Signature, WASM_BINARY};
+use sidechain_runtime::{opaque::SessionKeys, AccountId, CrossChainPublic, Signature, WASM_BINARY};
 use sp_core::{Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
-use sp_session_validator_management::MainChainScripts;
-use std::str::FromStr;
 
 // The URL for the telemetry server.
 // const STAGING_TELEMETRY_URL: &str = "wss://telemetry.polkadot.io/submit/";
 
 pub type ChainSpec = sc_service::GenericChainSpec;
-
-pub enum EnvVarReadError {
-	Missing(String),
-	ParseError(String),
-}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct AuthorityKeys {
@@ -40,54 +31,4 @@ where
 
 pub fn runtime_wasm() -> &'static [u8] {
 	WASM_BINARY.expect("Runtime wasm not available")
-}
-
-pub fn from_var_or<T: FromStr>(var: &str, default: T) -> Result<T, EnvVarReadError> {
-	if let Ok(env_var_string) = std::env::var(var) {
-		env_var_string.parse::<T>().map_err(|_| {
-			EnvVarReadError::ParseError(format!(
-				"Can not interpret environment variable {}={} as {}",
-				var,
-				env_var_string,
-				std::any::type_name::<T>()
-			))
-		})
-	} else {
-		Ok(default)
-	}
-}
-
-pub fn from_var<T: FromStr>(var: &str) -> Result<T, EnvVarReadError> {
-	let env_var_string = std::env::var(var).map_err(|_| {
-		EnvVarReadError::Missing(format!("Environment variable {} cannot be empty.", var))
-	})?;
-
-	env_var_string.parse::<T>().map_err(|_| {
-		EnvVarReadError::ParseError(format!(
-			"Can not interpret environment variable {}={} as {}",
-			var,
-			env_var_string,
-			std::any::type_name::<T>(),
-		))
-	})
-}
-
-pub fn read_mainchain_scripts_from_env() -> Result<MainChainScripts, EnvVarReadError> {
-	let committee_candidate_address = from_var("COMMITTEE_CANDIDATE_ADDRESS")?;
-	let d_parameter_policy = from_var("D_PARAMETER_POLICY_ID")?;
-	let permissioned_candidates_policy = from_var::<PolicyId>("PERMISSIONED_CANDIDATES_POLICY_ID")?;
-	Ok(MainChainScripts {
-		committee_candidate_address,
-		d_parameter_policy,
-		permissioned_candidates_policy,
-	})
-}
-
-pub fn read_native_token_main_chain_scripts_from_env(
-) -> Result<sp_native_token_management::MainChainScripts, EnvVarReadError> {
-	Ok(sp_native_token_management::MainChainScripts {
-		native_token_policy: from_var::<PolicyId>("NATIVE_TOKEN_POLICY_ID")?,
-		native_token_asset_name: from_var::<AssetName>("NATIVE_TOKEN_ASSET_NAME")?,
-		illiquid_supply_address: from_var::<MainchainAddress>("ILLIQUID_SUPPLY_VALIDATOR_ADDRESS")?,
-	})
 }

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -103,7 +103,7 @@ pub fn staging_sudo_key() -> AccountId {
 	)
 }
 
-pub fn staging_config() -> Result<ChainSpec, EnvVarReadError> {
+pub fn staging_config() -> Result<ChainSpec, envy::Error> {
 	Ok(ChainSpec::builder(runtime_wasm(), None)
 		.with_name("Staging")
 		.with_id("staging")
@@ -126,7 +126,7 @@ pub fn staging_genesis(
 	root_key: Option<AccountId>,
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
-) -> Result<serde_json::Value, EnvVarReadError> {
+) -> Result<serde_json::Value, envy::Error> {
 	let config = RuntimeGenesisConfig {
 		system: SystemConfig { ..Default::default() },
 		balances: BalancesConfig {
@@ -149,13 +149,7 @@ pub fn staging_genesis(
 				.collect(),
 		},
 		sidechain: SidechainConfig {
-			params: SidechainParams {
-				chain_id: from_var_or("CHAIN_ID", 1)?,
-				threshold_numerator: from_var_or("THRESHOLD_NUMERATOR", 2)?,
-				threshold_denominator: from_var_or("THRESHOLD_DENOMINATOR", 3)?,
-				genesis_committee_utxo: from_var::<UtxoId>("GENESIS_COMMITTEE_UTXO")?,
-				governance_authority: from_var::<MainchainAddressHash>("GOVERNANCE_AUTHORITY")?,
-			},
+			params: SidechainParams::read_from_env_with_defaults()?,
 			..Default::default()
 		},
 		polkadot_session_stub_for_grandpa: Default::default(),
@@ -164,10 +158,10 @@ pub fn staging_genesis(
 				.into_iter()
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
-			main_chain_scripts: read_mainchain_scripts_from_env()?,
+			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: read_native_token_main_chain_scripts_from_env()?,
+			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()?,
 			..Default::default()
 		},
 	};

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -26,7 +26,7 @@ pub fn authority_keys(
 	AuthorityKeys { session: session_keys, cross_chain: sidechain_pk.try_into().unwrap() }
 }
 
-pub fn development_config() -> Result<ChainSpec, EnvVarReadError> {
+pub fn development_config() -> Result<ChainSpec, envy::Error> {
 	Ok(ChainSpec::builder(runtime_wasm(), None)
 		.with_name("Development")
 		.with_id("dev")
@@ -142,7 +142,7 @@ pub fn testnet_sudo_key() -> AccountId {
 	)
 }
 
-pub fn local_testnet_config() -> Result<ChainSpec, EnvVarReadError> {
+pub fn local_testnet_config() -> Result<ChainSpec, envy::Error> {
 	Ok(ChainSpec::builder(runtime_wasm(), None)
 		.with_name("Local Testnet")
 		.with_id("local_testnet")
@@ -165,7 +165,7 @@ pub fn testnet_genesis(
 	root_key: Option<AccountId>,
 	endowed_accounts: Vec<AccountId>,
 	_enable_println: bool,
-) -> Result<serde_json::Value, EnvVarReadError> {
+) -> Result<serde_json::Value, envy::Error> {
 	let config = RuntimeGenesisConfig {
 		system: SystemConfig { ..Default::default() },
 		balances: BalancesConfig {
@@ -188,14 +188,8 @@ pub fn testnet_genesis(
 				.collect(),
 		},
 		sidechain: SidechainConfig {
-			params: SidechainParams {
-				chain_id: from_var_or("CHAIN_ID", 1)?,
-				threshold_numerator: from_var_or("THRESHOLD_NUMERATOR", 2)?,
-				threshold_denominator: from_var_or("THRESHOLD_DENOMINATOR", 3)?,
-				genesis_committee_utxo: from_var::<UtxoId>("GENESIS_COMMITTEE_UTXO")?,
-				governance_authority: from_var::<MainchainAddressHash>("GOVERNANCE_AUTHORITY")?,
-			},
-			slots_per_epoch: SlotsPerEpoch(from_var_or("SLOTS_PER_EPOCH", 60)?),
+			params: SidechainParams::read_from_env_with_defaults().unwrap(),
+			slots_per_epoch: SlotsPerEpoch::read_from_env().unwrap(),
 			..Default::default()
 		},
 		polkadot_session_stub_for_grandpa: Default::default(),
@@ -204,10 +198,12 @@ pub fn testnet_genesis(
 				.into_iter()
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
-			main_chain_scripts: read_mainchain_scripts_from_env()?,
+			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()
+				.unwrap(),
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: read_native_token_main_chain_scripts_from_env()?,
+			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()
+				.unwrap(),
 			..Default::default()
 		},
 	};

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -188,8 +188,8 @@ pub fn testnet_genesis(
 				.collect(),
 		},
 		sidechain: SidechainConfig {
-			params: SidechainParams::read_from_env_with_defaults().unwrap(),
-			slots_per_epoch: SlotsPerEpoch::read_from_env().unwrap(),
+			params: SidechainParams::read_from_env_with_defaults()?,
+			slots_per_epoch: SlotsPerEpoch::read_from_env()?,
 			..Default::default()
 		},
 		polkadot_session_stub_for_grandpa: Default::default(),
@@ -198,12 +198,10 @@ pub fn testnet_genesis(
 				.into_iter()
 				.map(|keys| (keys.cross_chain, keys.session))
 				.collect(),
-			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()
-				.unwrap(),
+			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()
-				.unwrap(),
+			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()?,
 			..Default::default()
 		},
 	};

--- a/node/src/tests/runtime_api_mock.rs
+++ b/node/src/tests/runtime_api_mock.rs
@@ -85,8 +85,8 @@ sp_api::mock_impl_runtime_apis! {
 		fn get_main_chain_scripts() -> sp_session_validator_management::MainChainScripts {
 			sp_session_validator_management::MainChainScripts {
 				committee_candidate_address: MainchainAddress::default(),
-				d_parameter_policy: PolicyId::default(),
-				permissioned_candidates_policy: PolicyId::default(),
+				d_parameter_policy_id: PolicyId::default(),
+				permissioned_candidates_policy_id: PolicyId::default(),
 			}
 		}
 	}
@@ -94,9 +94,9 @@ sp_api::mock_impl_runtime_apis! {
 	impl sp_native_token_management::NativeTokenManagementApi<Block> for TestApi {
 		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
 			sp_native_token_management::MainChainScripts {
-				native_token_policy: Default::default(),
+				native_token_policy_id: Default::default(),
 				native_token_asset_name: Default::default(),
-				illiquid_supply_address: Default::default(),
+				illiquid_supply_validator_address: Default::default(),
 
 			}
 		}

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -148,15 +148,15 @@ pub mod pallet {
 		#[pallet::weight((1, DispatchClass::Normal))]
 		pub fn set_main_chain_scripts(
 			origin: OriginFor<T>,
-			native_token_policy: PolicyId,
+			native_token_policy_id: PolicyId,
 			native_token_asset_name: AssetName,
-			illiquid_supply_address: MainchainAddress,
+			illiquid_supply_validator_address: MainchainAddress,
 		) -> DispatchResult {
 			ensure_root(origin)?;
 			let new_scripts = sp_native_token_management::MainChainScripts {
-				native_token_policy,
+				native_token_policy_id,
 				native_token_asset_name,
-				illiquid_supply_address,
+				illiquid_supply_validator_address,
 			};
 			MainChainScriptsConfiguration::<T>::put(new_scripts);
 			Ok(())

--- a/primitives/authority-selection-inherents/src/authority_selection_inputs.rs
+++ b/primitives/authority-selection-inherents/src/authority_selection_inputs.rs
@@ -43,15 +43,15 @@ impl AuthoritySelectionInputs {
 		let ariadne_parameters_response = candidate_data_source
 			.get_ariadne_parameters(
 				for_epoch,
-				scripts.d_parameter_policy.clone(),
-				scripts.permissioned_candidates_policy.clone(),
+				scripts.d_parameter_policy_id.clone(),
+				scripts.permissioned_candidates_policy_id.clone(),
 			)
 			.await
 			.map_err(|err| {
 				AuthoritySelectionInputsCreationError::AriadneParametersQuery(
 					for_epoch,
-					scripts.d_parameter_policy,
-					scripts.permissioned_candidates_policy,
+					scripts.d_parameter_policy_id,
+					scripts.permissioned_candidates_policy_id,
 					err,
 				)
 			})?;

--- a/primitives/authority-selection-inherents/src/runtime_api_mock.rs
+++ b/primitives/authority-selection-inherents/src/runtime_api_mock.rs
@@ -40,8 +40,8 @@ sp_api::mock_impl_runtime_apis! {
 		fn get_main_chain_scripts() -> MainChainScripts {
 			MainChainScripts {
 				committee_candidate_address: MainchainAddress::default(),
-				d_parameter_policy: PolicyId::default(),
-				permissioned_candidates_policy: PolicyId::default(),
+				d_parameter_policy_id: PolicyId::default(),
+				permissioned_candidates_policy_id: PolicyId::default(),
 			}
 		}
 	}

--- a/primitives/chain-params/Cargo.toml
+++ b/primitives/chain-params/Cargo.toml
@@ -13,6 +13,7 @@ plutus-datum-derive = { workspace = true }
 scale-info = { workspace = true }
 serde = { workspace = true, optional = true }
 hex-literal = { workspace = true }
+envy = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -22,6 +23,7 @@ std = [
 	"parity-scale-codec/std",
 	"scale-info/std",
 	"sidechain-domain/std",
+	"envy"
 ]
 serde = [
 	"dep:serde",

--- a/primitives/chain-params/src/lib.rs
+++ b/primitives/chain-params/src/lib.rs
@@ -49,6 +49,19 @@ pub fn default_denominator() -> u64 {
 #[cfg(feature = "std")]
 impl SidechainParams {
 	pub fn read_from_env_with_defaults() -> Result<Self, envy::Error> {
+		/// This structure is needed to read sidechain params from the environment variables because the main
+		/// type uses `rename_all = "camelCase"` serde option
+		#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+		struct SidechainParamsEnvConfiguration {
+			#[serde(default = "default_chain_id")]
+			pub chain_id: u16,
+			pub genesis_committee_utxo: UtxoId,
+			#[serde(default = "default_numerator")]
+			pub threshold_numerator: u64,
+			#[serde(default = "default_denominator")]
+			pub threshold_denominator: u64,
+			pub governance_authority: MainchainAddressHash,
+		}
 		let raw = envy::from_env::<SidechainParamsEnvConfiguration>()?;
 		Ok(Self {
 			chain_id: raw.chain_id,
@@ -58,19 +71,4 @@ impl SidechainParams {
 			governance_authority: raw.governance_authority,
 		})
 	}
-}
-
-/// This structure is needed to read sidechain params from the environment variables because the main
-/// type uses `rename_all = "camelCase"` serde option
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-#[cfg(feature = "std")]
-struct SidechainParamsEnvConfiguration {
-	#[serde(default = "default_chain_id")]
-	pub chain_id: u16,
-	pub genesis_committee_utxo: UtxoId,
-	#[serde(default = "default_numerator")]
-	pub threshold_numerator: u64,
-	#[serde(default = "default_denominator")]
-	pub threshold_denominator: u64,
-	pub governance_authority: MainchainAddressHash,
 }

--- a/primitives/chain-params/src/lib.rs
+++ b/primitives/chain-params/src/lib.rs
@@ -35,3 +35,42 @@ pub struct SidechainParams {
 	#[cfg_attr(feature = "std", arg(long))]
 	pub governance_authority: MainchainAddressHash,
 }
+
+pub fn default_chain_id() -> u16 {
+	1
+}
+pub fn default_numerator() -> u64 {
+	2
+}
+pub fn default_denominator() -> u64 {
+	3
+}
+
+#[cfg(feature = "std")]
+impl SidechainParams {
+	pub fn read_from_env_with_defaults() -> Result<Self, envy::Error> {
+		let raw = envy::from_env::<SidechainParamsEnvConfiguration>()?;
+		Ok(Self {
+			chain_id: raw.chain_id,
+			genesis_committee_utxo: raw.genesis_committee_utxo,
+			threshold_numerator: raw.threshold_numerator,
+			threshold_denominator: raw.threshold_denominator,
+			governance_authority: raw.governance_authority,
+		})
+	}
+}
+
+/// This structure is needed to read sidechain params from the environment variables because the main
+/// type uses `rename_all = "camelCase"` serde option
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg(feature = "std")]
+struct SidechainParamsEnvConfiguration {
+	#[serde(default = "default_chain_id")]
+	pub chain_id: u16,
+	pub genesis_committee_utxo: UtxoId,
+	#[serde(default = "default_numerator")]
+	pub threshold_numerator: u64,
+	#[serde(default = "default_denominator")]
+	pub threshold_denominator: u64,
+	pub governance_authority: MainchainAddressHash,
+}

--- a/primitives/native-token-management/Cargo.toml
+++ b/primitives/native-token-management/Cargo.toml
@@ -8,6 +8,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
 async-trait = { workspace = true, optional = true }
+envy = { workspace = true, optional = true }
 main-chain-follower-api = { workspace = true, optional = true, features = ["native-token"] }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
@@ -36,7 +37,8 @@ std = [
     "sp-blockchain",
     "sp-inherents/std",
     "sp-runtime/std",
-    "thiserror"
+    "thiserror",
+    "envy"
 ]
 serde = [
 	"dep:serde",

--- a/primitives/session-validator-management/Cargo.toml
+++ b/primitives/session-validator-management/Cargo.toml
@@ -17,6 +17,7 @@ sp-inherents = { workspace = true }
 sp-std = { workspace = true }
 sp-runtime = { workspace = true }
 thiserror = { workspace = true, optional = true }
+envy = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -28,7 +29,8 @@ std = [
     "sp-inherents/std",
     "sp-std/std",
     "sp-runtime/std",
-    "thiserror"
+    "thiserror",
+    "envy"
 ]
 serde = [
 	"dep:serde",

--- a/primitives/session-validator-management/query/src/lib.rs
+++ b/primitives/session-validator-management/query/src/lib.rs
@@ -167,8 +167,8 @@ where
 			.candidate_data_source
 			.get_ariadne_parameters(
 				epoch_number,
-				scripts.d_parameter_policy,
-				scripts.permissioned_candidates_policy,
+				scripts.d_parameter_policy_id,
+				scripts.permissioned_candidates_policy_id,
 			)
 			.await
 			.map_err(err_debug)?;

--- a/primitives/session-validator-management/src/lib.rs
+++ b/primitives/session-validator-management/src/lib.rs
@@ -59,11 +59,10 @@ impl MainChainScripts {
 			committee_candidate_address,
 			d_parameter_policy_id,
 			permissioned_candidates_policy_id,
-		} = envy::from_env::<MainChainScriptsEnvConfig>().unwrap();
+		} = envy::from_env::<MainChainScriptsEnvConfig>()?;
 
 		let committee_candidate_address = FromStr::from_str(&committee_candidate_address)
-			.map_err(|err| envy::Error::Custom(format!("Incorrect main chain address: {}", err)))
-			.unwrap();
+			.map_err(|err| envy::Error::Custom(format!("Incorrect main chain address: {}", err)))?;
 
 		Ok(Self {
 			committee_candidate_address,

--- a/primitives/session-validator-management/src/lib.rs
+++ b/primitives/session-validator-management/src/lib.rs
@@ -1,5 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
+use core::str::FromStr;
+
 use scale_info::TypeInfo;
 use sidechain_domain::{MainchainAddress, PolicyId};
 use sp_core::{Decode, Encode, MaxEncodedLen};
@@ -39,8 +41,36 @@ impl From<InherentError> for sp_inherents::Error {
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MainChainScripts {
 	pub committee_candidate_address: MainchainAddress,
-	pub d_parameter_policy: PolicyId,
-	pub permissioned_candidates_policy: PolicyId,
+	pub d_parameter_policy_id: PolicyId,
+	pub permissioned_candidates_policy_id: PolicyId,
+}
+
+#[cfg(feature = "std")]
+impl MainChainScripts {
+	pub fn read_from_env() -> Result<MainChainScripts, envy::Error> {
+		#[derive(serde::Serialize, serde::Deserialize)]
+		pub struct MainChainScriptsEnvConfig {
+			pub committee_candidate_address: String,
+			pub d_parameter_policy_id: PolicyId,
+			pub permissioned_candidates_policy_id: PolicyId,
+		}
+
+		let MainChainScriptsEnvConfig {
+			committee_candidate_address,
+			d_parameter_policy_id,
+			permissioned_candidates_policy_id,
+		} = envy::from_env::<MainChainScriptsEnvConfig>().unwrap();
+
+		let committee_candidate_address = FromStr::from_str(&committee_candidate_address)
+			.map_err(|err| envy::Error::Custom(format!("Incorrect main chain address: {}", err)))
+			.unwrap();
+
+		Ok(Self {
+			committee_candidate_address,
+			d_parameter_policy_id,
+			permissioned_candidates_policy_id,
+		})
+	}
 }
 
 sp_api::decl_runtime_apis! {

--- a/primitives/sidechain-slots/Cargo.toml
+++ b/primitives/sidechain-slots/Cargo.toml
@@ -18,6 +18,7 @@ sp-runtime = { workspace = true }
 sp-core = { workspace = true, features = ["serde"]}
 sp-consensus-slots = { workspace = true }
 serde = { workspace = true, optional = true }
+envy = { workspace = true, optional = true }
 
 [dev-dependencies]
 proptest = { workspace = true }
@@ -31,6 +32,7 @@ std = [
 	'sp-blockchain',
     'sp-core/std',
     'sp-consensus-slots/std',
+    'envy'
 ]
 serde = [
     "dep:serde",

--- a/primitives/sidechain-slots/src/lib.rs
+++ b/primitives/sidechain-slots/src/lib.rs
@@ -15,12 +15,6 @@ use sp_core::offchain::Timestamp;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SlotsPerEpoch(pub u32);
 
-#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-struct SlotsPerEpochEnvConfig {
-	#[cfg_attr(feature = "serde", serde(default = "default_slots_per_epoch"))]
-	slots_per_epoch: u32,
-}
-
 pub fn default_slots_per_epoch() -> u32 {
 	60
 }
@@ -35,6 +29,12 @@ impl Default for SlotsPerEpoch {
 impl SlotsPerEpoch {
 	#[cfg(feature = "std")]
 	pub fn read_from_env() -> Result<Self, envy::Error> {
+		#[derive(Serialize, Deserialize)]
+		struct SlotsPerEpochEnvConfig {
+			#[serde(default = "default_slots_per_epoch")]
+			slots_per_epoch: u32,
+		}
+
 		let raw = envy::from_env::<SlotsPerEpochEnvConfig>()?;
 		Ok(Self(raw.slots_per_epoch))
 	}

--- a/primitives/sidechain-slots/src/lib.rs
+++ b/primitives/sidechain-slots/src/lib.rs
@@ -15,6 +15,16 @@ use sp_core::offchain::Timestamp;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct SlotsPerEpoch(pub u32);
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+struct SlotsPerEpochEnvConfig {
+	#[cfg_attr(feature = "serde", serde(default = "default_slots_per_epoch"))]
+	slots_per_epoch: u32,
+}
+
+pub fn default_slots_per_epoch() -> u32 {
+	60
+}
+
 impl Default for SlotsPerEpoch {
 	/// Set to 60 to maintain backwards compatibility with existing chains.
 	fn default() -> Self {
@@ -23,6 +33,12 @@ impl Default for SlotsPerEpoch {
 }
 
 impl SlotsPerEpoch {
+	#[cfg(feature = "std")]
+	pub fn read_from_env() -> Result<Self, envy::Error> {
+		let raw = envy::from_env::<SlotsPerEpochEnvConfig>()?;
+		Ok(Self(raw.slots_per_epoch))
+	}
+
 	pub fn epoch_number(&self, slot: Slot) -> ScEpochNumber {
 		epoch_number(slot, self.0)
 	}


### PR DESCRIPTION
# Description

Moves logic that reads from the environment:
- sidechain params
- selection MC scripts
- native token MC scripts

to their respective crates

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

