### PR TITLE
Bump cardano node to 9.1.1

### DIFF
--- a/dev/local-environment/setup.sh
+++ b/dev/local-environment/setup.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 PARTNER_CHAINS_NODE_IMAGE="ghcr.io/input-output-hk/partner-chains/partner-chains-node:v1.1.1-rc1"
-CARDANO_IMAGE="ghcr.io/intersectmbo/cardano-node:9.1.0"
-DBSYNC_IMAGE="ghcr.io/intersectmbo/cardano-db-sync:13.3.0.0"
+CARDANO_IMAGE="ghcr.io/intersectmbo/cardano-node:9.1.1"
+DBSYNC_IMAGE="ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2"
 KUPO_IMAGE="cardanosolutions/kupo:v2.9.0"
 OGMIOS_IMAGE="cardanosolutions/ogmios:v6.6.0"
 POSTGRES_IMAGE="postgres:15.3"

--- a/docker/sidechain-dependencies/docker-compose.yml
+++ b/docker/sidechain-dependencies/docker-compose.yml
@@ -9,7 +9,7 @@ volumes:
 
 services:
   cardano-node:
-    image: ghcr.io/intersectmbo/cardano-node:9.1.0
+    image: ghcr.io/intersectmbo/cardano-node:9.1.1
     network_mode: "host"
     container_name: sidechains-cardano-node
     environment:
@@ -37,7 +37,7 @@ services:
       retries: 5
 
   db-sync:
-    image: ghcr.io/intersectmbo/cardano-db-sync:13.3.0.0
+    image: ghcr.io/intersectmbo/cardano-db-sync:13.5.0.2
     container_name: sidechains-db-sync
     depends_on:
       postgres:

--- a/docs/user-guides/chain-builder.md
+++ b/docs/user-guides/chain-builder.md
@@ -7,8 +7,8 @@ Partner Chain builders are organizations that want to build their own blockchain
     1. Cardano node v9.1.1
         1. Ogmios v6.5.0
         2. Kupo - v2.9.0
-        3. DB Sync  v13.3.0.0 (PostgreSQLv15.3)
-    2. Download the partner chain node v1.0
+        3. DB Sync  v13.5.0.2 (PostgreSQLv15.3)
+    2. Download the partner chain node v1.1.0
 2. Run the generate-keys wizard
 3. Run the prepare-configuration wizard
     1. Set chain parameters
@@ -126,7 +126,7 @@ sudo systemctl start kupo.service
 
 Please refer to [Kupo](https://cardanosolutions.github.io/kupo/#section/Overview) for detailed instructions.
 
-### 1.1.3 Cardano DB Sync v13.3.0.0
+### 1.1.3 Cardano DB Sync v13.5.0.2
 
 The partner chain needs DB Sync on `cardano-node` to observe Cardano's state.
 

--- a/docs/user-guides/permissioned.md
+++ b/docs/user-guides/permissioned.md
@@ -8,8 +8,8 @@ Before you begin, some software must be installed.
 
 1. Install dependencies
     1. Cardano node v9.1.1
-        1. DB Sync v13.3.0.0 (PostgreSQL v15.3)
-2. Download the partner chain node v1.0
+        1. DB Sync v13.5.0.2 (PostgreSQL v15.3)
+2. Download the partner chain node v1.1.0
 3. Run the generate-keys wizard
 4. Share keys with the chain builder
 5. Obtain the chain configuration and specification files

--- a/docs/user-guides/registered.md
+++ b/docs/user-guides/registered.md
@@ -8,7 +8,7 @@ A registered block producer is a Cardano stake pool operator (SPO) that desires 
     1. Cardano node v9.1.1
         1. Ogmios v6.5.0
         2. Kupo - v2.9.0
-        3. Cardano DB Sync v13.3.0.0 (PostgreSQL v15.3)
+        3. Cardano DB Sync v13.5.0.2 (PostgreSQL v15.3)
     2. Download the partner chain node v1.0
 3. Run the generate-keys wizard
 4. Obtain chain parameters from the chain builder
@@ -130,7 +130,7 @@ sudo systemctl start kupo.service
 
 Please refer to [Kupo](https://cardanosolutions.github.io/kupo/#section/Overview) for detailed instructions.
 
-### 2.1.3 Cardano DB Sync v13.3.0.0
+### 2.1.3 Cardano DB Sync v13.5.0.2
 
 The partner chain needs DB Sync on a `cardano-node` to observe Cardano's state.
 

--- a/flake.lock
+++ b/flake.lock
@@ -27,7 +27,7 @@
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.3.0.0",
+        "ref": "13.5.0.2",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -61,7 +61,7 @@
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.1.0",
+        "ref": "9.1.1",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -29,11 +29,11 @@
       flake = false;
     };
     cardano-node = {
-      url = "github:IntersectMBO/cardano-node/9.1.0";
+      url = "github:IntersectMBO/cardano-node/9.1.1";
       flake = false;
     };
     cardano-dbsync = {
-      url = "github:IntersectMBO/cardano-db-sync/13.3.0.0";
+      url = "github:IntersectMBO/cardano-db-sync/13.5.0.2";
       flake = false;
     };
     cardano-nix = {

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -106,7 +106,7 @@
         pkgs = [
           {
             name = "cardano-cli";
-            help = "CLI v9.1.0 that is used in partner-chains dependency stack";
+            help = "CLI v9.1.1 that is used in partner-chains dependency stack";
             # This command has some eval because of IFD
             command = "${self'.packages.cardano-cli}/bin/cardano-cli $@";
           }


### PR DESCRIPTION
Bump dbsync to 15.3.0.2

# Description
 Cardano 9.1.1 has a hotfix for post Chang chains (doesn not require a db replay). I thought we should be up to date.
 Not sure dbsync is important to upgrade but why not? It works fine (passed all e2e tests on PC Local Env)

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

