### PR TITLE
feat: move partner chains session pallet from polkadot-sdk fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2522,7 +2522,7 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 [[package]]
 name = "fork-tree"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
 ]
@@ -2555,7 +2555,7 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 [[package]]
 name = "frame-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "frame-benchmarking-cli"
 version = "42.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "Inflector",
  "array-bytes",
@@ -2629,7 +2629,7 @@ dependencies = [
 [[package]]
 name = "frame-executive"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "aquamarine",
  "frame-support",
@@ -2659,7 +2659,7 @@ dependencies = [
 [[package]]
 name = "frame-metadata-hash-extension"
 version = "0.5.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "docify",
@@ -2674,7 +2674,7 @@ dependencies = [
 [[package]]
 name = "frame-support"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "aquamarine",
  "array-bytes",
@@ -2715,7 +2715,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural"
 version = "30.0.2"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -2734,7 +2734,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support-procedural-tools-derive",
  "proc-macro-crate 3.1.0",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "frame-support-procedural-tools-derive"
 version = "12.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2756,7 +2756,7 @@ dependencies = [
 [[package]]
 name = "frame-system"
 version = "37.1.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "cfg-if",
  "docify",
@@ -2776,7 +2776,7 @@ dependencies = [
 [[package]]
 name = "frame-system-benchmarking"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -2790,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "frame-system-rpc-runtime-api"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "parity-scale-codec",
@@ -2800,7 +2800,7 @@ dependencies = [
 [[package]]
 name = "frame-try-runtime"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -5616,7 +5616,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "pallet-aura"
 version = "36.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5632,7 +5632,7 @@ dependencies = [
 [[package]]
 name = "pallet-authorship"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5645,7 +5645,7 @@ dependencies = [
 [[package]]
 name = "pallet-babe"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5668,7 +5668,7 @@ dependencies = [
 [[package]]
 name = "pallet-balances"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5699,7 +5699,7 @@ dependencies = [
 [[package]]
 name = "pallet-grandpa"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -5713,7 +5713,6 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core",
  "sp-io",
- "sp-partner-chains-session",
  "sp-runtime",
  "sp-session",
  "sp-staking",
@@ -5735,8 +5734,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-partner-chains-session"
-version = "1.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+version = "1.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5746,7 +5744,6 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core",
- "sp-partner-chains-session",
  "sp-runtime",
  "sp-staking",
  "sp-std",
@@ -5755,7 +5752,7 @@ dependencies = [
 [[package]]
 name = "pallet-session"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5771,6 +5768,17 @@ dependencies = [
  "sp-staking",
  "sp-state-machine",
  "sp-trie",
+]
+
+[[package]]
+name = "pallet-session-runtime-stub"
+version = "1.1.0"
+dependencies = [
+ "pallet-partner-chains-session",
+ "pallet-session",
+ "sp-runtime",
+ "sp-staking",
+ "sp-std",
 ]
 
 [[package]]
@@ -5873,7 +5881,7 @@ dependencies = [
 [[package]]
 name = "pallet-sudo"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5888,7 +5896,7 @@ dependencies = [
 [[package]]
 name = "pallet-timestamp"
 version = "36.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -5907,7 +5915,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -5922,7 +5930,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc"
 version = "40.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -5938,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7616,7 +7624,7 @@ dependencies = [
 [[package]]
 name = "sc-allocator"
 version = "29.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "log",
  "sp-core",
@@ -7627,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "sc-basic-authorship"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "futures",
  "futures-timer",
@@ -7649,7 +7657,7 @@ dependencies = [
 [[package]]
 name = "sc-block-builder"
 version = "0.42.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7664,7 +7672,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "docify",
@@ -7691,7 +7699,7 @@ dependencies = [
 [[package]]
 name = "sc-chain-spec-derive"
 version = "12.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -7702,7 +7710,7 @@ dependencies = [
 [[package]]
 name = "sc-cli"
 version = "0.46.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "chrono",
@@ -7743,7 +7751,7 @@ dependencies = [
 [[package]]
 name = "sc-client-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "fnv",
  "futures",
@@ -7770,7 +7778,7 @@ dependencies = [
 [[package]]
 name = "sc-client-db"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -7796,7 +7804,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -7820,7 +7828,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-aura"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -7849,7 +7857,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa"
 version = "0.29.1"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "ahash",
  "array-bytes",
@@ -7893,7 +7901,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-grandpa-rpc"
 version = "0.29.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "finality-grandpa",
  "futures",
@@ -7913,7 +7921,7 @@ dependencies = [
 [[package]]
 name = "sc-consensus-slots"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -7936,7 +7944,7 @@ dependencies = [
 [[package]]
 name = "sc-executor"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -7959,7 +7967,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-common"
 version = "0.35.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "polkavm",
  "sc-allocator",
@@ -7972,7 +7980,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-polkavm"
 version = "0.32.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "log",
  "polkavm",
@@ -7983,7 +7991,7 @@ dependencies = [
 [[package]]
 name = "sc-executor-wasmtime"
 version = "0.35.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -8001,7 +8009,7 @@ dependencies = [
 [[package]]
 name = "sc-informant"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "ansi_term",
  "futures",
@@ -8018,7 +8026,7 @@ dependencies = [
 [[package]]
 name = "sc-keystore"
 version = "33.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "parking_lot 0.12.3",
@@ -8032,7 +8040,7 @@ dependencies = [
 [[package]]
 name = "sc-mixnet"
 version = "0.14.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "arrayvec",
@@ -8061,7 +8069,7 @@ dependencies = [
 [[package]]
 name = "sc-network"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8112,7 +8120,7 @@ dependencies = [
 [[package]]
 name = "sc-network-common"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -8130,7 +8138,7 @@ dependencies = [
 [[package]]
 name = "sc-network-gossip"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "ahash",
  "futures",
@@ -8149,7 +8157,7 @@ dependencies = [
 [[package]]
 name = "sc-network-light"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8170,7 +8178,7 @@ dependencies = [
 [[package]]
 name = "sc-network-sync"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "async-channel",
@@ -8207,7 +8215,7 @@ dependencies = [
 [[package]]
 name = "sc-network-test"
 version = "0.8.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -8239,7 +8247,7 @@ dependencies = [
 [[package]]
 name = "sc-network-transactions"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8258,7 +8266,7 @@ dependencies = [
 [[package]]
 name = "sc-network-types"
 version = "0.12.1"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "bs58 0.5.1",
  "ed25519-dalek",
@@ -8275,7 +8283,7 @@ dependencies = [
 [[package]]
 name = "sc-offchain"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "bytes",
@@ -8348,7 +8356,7 @@ dependencies = [
 [[package]]
 name = "sc-proposer-metrics"
 version = "0.18.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "log",
  "substrate-prometheus-endpoint",
@@ -8357,7 +8365,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "futures",
  "jsonrpsee",
@@ -8389,7 +8397,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-api"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -8409,7 +8417,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-server"
 version = "16.0.2"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "forwarded-header-value",
  "futures",
@@ -8431,7 +8439,7 @@ dependencies = [
 [[package]]
 name = "sc-rpc-spec-v2"
 version = "0.44.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "futures",
@@ -8463,7 +8471,7 @@ dependencies = [
 [[package]]
 name = "sc-service"
 version = "0.45.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "directories",
@@ -8527,7 +8535,7 @@ dependencies = [
 [[package]]
 name = "sc-state-db"
 version = "0.36.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -8538,7 +8546,7 @@ dependencies = [
 [[package]]
 name = "sc-sysinfo"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "derive_more",
  "futures",
@@ -8559,7 +8567,7 @@ dependencies = [
 [[package]]
 name = "sc-telemetry"
 version = "24.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "chrono",
  "futures",
@@ -8579,7 +8587,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -8609,7 +8617,7 @@ dependencies = [
 [[package]]
 name = "sc-tracing-proc-macro"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "proc-macro-crate 3.1.0",
  "proc-macro2",
@@ -8620,7 +8628,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -8647,7 +8655,7 @@ dependencies = [
 [[package]]
 name = "sc-transaction-pool-api"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -8663,7 +8671,7 @@ dependencies = [
 [[package]]
 name = "sc-utils"
 version = "17.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-channel",
  "futures",
@@ -9039,6 +9047,7 @@ dependencies = [
  "frame-system",
  "log",
  "pallet-partner-chains-session",
+ "pallet-session",
  "pallet-session-validator-management",
  "pallet-sidechain",
  "sidechain-domain",
@@ -9213,6 +9222,8 @@ dependencies = [
  "pallet-grandpa",
  "pallet-native-token-management",
  "pallet-partner-chains-session",
+ "pallet-session",
+ "pallet-session-runtime-stub",
  "pallet-session-validator-management",
  "pallet-session-validator-management-benchmarking",
  "pallet-sidechain",
@@ -9241,7 +9252,6 @@ dependencies = [
  "sp-keyring",
  "sp-native-token-management",
  "sp-offchain",
- "sp-partner-chains-session",
  "sp-runtime",
  "sp-session",
  "sp-session-validator-management",
@@ -9428,7 +9438,7 @@ dependencies = [
 [[package]]
 name = "sp-api"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "hash-db",
@@ -9450,7 +9460,7 @@ dependencies = [
 [[package]]
 name = "sp-api-proc-macro"
 version = "20.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "Inflector",
  "blake2 0.10.6",
@@ -9464,7 +9474,7 @@ dependencies = [
 [[package]]
 name = "sp-application-crypto"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9476,7 +9486,7 @@ dependencies = [
 [[package]]
 name = "sp-arithmetic"
 version = "26.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -9490,7 +9500,7 @@ dependencies = [
 [[package]]
 name = "sp-block-builder"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -9513,7 +9523,7 @@ dependencies = [
 [[package]]
 name = "sp-blockchain"
 version = "37.0.1"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "futures",
  "parity-scale-codec",
@@ -9532,7 +9542,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "futures",
@@ -9547,7 +9557,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-aura"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9563,7 +9573,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-babe"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -9581,7 +9591,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-grandpa"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -9598,7 +9608,7 @@ dependencies = [
 [[package]]
 name = "sp-consensus-slots"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9609,7 +9619,7 @@ dependencies = [
 [[package]]
 name = "sp-core"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "bitflags 1.3.2",
@@ -9655,7 +9665,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -9668,7 +9678,7 @@ dependencies = [
 [[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
@@ -9678,7 +9688,7 @@ dependencies = [
 [[package]]
 name = "sp-database"
 version = "10.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "kvdb",
  "parking_lot 0.12.3",
@@ -9687,7 +9697,7 @@ dependencies = [
 [[package]]
 name = "sp-debug-derive"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9697,7 +9707,7 @@ dependencies = [
 [[package]]
 name = "sp-externalities"
 version = "0.29.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -9707,7 +9717,7 @@ dependencies = [
 [[package]]
 name = "sp-genesis-builder"
 version = "0.15.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9719,7 +9729,7 @@ dependencies = [
 [[package]]
 name = "sp-inherents"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -9732,7 +9742,7 @@ dependencies = [
 [[package]]
 name = "sp-io"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "bytes",
  "docify",
@@ -9758,7 +9768,7 @@ dependencies = [
 [[package]]
 name = "sp-keyring"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "sp-core",
  "sp-runtime",
@@ -9768,7 +9778,7 @@ dependencies = [
 [[package]]
 name = "sp-keystore"
 version = "0.40.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.3",
@@ -9779,7 +9789,7 @@ dependencies = [
 [[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "thiserror",
  "zstd 0.12.4",
@@ -9788,7 +9798,7 @@ dependencies = [
 [[package]]
 name = "sp-metadata-ir"
 version = "0.7.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "frame-metadata",
  "parity-scale-codec",
@@ -9798,7 +9808,7 @@ dependencies = [
 [[package]]
 name = "sp-mixnet"
 version = "0.12.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -9828,7 +9838,7 @@ dependencies = [
 [[package]]
 name = "sp-offchain"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -9838,7 +9848,7 @@ dependencies = [
 [[package]]
 name = "sp-panic-handler"
 version = "13.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "backtrace",
  "lazy_static",
@@ -9858,17 +9868,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-partner-chains-session"
-version = "4.0.0-dev"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
-dependencies = [
- "sp-staking",
-]
-
-[[package]]
 name = "sp-rpc"
 version = "32.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -9878,7 +9880,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime"
 version = "39.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "either",
@@ -9904,7 +9906,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface"
 version = "28.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -9923,7 +9925,7 @@ dependencies = [
 [[package]]
 name = "sp-runtime-interface-proc-macro"
 version = "18.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "Inflector",
  "expander",
@@ -9936,7 +9938,7 @@ dependencies = [
 [[package]]
 name = "sp-session"
 version = "35.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -10010,7 +10012,7 @@ dependencies = [
 [[package]]
 name = "sp-staking"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -10023,7 +10025,7 @@ dependencies = [
 [[package]]
 name = "sp-state-machine"
 version = "0.43.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "hash-db",
  "log",
@@ -10043,7 +10045,7 @@ dependencies = [
 [[package]]
 name = "sp-statement-store"
 version = "18.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "aes-gcm",
  "curve25519-dalek",
@@ -10067,12 +10069,12 @@ dependencies = [
 [[package]]
 name = "sp-std"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 
 [[package]]
 name = "sp-storage"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10084,7 +10086,7 @@ dependencies = [
 [[package]]
 name = "sp-timestamp"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10096,7 +10098,7 @@ dependencies = [
 [[package]]
 name = "sp-tracing"
 version = "17.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -10107,7 +10109,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-pool"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -10116,7 +10118,7 @@ dependencies = [
 [[package]]
 name = "sp-transaction-storage-proof"
 version = "34.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -10130,7 +10132,7 @@ dependencies = [
 [[package]]
 name = "sp-trie"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "ahash",
  "hash-db",
@@ -10153,7 +10155,7 @@ dependencies = [
 [[package]]
 name = "sp-version"
 version = "37.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -10170,7 +10172,7 @@ dependencies = [
 [[package]]
 name = "sp-version-proc-macro"
 version = "14.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "parity-scale-codec",
  "proc-macro2",
@@ -10181,7 +10183,7 @@ dependencies = [
 [[package]]
 name = "sp-wasm-interface"
 version = "21.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "anyhow",
  "impl-trait-for-tuples",
@@ -10193,7 +10195,7 @@ dependencies = [
 [[package]]
 name = "sp-weights"
 version = "31.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -10595,7 +10597,7 @@ dependencies = [
 [[package]]
 name = "substrate-bip39"
 version = "0.6.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
@@ -10607,12 +10609,12 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 
 [[package]]
 name = "substrate-frame-rpc-system"
 version = "38.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "docify",
  "frame-system-rpc-runtime-api",
@@ -10632,7 +10634,7 @@ dependencies = [
 [[package]]
 name = "substrate-prometheus-endpoint"
 version = "0.17.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "http-body-util",
  "hyper 1.4.1",
@@ -10646,7 +10648,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-client"
 version = "2.0.1"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "async-trait",
@@ -10673,7 +10675,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime"
 version = "2.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "frame-executive",
@@ -10717,7 +10719,7 @@ dependencies = [
 [[package]]
 name = "substrate-test-runtime-client"
 version = "2.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "futures",
  "sc-block-builder",
@@ -10735,7 +10737,7 @@ dependencies = [
 [[package]]
 name = "substrate-wasm-builder"
 version = "24.0.0"
-source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-revert-changes-1#0b623e702cabe4b006e6a80e2cf3f5d02f632d06"
+source = "git+https://github.com/input-output-hk/polkadot-sdk.git?tag=partnerchains-stable-2407-1-v2#36f90afb8724528f5150d97059ca506c5fb53403"
 dependencies = [
  "array-bytes",
  "build-helper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,8 @@ members = [
 	"client/consensus/aura",
     "node",
 	"pallets/block-rewards",
+	"pallets/pallet-session-runtime-stub",
+	"pallets/partner-chains-session",
 	"pallets/sidechain",
 	"pallets/sidechain/rpc",
     "pallets/session-validator-management",
@@ -100,76 +102,75 @@ inquire = { version = "0.7.5" }
 parking_lot = { version = "0.12.1", default-features = false }
 
 # substrate dependencies
-frame-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-benchmarking-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-executive = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-support = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-system-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-frame-try-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-balances = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-sudo = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-transaction-payment = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-pallet-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-basic-authorship = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-client-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-client-db = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-consensus-grandpa-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-executor = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-network = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-network-test = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-rpc-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-service = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-telemetry = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-transaction-pool-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sc-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-application-crypto = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-blockchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-core = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-crypto-hashing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-inherents = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-io = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-keyring = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-tracing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-partner-chains-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-staking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-std = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-version = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-storage = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-weights = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-substrate-build-script-utils = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-substrate-frame-rpc-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-substrate-test-runtime-client = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-substrate-wasm-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
-sp-genesis-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-revert-changes-1" }
+frame-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-benchmarking-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-executive = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-support = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-system-benchmarking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-system-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+frame-try-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-balances = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-sudo = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-transaction-payment = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-transaction-payment-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-basic-authorship = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-cli = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-client-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-client-db = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-consensus-grandpa-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-executor = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-network = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-network-test = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-rpc = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-rpc-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-service = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-telemetry = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-transaction-pool-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sc-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-api = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-application-crypto = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-block-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-blockchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-consensus = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-consensus-aura = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-consensus-grandpa = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-consensus-slots = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-core = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-crypto-hashing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-inherents = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-io = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-keyring = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-keystore = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-offchain = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-runtime = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-session = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-tracing = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-staking = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-std = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-timestamp = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-transaction-pool = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-version = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-storage = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-weights = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+substrate-build-script-utils = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+substrate-frame-rpc-system = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+substrate-test-runtime-client = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+substrate-wasm-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
+sp-genesis-builder = { default-features = false, git = "https://github.com/input-output-hk/polkadot-sdk.git", tag ="partnerchains-stable-2407-1-v2" }
 
 # local dependencies
 sidechain-runtime = { path = "runtime" }
@@ -206,3 +207,5 @@ pallet-native-token-management = { path = "pallets/native-token-management", def
 sp-native-token-management = { path = "primitives/native-token-management", default-features = false }
 sc-partner-chains-consensus-aura = { path = "client/consensus/aura", default-features = false }
 sp-partner-chains-consensus-aura = { path = "primitives/consensus/aura", default-features = false }
+pallet-partner-chains-session = { path = "pallets/partner-chains-session", default-features = false }
+pallet-session-runtime-stub = { path = "pallets/pallet-session-runtime-stub", default-features = false }

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 * moved out some cli related code from `node` crate, in order to require less copy-paste in users nodes
 * removed USE_CHAIN_INIT code. Migration strategy is to remove copy-pasted and adapted code. It will not compile with vanilla polkadot-sdk, that we plan to use in future.
+* moved `pallet-partner-chains-session` from polkadot-sdk fork to this repository. Node uses vanilla grandpa and aura consensus now. No migration is needed.
 * moved `sc-consensus-aura` from input-output-hk/polkadot-sdk fork to this repository,
   to `sc-partner-chains-consensus-aura` and `sp-partner-chains-consensus-aura`.
   This change requires migration of the node, PartnerChainsProposerFactory has to be used.

--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -158,6 +158,7 @@ pub fn staging_genesis(
 			},
 			..Default::default()
 		},
+		polkadot_session_stub_for_grandpa: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -39,6 +39,7 @@ pub fn chain_spec() -> Result<ChainSpec, EnvVarReadError> {
 			},
 			..Default::default()
 		},
+		polkadot_session_stub_for_grandpa: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			// Same as SessionConfig
 			initial_authorities: vec![],

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -198,6 +198,7 @@ pub fn testnet_genesis(
 			slots_per_epoch: SlotsPerEpoch(from_var_or("SLOTS_PER_EPOCH", 60)?),
 			..Default::default()
 		},
+		polkadot_session_stub_for_grandpa: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()

--- a/pallets/pallet-session-runtime-stub/Cargo.toml
+++ b/pallets/pallet-session-runtime-stub/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "pallet-session-runtime-stub"
+version = "1.1.0"
+description = "Runtime implementations for polkadot-sdk pallet-session when pallet-partner-chains-session is used"
+edition = "2021"
+license = "Apache-2.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+pallet-partner-chains-session = { workspace = true }
+pallet-session = { workspace = true }
+sp-runtime = { workspace = true }
+sp-staking = { workspace = true }
+sp-std = {workspace = true}
+
+[features]
+default = [ "std" ]
+
+std = [
+	"pallet-partner-chains-session/std",
+	"pallet-session/std",
+	"sp-runtime/std",
+	"sp-staking/std",
+	"sp-std/std"
+]

--- a/pallets/pallet-session-runtime-stub/src/lib.rs
+++ b/pallets/pallet-session-runtime-stub/src/lib.rs
@@ -1,0 +1,51 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use sp_staking::SessionIndex;
+use sp_std::prelude::*;
+
+/// Use this when you need to have a pallet-session Config implemented in your runtime.
+pub struct PalletSessionStubImpls;
+
+impl<T> pallet_session::ShouldEndSession<T> for PalletSessionStubImpls {
+	fn should_end_session(_: T) -> bool {
+		false
+	}
+}
+
+impl<T> pallet_session::SessionManager<T> for PalletSessionStubImpls {
+	fn new_session(_: SessionIndex) -> Option<Vec<T>> {
+		None
+	}
+
+	fn end_session(_: SessionIndex) {}
+
+	fn start_session(_: SessionIndex) {}
+}
+
+impl<T> sp_runtime::traits::Convert<T, Option<T>> for PalletSessionStubImpls {
+	fn convert(t: T) -> Option<T> {
+		Some(t)
+	}
+}
+
+/// Macro to implement `pallet_session::Config`, using existing `pallet_partner_chains_session::Config
+/// Example usage: impl_pallet_session_config!(Runtime);
+#[macro_export]
+macro_rules! impl_pallet_session_config {
+	($type:ty) => {
+		impl pallet_session::Config for $type
+		where
+			$type: pallet_partner_chains_session::Config,
+		{
+			type RuntimeEvent = <$type as pallet_partner_chains_session::Config>::RuntimeEvent;
+			type ValidatorId = <$type as pallet_partner_chains_session::Config>::ValidatorId;
+			type ValidatorIdOf = pallet_session_runtime_stub::PalletSessionStubImpls;
+			type ShouldEndSession = pallet_session_runtime_stub::PalletSessionStubImpls;
+			type NextSessionRotation = ();
+			type SessionManager = pallet_session_runtime_stub::PalletSessionStubImpls;
+			type SessionHandler = <$type as pallet_partner_chains_session::Config>::SessionHandler;
+			type Keys = <$type as pallet_partner_chains_session::Config>::Keys;
+			type WeightInfo = ();
+		}
+	};
+}

--- a/pallets/partner-chains-session/Cargo.toml
+++ b/pallets/partner-chains-session/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "pallet-partner-chains-session"
+version = "1.1.0"
+description = "FRAME pallet for setting validators with InherentData and session management"
+edition = "2021"
+license = "Apache-2.0"
+
+[package.metadata.docs.rs]
+targets = ["x86_64-unknown-linux-gnu"]
+
+[dependencies]
+parity-scale-codec = { workspace = true, features = ["derive"] }
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+impl-trait-for-tuples = "0.2.2"
+log = { workspace = true }
+pallet-timestamp = { workspace = true }
+scale-info = { workspace = true, features = ["derive", "serde"] }
+sp-core = { workspace = true, features = ["serde"] }
+sp-runtime = { workspace = true, features = ["serde"] }
+sp-staking = { workspace = true, features = ["serde"] }
+sp-std = { workspace = true }
+
+[features]
+default = ["std", "polkadot-js-compat"]
+std = [
+	"parity-scale-codec/std",
+	"frame-support/std",
+	"frame-system/std",
+	"log/std",
+	"scale-info/std",
+	"sp-core/std",
+	"sp-runtime/std",
+	"sp-staking/std",
+	"sp-std/std",
+]
+polkadot-js-compat = []

--- a/pallets/partner-chains-session/src/lib.rs
+++ b/pallets/partner-chains-session/src/lib.rs
@@ -1,0 +1,525 @@
+// This file was copied from substrate/frame/session/src/lib.rs in polkadot-sdk repository and heavily modified.
+// Modifications can be seen by comparing the two files.
+
+// Copyright (C) Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: Apache-2.0
+
+// Additional modifications by Input Output Global, Inc.
+// Copyright (C) 2024, Input Output Global, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! # Session Pallet
+//!
+//! The Session pallet allows validators to manage their session keys, provides a function for
+//! changing the session length, and handles session rotation.
+//!
+//! - [`Config`]
+//! - [`Call`]
+//! - [`Pallet`]
+//!
+//! ## Overview
+//!
+//! ### Terminology
+//! <!-- Original author of paragraph: @gavofyork -->
+//!
+//! - **Session:** A session is a period of time that has a constant set of validators. Validators
+//!   can only join or exit the validator set at a session change. It is measured in block numbers.
+//!   The block where a session is ended is determined by the `ShouldEndSession` trait. When the
+//!   session is ending, a new validator set can be chosen by `OnSessionEnding` implementations.
+//!
+//! - **Session key:** A session key is actually several keys kept together that provide the various
+//!   signing functions required by network authorities/validators in pursuit of their duties.
+//! - **Validator ID:** Every account has an associated validator ID. For some simple staking
+//!   systems, this may just be the same as the account ID. For staking systems using a
+//!   stash/controller model, the validator ID would be the stash account ID of the controller.
+//!
+//! - **Session key configuration process:** Session keys are set using `set_keys` for use not in
+//!   the next session, but the session after next. They are stored in `NextKeys`, a mapping between
+//!   the caller's `ValidatorId` and the session keys provided. `set_keys` allows users to set their
+//!   session key prior to being selected as validator. It is a public call since it uses
+//!   `ensure_signed`, which checks that the origin is a signed account. As such, the account ID of
+//!   the origin stored in `NextKeys` may not necessarily be associated with a block author or a
+//!   validator. The session keys of accounts are removed once their account balance is zero.
+//!
+//! - **Session length:** This pallet does not assume anything about the length of each session.
+//!   Rather, it relies on an implementation of `ShouldEndSession` to dictate a new session's start.
+//!   This pallet provides the `PeriodicSessions` struct for simple periodic sessions.
+//!
+//! - **Session rotation configuration:** Configure as either a 'normal' (rewardable session where
+//!   rewards are applied) or 'exceptional' (slashable) session rotation.
+//!
+//! - **Session rotation process:** At the beginning of each block, the `on_initialize` function
+//!   queries the provided implementation of `ShouldEndSession`. If the session is to end the newly
+//!   activated validator IDs and session keys are taken from storage and passed to the
+//!   `SessionHandler`. The validator set supplied by `SessionManager::new_session` and the
+//!   corresponding session keys, which may have been registered via `set_keys` during the previous
+//!   session, are written to storage where they will wait one session before being passed to the
+//!   `SessionHandler` themselves.
+//!
+//! ### Goals
+//!
+//! The Session pallet is designed to make the following possible:
+//!
+//! - Set session keys of the validator set for upcoming sessions.
+//! - Control the length of sessions.
+//! - Configure and switch between either normal or exceptional session rotations.
+//!
+//! ## Interface
+//!
+//!
+//! ### Public Functions
+//!
+//! - `rotate_session` - Change to the next session. Register the new authority set.
+//! - `disable_index` - Disable a validator by index.
+//! - `disable` - Disable a validator by Validator ID
+//!
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::collections::BTreeSet;
+use frame_support::{
+	traits::{
+		EstimateNextNewSession, EstimateNextSessionRotation, OneSessionHandler,
+		ValidatorRegistration,
+	},
+	weights::Weight,
+};
+use frame_system::pallet_prelude::BlockNumberFor;
+use frame_system::DecRefStatus;
+pub use pallet::*;
+use sp_runtime::{traits::OpaqueKeys, DispatchError, KeyTypeId, RuntimeAppPublic};
+use sp_staking::SessionIndex;
+use sp_std::prelude::*;
+
+/// Decides whether the session should be ended.
+pub trait ShouldEndSession<BlockNumber> {
+	/// Return `true` if the session should be ended.
+	fn should_end_session(now: BlockNumber) -> bool;
+}
+
+/// A trait for managing creation of new validator set.
+pub trait SessionManager<ValidatorId, Keys> {
+	/// Plan a new session, and optionally provide the new validator set.
+	///
+	/// Even if the validator-set is the same as before, if any underlying economic conditions have
+	/// changed (i.e. stake-weights), the new validator set must be returned. This is necessary for
+	/// consensus engines making use of the session pallet to issue a validator-set change so
+	/// misbehavior can be provably associated with the new economic conditions as opposed to the
+	/// old. The returned validator set, if any, will not be applied until `new_index`. `new_index`
+	/// is strictly greater than from previous call.
+	///
+	/// The first session start at index 0.
+	///
+	/// `new_session(session)` is guaranteed to be called before `end_session(session-1)`. In other
+	/// words, a new session must always be planned before an ongoing one can be finished.
+	fn new_session(new_index: SessionIndex) -> Option<Vec<(ValidatorId, Keys)>>;
+	/// Same as `new_session`, but it this should only be called at genesis.
+	///
+	/// The session manager might decide to treat this in a different way. Default impl is simply
+	/// using [`new_session`](Self::new_session).
+	fn new_session_genesis(new_index: SessionIndex) -> Option<Vec<(ValidatorId, Keys)>> {
+		Self::new_session(new_index)
+	}
+	/// End the session.
+	///
+	/// Because the session pallet can queue validator set the ending session can be lower than the
+	/// last new session index.
+	fn end_session(end_index: SessionIndex);
+	/// Start an already planned session.
+	///
+	/// The session start to be used for validation.
+	fn start_session(start_index: SessionIndex);
+}
+
+impl<A, B> SessionManager<A, B> for () {
+	fn new_session(_: SessionIndex) -> Option<Vec<(A, B)>> {
+		None
+	}
+	fn start_session(_: SessionIndex) {}
+	fn end_session(_: SessionIndex) {}
+}
+
+/// Handler for session life cycle events.
+pub trait SessionHandler<ValidatorId> {
+	/// All the key type ids this session handler can process.
+	///
+	/// The order must be the same as it expects them in
+	/// [`on_new_session`](Self::on_new_session<Ks>) and
+	/// [`on_genesis_session`](Self::on_genesis_session<Ks>).
+	const KEY_TYPE_IDS: &'static [KeyTypeId];
+
+	/// The given validator set will be used for the genesis session.
+	/// It is guaranteed that the given validator set will also be used
+	/// for the second session, therefore the first call to `on_new_session`
+	/// should provide the same validator set.
+	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(ValidatorId, Ks)]);
+
+	/// Session set has changed; act appropriately. Note that this can be called
+	/// before initialization of your pallet.
+	///
+	/// `changed` is true whenever any of the session keys or underlying economic
+	/// identities or weightings behind those keys has changed.
+	fn on_new_session<Ks: OpaqueKeys>(
+		changed: bool,
+		validators: &[(ValidatorId, Ks)],
+		queued_validators: &[(ValidatorId, Ks)],
+	);
+
+	/// A notification for end of the session.
+	///
+	/// Note it is triggered before any [`SessionManager::end_session`] handlers,
+	/// so we can still affect the validator set.
+	fn on_before_session_ending() {}
+
+	/// A validator got disabled. Act accordingly until a new session begins.
+	fn on_disabled(validator_index: u32);
+}
+
+#[impl_trait_for_tuples::impl_for_tuples(1, 30)]
+#[tuple_types_custom_trait_bound(OneSessionHandler<AId>)]
+impl<AId> SessionHandler<AId> for Tuple {
+	for_tuples!(
+		const KEY_TYPE_IDS: &'static [KeyTypeId] = &[ #( <Tuple::Key as RuntimeAppPublic>::ID ),* ];
+	);
+
+	fn on_genesis_session<Ks: OpaqueKeys>(validators: &[(AId, Ks)]) {
+		for_tuples!(
+			#(
+				let our_keys: Box<dyn Iterator<Item=_>> = Box::new(validators.iter()
+					.filter_map(|k|
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					)
+				);
+
+				Tuple::on_genesis_session(our_keys);
+			)*
+		)
+	}
+
+	fn on_new_session<Ks: OpaqueKeys>(
+		changed: bool,
+		validators: &[(AId, Ks)],
+		queued_validators: &[(AId, Ks)],
+	) {
+		for_tuples!(
+			#(
+				let our_keys: Box<dyn Iterator<Item=_>> = Box::new(validators.iter()
+					.filter_map(|k|
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					));
+				let queued_keys: Box<dyn Iterator<Item=_>> = Box::new(queued_validators.iter()
+					.filter_map(|k|
+						k.1.get::<Tuple::Key>(<Tuple::Key as RuntimeAppPublic>::ID).map(|k1| (&k.0, k1))
+					));
+				Tuple::on_new_session(changed, our_keys, queued_keys);
+			)*
+		)
+	}
+
+	fn on_before_session_ending() {
+		for_tuples!( #( Tuple::on_before_session_ending(); )* )
+	}
+
+	fn on_disabled(i: u32) {
+		for_tuples!( #( Tuple::on_disabled(i); )* )
+	}
+}
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+
+	/// The current storage version.
+	const STORAGE_VERSION: StorageVersion = StorageVersion::new(0);
+
+	#[pallet::pallet]
+	#[pallet::storage_version(STORAGE_VERSION)]
+	#[pallet::without_storage_info]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// The overarching event type.
+		type RuntimeEvent: From<Event> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+		/// A stable ID for a validator.
+		type ValidatorId: Member
+			+ Parameter
+			+ MaybeSerializeDeserialize
+			+ MaxEncodedLen
+			+ Into<Self::AccountId>;
+
+		/// Indicator for when to end the session.
+		type ShouldEndSession: ShouldEndSession<BlockNumberFor<Self>>;
+
+		/// Something that can predict the next session rotation. This should typically come from
+		/// the same logical unit that provides [`ShouldEndSession`], yet, it gives a best effort
+		/// estimate. It is helpful to implement [`EstimateNextNewSession`].
+		type NextSessionRotation: EstimateNextSessionRotation<BlockNumberFor<Self>>;
+
+		/// Handler for managing new session.
+		type SessionManager: SessionManager<Self::ValidatorId, Self::Keys>;
+
+		/// Handler when a session has changed.
+		type SessionHandler: SessionHandler<Self::ValidatorId>;
+
+		/// The keys.
+		type Keys: OpaqueKeys + Member + Parameter + MaybeSerializeDeserialize;
+	}
+
+	pub type ValidatorList<T> = Vec<<T as Config>::ValidatorId>;
+	pub type ValidatorAndKeysList<T> = Vec<(<T as Config>::ValidatorId, <T as Config>::Keys)>;
+
+	#[pallet::genesis_config]
+	#[derive(frame_support::DefaultNoBound)]
+	pub struct GenesisConfig<T: Config> {
+		pub initial_validators: ValidatorAndKeysList<T>,
+	}
+
+	#[pallet::genesis_build]
+	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
+		fn build(&self) {
+			if T::SessionHandler::KEY_TYPE_IDS.len() != T::Keys::key_ids().len() {
+				panic!("Number of keys in session handler and session keys does not match");
+			}
+
+			T::SessionHandler::KEY_TYPE_IDS
+				.iter()
+				.zip(T::Keys::key_ids())
+				.enumerate()
+				.for_each(|(i, (sk, kk))| {
+					if sk != kk {
+						panic!(
+							"Session handler and session key expect different key type at index: {}",
+							i,
+						);
+					}
+				});
+
+			let maybe_genesis_validators = Pallet::<T>::new_session_genesis(0);
+			let initial_validators = match &maybe_genesis_validators {
+				Some(validators) => validators,
+				None => {
+					frame_support::print(
+						"No initial validator provided by `SessionManager`, use \
+						session config keys to generate initial validator set.",
+					);
+					&self.initial_validators
+				},
+			};
+			Pallet::<T>::rotate_validators(initial_validators);
+			T::SessionHandler::on_genesis_session::<T::Keys>(initial_validators);
+			T::SessionManager::start_session(0);
+		}
+	}
+
+	#[pallet::storage]
+	// This storage is only needed to keep compatibility with Polkadot.js
+	pub type Validators<T: Config> = StorageValue<_, ValidatorList<T>, ValueQuery>;
+
+	#[pallet::storage]
+	pub type ValidatorsAndKeys<T: Config> = StorageValue<_, ValidatorAndKeysList<T>, ValueQuery>;
+
+	/// Current index of the session.
+	#[pallet::storage]
+	pub type CurrentIndex<T> = StorageValue<_, SessionIndex, ValueQuery>;
+
+	/// Indices of disabled validators.
+	///
+	/// The vec is always kept sorted so that we can find whether a given validator is
+	/// disabled using binary search. It gets cleared when `on_session_ending` returns
+	/// a new set of identities.
+	#[pallet::storage]
+	pub type DisabledValidators<T> = StorageValue<_, Vec<u32>, ValueQuery>;
+
+	#[pallet::event]
+	#[pallet::generate_deposit(pub(super) fn deposit_event)]
+	pub enum Event {
+		/// New session has happened. Note that the argument is the session index, not the
+		/// block number as the type might suggest.
+		NewSession { session_index: SessionIndex },
+	}
+
+	#[pallet::hooks]
+	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
+		/// Called when a block is initialized. Will rotate session if it is the last
+		/// block of the current session.
+		fn on_initialize(n: BlockNumberFor<T>) -> Weight {
+			if T::ShouldEndSession::should_end_session(n) {
+				Self::rotate_session();
+				T::BlockWeights::get().max_block
+			} else {
+				// NOTE: the non-database part of the weight for `should_end_session(n)` is
+				// included as weight for empty block, the database part is expected to be in
+				// cache.
+				Weight::zero()
+			}
+		}
+	}
+}
+
+impl<T: Config> Pallet<T> {
+	/// Public function to access the current set of validators.
+	pub fn validators() -> Vec<T::ValidatorId> {
+		Validators::<T>::get()
+	}
+
+	pub fn validators_and_keys() -> Vec<(T::ValidatorId, T::Keys)> {
+		ValidatorsAndKeys::<T>::get()
+	}
+
+	/// Public function to access the current session index.
+	pub fn current_index() -> SessionIndex {
+		CurrentIndex::<T>::get()
+	}
+
+	/// Public function to access the disabled validators.
+	pub fn disabled_validators() -> Vec<u32> {
+		DisabledValidators::<T>::get()
+	}
+
+	/// Move on to next session. Register new validator set with session keys.
+	pub fn rotate_session() {
+		let session_index = <CurrentIndex<T>>::get();
+		log::trace!(target: "runtime::session", "rotating session {:?}", session_index);
+
+		T::SessionHandler::on_before_session_ending();
+		T::SessionManager::end_session(session_index);
+
+		let session_index = session_index + 1;
+		<CurrentIndex<T>>::put(session_index);
+
+		let (validators, changed) = if let Some(validators) = Self::new_session(session_index) {
+			Self::rotate_validators(&validators);
+			(validators, true)
+		} else {
+			(ValidatorsAndKeys::<T>::get(), false)
+		};
+
+		T::SessionManager::start_session(session_index);
+		Self::deposit_event(Event::NewSession { session_index });
+		// TODO if possible, remove queued_validators from SessionHandler (both Aura and Grandpa aren't using them anyway)
+		T::SessionHandler::on_new_session::<T::Keys>(changed, validators.as_ref(), &[]);
+	}
+
+	/// Disable the validator of index `i`, returns `false` if the validator was already disabled.
+	pub fn disable_index(i: u32) -> bool {
+		if i >= Validators::<T>::decode_len().unwrap_or(0) as u32 {
+			return false;
+		}
+
+		<DisabledValidators<T>>::mutate(|disabled| {
+			if let Err(index) = disabled.binary_search(&i) {
+				disabled.insert(index, i);
+				T::SessionHandler::on_disabled(i);
+				return true;
+			}
+
+			false
+		})
+	}
+
+	/// Disable the validator identified by `c`. (If using with the staking pallet,
+	/// this would be their *stash* account.)
+	///
+	/// Returns `false` either if the validator could not be found or it was already
+	/// disabled.
+	pub fn disable(c: &T::ValidatorId) -> bool {
+		ValidatorsAndKeys::<T>::get()
+			.iter()
+			.position(|(i, _)| i == c)
+			.map(|i| Self::disable_index(i as u32))
+			.unwrap_or(false)
+	}
+
+	pub fn acc_ids(validators: &[(T::ValidatorId, T::Keys)]) -> Vec<T::AccountId> {
+		validators.iter().map(|(v_id, _)| v_id.clone().into()).collect()
+	}
+	fn inc_provider(account: &T::AccountId) {
+		frame_system::Pallet::<T>::inc_providers(account);
+	}
+
+	fn dec_provider(account: &T::AccountId) -> Result<DecRefStatus, DispatchError> {
+		frame_system::Pallet::<T>::dec_providers(account)
+	}
+
+	fn change_account_providers(new_ids: &[T::AccountId], old_ids: &[T::AccountId]) {
+		let new_ids = BTreeSet::from_iter(new_ids);
+		let old_ids = BTreeSet::from_iter(old_ids);
+		let to_inc = new_ids.difference(&old_ids);
+		let to_dec = old_ids.difference(&new_ids);
+		for account in to_inc {
+			Self::inc_provider(account);
+		}
+		for account in to_dec {
+			Self::dec_provider(account).expect("We always match dec_providers with corresponding inc_providers, thus it cannot fail");
+		}
+	}
+
+	fn rotate_validators(new_validators: &ValidatorAndKeysList<T>) {
+		ValidatorsAndKeys::<T>::put(new_validators);
+		#[cfg(feature = "polkadot-js-compat")]
+		{
+			let validator_ids: Vec<_> = new_validators.iter().cloned().map(|v| v.0).collect();
+			// This storage is not used for chain operation but is required by
+			// Polkadot.js to show block producers in the explorer
+			Validators::<T>::put(validator_ids);
+		}
+		Self::change_account_providers(
+			&Self::acc_ids(new_validators),
+			&Self::acc_ids(&ValidatorsAndKeys::<T>::get()),
+		);
+		<DisabledValidators<T>>::take();
+	}
+
+	pub fn new_session(index: SessionIndex) -> Option<ValidatorAndKeysList<T>> {
+		let validators = T::SessionManager::new_session(index)?;
+		Some(validators)
+	}
+
+	pub fn new_session_genesis(index: SessionIndex) -> Option<ValidatorAndKeysList<T>> {
+		let validators = T::SessionManager::new_session_genesis(index)?;
+		Some(validators)
+	}
+}
+
+impl<T: Config> ValidatorRegistration<T::ValidatorId> for Pallet<T> {
+	fn is_registered(id: &T::ValidatorId) -> bool {
+		ValidatorsAndKeys::<T>::get().iter().any(|(vid, _)| vid == id)
+	}
+}
+
+impl<T: Config> EstimateNextNewSession<BlockNumberFor<T>> for Pallet<T> {
+	fn average_session_length() -> BlockNumberFor<T> {
+		T::NextSessionRotation::average_session_length()
+	}
+
+	/// This session pallet always calls new_session and next_session at the same time, hence we
+	/// do a simple proxy and pass the function to next rotation.
+	fn estimate_next_new_session(now: BlockNumberFor<T>) -> (Option<BlockNumberFor<T>>, Weight) {
+		T::NextSessionRotation::estimate_next_session_rotation(now)
+	}
+}
+
+impl<T: Config> frame_support::traits::DisabledValidators for Pallet<T> {
+	fn is_disabled(index: u32) -> bool {
+		DisabledValidators::<T>::get().binary_search(&index).is_ok()
+	}
+
+	fn disabled_validators() -> Vec<u32> {
+		DisabledValidators::<T>::get()
+	}
+}

--- a/primitives/session-manager/Cargo.toml
+++ b/primitives/session-manager/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 derive-new = { workspace = true }
 frame-system = { workspace = true }
 log = { workspace = true }
+pallet-session = { workspace = true }
 pallet-session-validator-management = { workspace = true }
 pallet-sidechain = { workspace = true }
 pallet-partner-chains-session = { workspace = true }

--- a/primitives/session-manager/src/lib.rs
+++ b/primitives/session-manager/src/lib.rs
@@ -13,7 +13,7 @@ pub struct ValidatorManagementSessionManager<T> {
 }
 
 /// SessionManager, which takes committee from pallet_session_validator_management.
-impl<T: pallet_session_validator_management::Config>
+impl<T: pallet_session_validator_management::Config + pallet_session::Config>
 	pallet_partner_chains_session::SessionManager<T::AccountId, T::AuthorityKeys>
 	for ValidatorManagementSessionManager<T>
 {
@@ -33,6 +33,7 @@ impl<T: pallet_session_validator_management::Config>
 	// important programming errors.
 	fn new_session(new_index: SessionIndex) -> Option<Vec<(T::AccountId, T::AuthorityKeys)>> {
 		info!("New session {new_index}");
+		pallet_session::pallet::CurrentIndex::<T>::put(new_index);
 		Some(
 			pallet_session_validator_management::Pallet::<T>::rotate_committee_to_next_epoch()
 				.expect(

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -21,6 +21,7 @@ pallet-balances = { workspace = true }
 frame-support = { workspace = true }
 pallet-grandpa = { workspace = true }
 pallet-partner-chains-session = { workspace = true }
+pallet-session = { workspace = true }
 pallet-sudo = { workspace = true }
 frame-system = { workspace = true }
 frame-try-runtime = { workspace = true, optional = true }
@@ -38,7 +39,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-partner-chains-session = { workspace = true }
 sp-staking = { workspace = true }
 sp-std = { workspace = true }
 sp-transaction-pool = { workspace = true }
@@ -72,6 +72,7 @@ sidechain-slots = { workspace = true }
 session-manager = { workspace = true }
 pallet-native-token-management = { workspace = true }
 sp-native-token-management = { workspace = true, features = ["serde"] }
+pallet-session-runtime-stub = { workspace = true, default-features = false }
 
 [dev-dependencies]
 sp-io = { workspace = true }
@@ -128,7 +129,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-partner-chains-session/std",
 	"sp-staking/std",
 	"sp-std/std",
 	"sp-transaction-pool/std",
@@ -143,7 +143,8 @@ std = [
 	"sp-inherents/std",
 	"chain-params/std",
 	"pallet-native-token-management/std",
-	"sp-native-token-management/std"
+	"sp-native-token-management/std",
+	"pallet-session-runtime-stub/std",
 ]
 
 runtime-benchmarks = [

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -502,7 +502,7 @@ construct_runtime!(
 		// Partner Chains session_manager ValidatorManagementSessionManager write to this storage.
 		// It is wired in by pallet_partner_chains_session.
 		PolkadotSessionStubForGrandpa: pallet_session,
-		// The order matters!! pallet_partner_chains_session needs to come last for correct initialization order,
+		// The order matters!! pallet_partner_chains_session needs to come last for correct initialization order
 		Session: pallet_partner_chains_session,
 		NativeTokenManagement: pallet_native_token_management,
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -499,7 +499,7 @@ construct_runtime!(
 		BlockRewards: pallet_block_rewards,
 		// pallet_grandpa depends on pallet_session CurrentIndex storage.
 		// Only stub implementation of pallet_session should be wired.
-		// Partner Chains session_manager ValidatorManagementSessionManager write to this storage.
+		// Partner Chains session_manager ValidatorManagementSessionManager writes to this storage.
 		// It is wired in by pallet_partner_chains_session.
 		PolkadotSessionStubForGrandpa: pallet_session,
 		// The order matters!! pallet_partner_chains_session needs to come last for correct initialization order

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -47,7 +47,6 @@ use sidechain_domain::{
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_partner_chains_session::CurrentSessionIndex;
 #[cfg(any(feature = "std", test))]
 pub use sp_runtime::BuildStorage;
 use sp_runtime::DispatchResult;
@@ -62,7 +61,6 @@ use sp_runtime::{
 };
 pub use sp_runtime::{Perbill, Permill};
 use sp_sidechain::SidechainStatus;
-use sp_staking::SessionIndex;
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -354,6 +352,8 @@ impl pallet_aura::Config for Runtime {
 	type SlotDuration = ConstU64<SLOT_DURATION>;
 }
 
+pallet_session_runtime_stub::impl_pallet_session_config!(Runtime);
+
 impl pallet_grandpa::Config for Runtime {
 	type RuntimeEvent = RuntimeEvent;
 
@@ -422,12 +422,6 @@ impl pallet_partner_chains_session::Config for Runtime {
 	type SessionManager = ValidatorManagementSessionManager<Runtime>;
 	type SessionHandler = <opaque::SessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = opaque::SessionKeys;
-}
-
-impl CurrentSessionIndex for Runtime {
-	fn current_session_index() -> SessionIndex {
-		Session::current_index()
-	}
 }
 
 parameter_types! {
@@ -503,7 +497,12 @@ construct_runtime!(
 		Sidechain: pallet_sidechain,
 		SessionCommitteeManagement: pallet_session_validator_management,
 		BlockRewards: pallet_block_rewards,
-		// The order matters!! Session pallet needs to come last for correct initialization order
+		// pallet_grandpa depends on pallet_session CurrentIndex storage.
+		// Only stub implementation of pallet_session should be wired.
+		// Partner Chains session_manager ValidatorManagementSessionManager write to this storage.
+		// It is wired in by pallet_partner_chains_session.
+		PolkadotSessionStubForGrandpa: pallet_session,
+		// The order matters!! pallet_partner_chains_session needs to come last for correct initialization order,
 		Session: pallet_partner_chains_session,
 		NativeTokenManagement: pallet_native_token_management,
 	}

--- a/runtime/src/mock.rs
+++ b/runtime/src/mock.rs
@@ -44,6 +44,7 @@ frame_support::construct_runtime!(
 		Aura: pallet_aura,
 		Grandpa: pallet_grandpa,
 		Balances: pallet_balances,
+		Session0: pallet_session,
 		Session: pallet_partner_chains_session,
 	}
 );
@@ -102,8 +103,6 @@ impl pallet_balances::Config for Test {
 }
 
 use sp_consensus_aura::AURA_ENGINE_ID;
-use sp_partner_chains_session::CurrentSessionIndex;
-use sp_staking::SessionIndex;
 
 pub const SLOTS_PER_EPOCH: u32 = 7;
 
@@ -122,6 +121,8 @@ impl From<(sr25519::Public, ed25519::Public)> for TestSessionKeys {
 	}
 }
 
+pallet_session_runtime_stub::impl_pallet_session_config!(Test);
+
 impl pallet_partner_chains_session::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type ValidatorId = <Self as frame_system::Config>::AccountId;
@@ -130,12 +131,6 @@ impl pallet_partner_chains_session::Config for Test {
 	type SessionManager = ValidatorManagementSessionManager<Test>;
 	type SessionHandler = <TestSessionKeys as OpaqueKeys>::KeyTypeIdProviders;
 	type Keys = TestSessionKeys;
-}
-
-impl CurrentSessionIndex for Test {
-	fn current_session_index() -> SessionIndex {
-		Session::current_index()
-	}
 }
 
 impl pallet_sidechain::Config for Test {

--- a/runtime/src/mock.rs
+++ b/runtime/src/mock.rs
@@ -44,7 +44,7 @@ frame_support::construct_runtime!(
 		Aura: pallet_aura,
 		Grandpa: pallet_grandpa,
 		Balances: pallet_balances,
-		Session0: pallet_session,
+		PolkadotSessionStubForGrandpa: pallet_session,
 		Session: pallet_partner_chains_session,
 	}
 );


### PR DESCRIPTION
# Description

Changes:
* depends on polkadot-sdk with removed partner chains session and grandpa modifications
* moved the partner-chains-session
* NOT moved sp-partner-chains-session, because it was only providing CurrentSessionIndex that was only used by modified grandpa, so it was not used anymore
* added pallet-session-runtime-stub and used it in runtime wiring - this is the new code and area where I need your critique the most

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
~- [ ] New tests are added if needed and existing tests are updated.~ Only moved meaningful code.
~- [ ] Relevant logging and metrics added~
- [x] CI passes. See note on CI.
~- [ ] Any changes are noted in the `changelog.md` for affected crate ~ - I'll update global changelog when the code is approved
- [x] Self-reviewed the diff


