### PR TITLE
fix: native token inherent check when no tokens transfered

### DIFF
--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -115,6 +115,7 @@ pub mod pallet {
 
 		fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			Ok(Self::get_transfered_tokens_from_inherent_data(data)
+				.filter(|data| data.token_amount.0 > 0)
 				.map(|data| InherentError::TokenTransferNotHandled(data.token_amount.clone())))
 		}
 	}

--- a/pallets/native-token-management/src/tests.rs
+++ b/pallets/native-token-management/src/tests.rs
@@ -76,7 +76,7 @@ mod is_inherent_required {
 	use super::*;
 
 	#[test]
-	fn yes_when_data_present() {
+	fn yes_when_nonzero_data_present() {
 		new_test_ext().execute_with(|| {
 			let inherent_data = test_inherent_data(1001);
 			let error = NativeTokenManagement::is_inherent_required(&inherent_data)
@@ -84,6 +84,17 @@ mod is_inherent_required {
 				.expect("Check should return an error object.");
 
 			assert_eq!(error, InherentError::TokenTransferNotHandled(1001.into()));
+		})
+	}
+
+	#[test]
+	fn no_when_data_present_but_is_zero() {
+		new_test_ext().execute_with(|| {
+			let inherent_data = test_inherent_data(0);
+			let error = NativeTokenManagement::is_inherent_required(&inherent_data)
+				.expect("Check should successfully run.");
+
+			assert_eq!(error, None);
 		})
 	}
 


### PR DESCRIPTION
# Description

Fixes the issue where `create_inherent` skips inherent creation when 0 tokens have been transfered, but `is_inherent_required` still expected an inherent to be present

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

