### PR TITLE
feat: remove env-var read from BlockDataSourceMock

### DIFF
--- a/mainchain-follower/mock/src/block.rs
+++ b/mainchain-follower/mock/src/block.rs
@@ -5,7 +5,10 @@ use main_chain_follower_api::*;
 use sidechain_domain::*;
 use std::env;
 
-pub struct BlockDataSourceMock;
+pub struct BlockDataSourceMock {
+	/// Duration of a mainchain epoch in milliseconds
+	mc_epoch_duration_millis: u32,
+}
 
 #[async_trait]
 impl BlockDataSource for BlockDataSourceMock {
@@ -22,7 +25,7 @@ impl BlockDataSource for BlockDataSourceMock {
 		reference_timestamp: Timestamp,
 	) -> Result<Option<MainchainBlock>> {
 		let block_number = (reference_timestamp.0 / 20000) as u32;
-		let epoch = block_number / BlockDataSourceMock::blocks_per_epoch();
+		let epoch = block_number / (self.mc_epoch_duration_millis / 20000);
 		let mut hash_arr = [0u8; 32];
 		hash_arr[..4].copy_from_slice(&block_number.to_be_bytes());
 		Ok(Some(MainchainBlock {
@@ -49,11 +52,5 @@ impl BlockDataSourceMock {
 			.duration_since(std::time::UNIX_EPOCH)
 			.unwrap()
 			.as_millis() as u64
-	}
-
-	fn blocks_per_epoch() -> u32 {
-		let val = env::var("MC__EPOCH_DURATION_MILLIS").unwrap();
-		let millis: u32 = val.parse().unwrap();
-		millis / 20000
 	}
 }

--- a/mainchain-follower/mock/src/block.rs
+++ b/mainchain-follower/mock/src/block.rs
@@ -25,7 +25,7 @@ impl BlockDataSource for BlockDataSourceMock {
 		reference_timestamp: Timestamp,
 	) -> Result<Option<MainchainBlock>> {
 		let block_number = (reference_timestamp.0 / 20000) as u32;
-		let epoch = block_number / (self.mc_epoch_duration_millis / 20000);
+		let epoch = block_number / self.block_per_epoch();
 		let mut hash_arr = [0u8; 32];
 		hash_arr[..4].copy_from_slice(&block_number.to_be_bytes());
 		Ok(Some(MainchainBlock {
@@ -47,6 +47,10 @@ impl BlockDataSource for BlockDataSourceMock {
 }
 
 impl BlockDataSourceMock {
+	fn block_per_epoch(&self) -> u32 {
+		self.mc_epoch_duration_millis / 20000
+	}
+
 	fn millis_now() -> u64 {
 		std::time::SystemTime::now()
 			.duration_since(std::time::UNIX_EPOCH)

--- a/mainchain-follower/mock/src/block.rs
+++ b/mainchain-follower/mock/src/block.rs
@@ -3,7 +3,6 @@ pub use main_chain_follower_api::block::*;
 use main_chain_follower_api::common::*;
 use main_chain_follower_api::*;
 use sidechain_domain::*;
-use std::env;
 
 pub struct BlockDataSourceMock {
 	/// Duration of a mainchain epoch in milliseconds
@@ -47,6 +46,10 @@ impl BlockDataSource for BlockDataSourceMock {
 }
 
 impl BlockDataSourceMock {
+	pub fn new(mc_epoch_duration_millis: u32) -> Self {
+		Self { mc_epoch_duration_millis }
+	}
+
 	fn block_per_epoch(&self) -> u32 {
 		self.mc_epoch_duration_millis / 20000
 	}

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -50,8 +50,13 @@ fn use_mock_follower() -> bool {
 
 pub fn create_mock_data_sources(
 ) -> std::result::Result<DataSources, Box<dyn Error + Send + Sync + 'static>> {
+	let mv_epoch_duration_millis: u32 = env::var("MC__EPOCH_DURATION_MILLIS")
+		.ok()
+		.and_then(|v| v.parse::<u32>().ok())
+		.unwrap();
+	let block_data_source_mock = BlockDataSourceMock::new(mc_epoch_duration_millis);
 	Ok(DataSources {
-		block: Arc::new(BlockDataSourceMock),
+		block: Arc::new(block_data_source_mock),
 		candidate: Arc::new(MockCandidateDataSource::from_env()?),
 		native_token: Arc::new(NativeTokenDataSourceMock::new()),
 	})

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -50,7 +50,7 @@ fn use_mock_follower() -> bool {
 
 pub fn create_mock_data_sources(
 ) -> std::result::Result<DataSources, Box<dyn Error + Send + Sync + 'static>> {
-	let mv_epoch_duration_millis: u32 = env::var("MC__EPOCH_DURATION_MILLIS")
+	let mc_epoch_duration_millis: u32 = std::env::var("MC__EPOCH_DURATION_MILLIS")
 		.ok()
 		.and_then(|v| v.parse::<u32>().ok())
 		.unwrap();


### PR DESCRIPTION
# Description

Removes the direct environment variable read in `BlockDataSourceMock`. This removes the requirement on the application level for setting an environment variable.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

