### PR TITLE
change: better result and IO assertions in CLI tests

### DIFF
--- a/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -23,7 +23,7 @@ fn happy_path() {
 			show_outro(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -57,7 +57,7 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	result.expect_err("Expected the result to be an error");
+	result.expect_err("should return error");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -72,7 +72,7 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	result.expect_err("Expected the result to be an error");
+	result.expect_err("should return error");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -90,7 +90,7 @@ fn errors_if_chain_spec_is_missing() {
 			read_chain_spec_io(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	let err = result.expect_err("Expected the result to be an error");
+	let err = result.expect_err("should return error");
 	assert_eq!(
 		err.to_string(),
 		"Could not read chain-spec.json file. File is expected to exists.".to_string()
@@ -113,7 +113,7 @@ fn forwards_build_spec_error_if_it_fails() {
 			run_build_spec_io(Err(error)),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	let err = result.expect_err("Expected the result to be an error");
+	let err = result.expect_err("should return error");
 	assert_eq!(err.to_string(), "Failed miserably".to_string());
 	should_have_no_io_left!(mock_context);
 }

--- a/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
-use crate::tests::{MockIO, MockIOContext};
+use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
 use crate::{config, CmdRun};
 use anyhow::anyhow;
 use colored::Colorize;
@@ -23,8 +23,7 @@ fn happy_path() {
 			show_outro(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context)
 }
 
 #[test]
@@ -57,8 +56,7 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_err());
+	should_be_failure!(result, mock_context);
 }
 
 #[test]
@@ -72,8 +70,7 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_err());
+	should_be_failure!(result, mock_context);
 }
 
 #[test]
@@ -90,10 +87,9 @@ fn errors_if_chain_spec_is_missing() {
 			read_chain_spec_io(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_err());
+	let err = should_be_failure!(result, mock_context);
 	assert_eq!(
-		result.err().unwrap().to_string(),
+		err.to_string(),
 		"Could not read chain-spec.json file. File is expected to exists.".to_string()
 	);
 }
@@ -113,9 +109,8 @@ fn forwards_build_spec_error_if_it_fails() {
 			run_build_spec_io(Err(error)),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_err());
-	assert_eq!(result.err().unwrap().to_string(), "Failed miserably".to_string())
+	let err = should_be_failure!(result, mock_context);
+	assert_eq!(err.to_string(), "Failed miserably".to_string())
 }
 
 fn test_config_content() -> serde_json::Value {

--- a/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
-use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+use crate::tests::{MockIO, MockIOContext};
 use crate::{config, CmdRun};
 use anyhow::anyhow;
 use colored::Colorize;
@@ -24,7 +24,6 @@ fn happy_path() {
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -58,7 +57,6 @@ If you are a validator, you can obtain the chain configuration file from the gov
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
 	result.expect_err("should return error");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -73,7 +71,6 @@ If you are a validator, you can obtain the chain configuration file from the gov
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
 	result.expect_err("should return error");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -95,7 +92,6 @@ fn errors_if_chain_spec_is_missing() {
 		err.to_string(),
 		"Could not read chain-spec.json file. File is expected to exists.".to_string()
 	);
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -115,7 +111,6 @@ fn forwards_build_spec_error_if_it_fails() {
 	let result = CreateChainSpecCmd.run(&mock_context);
 	let err = result.expect_err("should return error");
 	assert_eq!(err.to_string(), "Failed miserably".to_string());
-	should_have_no_io_left!(mock_context);
 }
 
 fn test_config_content() -> serde_json::Value {

--- a/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,6 +1,6 @@
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
-use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
+use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 use crate::{config, CmdRun};
 use anyhow::anyhow;
 use colored::Colorize;
@@ -23,7 +23,8 @@ fn happy_path() {
 			show_outro(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	should_be_success!(result, mock_context)
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -56,7 +57,8 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	should_be_failure!(result, mock_context);
+	result.expect_err("Expected the result to be an error");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -70,7 +72,8 @@ If you are the governance authority, please make sure you have run the `prepare-
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	should_be_failure!(result, mock_context);
+	result.expect_err("Expected the result to be an error");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -87,11 +90,12 @@ fn errors_if_chain_spec_is_missing() {
 			read_chain_spec_io(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	let err = should_be_failure!(result, mock_context);
+	let err = result.expect_err("Expected the result to be an error");
 	assert_eq!(
 		err.to_string(),
 		"Could not read chain-spec.json file. File is expected to exists.".to_string()
 	);
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -109,8 +113,9 @@ fn forwards_build_spec_error_if_it_fails() {
 			run_build_spec_io(Err(error)),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
-	let err = should_be_failure!(result, mock_context);
-	assert_eq!(err.to_string(), "Failed miserably".to_string())
+	let err = result.expect_err("Expected the result to be an error");
+	assert_eq!(err.to_string(), "Failed miserably".to_string());
+	should_have_no_io_left!(mock_context);
 }
 
 fn test_config_content() -> serde_json::Value {

--- a/partner-chains-cli/src/generate_keys/tests.rs
+++ b/partner-chains-cli/src/generate_keys/tests.rs
@@ -181,7 +181,8 @@ fn happy_path() {
 
 	let result = GenerateKeysCmd {}.run(&mock_context);
 
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 mod config_read {
@@ -299,7 +300,8 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -324,7 +326,8 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 }
 

--- a/partner-chains-cli/src/generate_keys/tests.rs
+++ b/partner-chains-cli/src/generate_keys/tests.rs
@@ -181,9 +181,7 @@ fn happy_path() {
 
 	let result = GenerateKeysCmd {}.run(&mock_context);
 
-	mock_context.no_more_io_expected();
-
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context);
 }
 
 mod config_read {
@@ -199,7 +197,7 @@ mod config_read {
 
 		let result = GenerateKeysConfig::load(&context);
 
-		context.no_more_io_expected();
+		should_have_no_io_left!(context);
 
 		assert_eq!(result.chain_name, CHAIN_NAME);
 		assert_eq!(result.node_executable, EXECUTABLE_PATH);
@@ -227,7 +225,7 @@ mod config_read {
 
 		let result = GenerateKeysConfig::load(&context);
 
-		context.no_more_io_expected();
+		should_have_no_io_left!(context);
 
 		assert_eq!(result.chain_name, CHAIN_NAME);
 		assert_eq!(result.node_executable, EXECUTABLE_PATH);
@@ -301,9 +299,7 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -328,9 +324,7 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 }
 

--- a/partner-chains-cli/src/generate_keys/tests.rs
+++ b/partner-chains-cli/src/generate_keys/tests.rs
@@ -182,7 +182,6 @@ fn happy_path() {
 	let result = GenerateKeysCmd {}.run(&mock_context);
 
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 mod config_read {
@@ -197,8 +196,6 @@ mod config_read {
 			.with_expected_io(vec![scenarios::prompt_all_config_fields()]);
 
 		let result = GenerateKeysConfig::load(&context);
-
-		should_have_no_io_left!(context);
 
 		assert_eq!(result.chain_name, CHAIN_NAME);
 		assert_eq!(result.node_executable, EXECUTABLE_PATH);
@@ -226,8 +223,6 @@ mod config_read {
 
 		let result = GenerateKeysConfig::load(&context);
 
-		should_have_no_io_left!(context);
-
 		assert_eq!(result.chain_name, CHAIN_NAME);
 		assert_eq!(result.node_executable, EXECUTABLE_PATH);
 		assert_eq!(result.substrate_node_base_path, DATA_PATH);
@@ -235,15 +230,7 @@ mod config_read {
 
 	#[test]
 	fn verify_executable_returns_error_when_node_executable_missing() {
-		let context = MockIOContext::new().with_expected_io(vec![
-			MockIO::file_write_json(
-				RESOURCES_CONFIG_PATH,
-				serde_json::json!({
-				  "substrate_node_executable_path": "./partner-chains-node"
-				}),
-			),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
-		]);
+		let context = MockIOContext::new();
 
 		let result = verify_executable(&default_config(), &context);
 
@@ -301,7 +288,6 @@ mod generate_spo_keys {
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -327,7 +313,6 @@ mod generate_spo_keys {
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 }
 

--- a/partner-chains-cli/src/generate_keys/tests.rs
+++ b/partner-chains-cli/src/generate_keys/tests.rs
@@ -181,7 +181,7 @@ fn happy_path() {
 
 	let result = GenerateKeysCmd {}.run(&mock_context);
 
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -300,7 +300,7 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -326,7 +326,7 @@ mod generate_spo_keys {
 
 		let result = generate_spo_keys(&default_config(), &mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 }

--- a/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -192,7 +192,7 @@ pub mod tests {
 	use crate::config::{ConfigFieldDefinition, SelectOptions, RESOURCES_CONFIG_FILE_PATH};
 	use crate::prepare_configuration::PrepareConfigurationError::NetworkKeyNotFoundError;
 	use crate::prepare_configuration::Protocol::{Dns, Ipv4};
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
 
 	const KEY: &str = "962515971a22aa95706c2109ba6e9502c7f39b33bdf63024f46f77894424f1fe";
 	pub const CHAIN_NAME: &str = "partner_chains_template";
@@ -327,9 +327,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -344,9 +342,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -374,9 +370,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -404,9 +398,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -417,13 +409,9 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		mock_context.no_more_io_expected();
+		let error = should_be_failure!(result, mock_context);
 
-		assert!(result.is_err());
-		assert_eq!(
-			result.err().unwrap().to_string(),
-			NetworkKeyNotFoundError(network_key_file()).to_string()
-		);
+		assert_eq!(error.to_string(), NetworkKeyNotFoundError(network_key_file()).to_string());
 	}
 
 	#[test]
@@ -445,8 +433,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -464,10 +451,8 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_err());
-		assert!(result.err().unwrap().to_string().contains("⚠️ Invalid IP address"));
+		let error = should_be_failure!(result, mock_context);
+		assert!(error.to_string().contains("⚠️ Invalid IP address"));
 	}
 
 	pub fn save_to_existing_file<T>(

--- a/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -192,7 +192,7 @@ pub mod tests {
 	use crate::config::{ConfigFieldDefinition, SelectOptions, RESOURCES_CONFIG_FILE_PATH};
 	use crate::prepare_configuration::PrepareConfigurationError::NetworkKeyNotFoundError;
 	use crate::prepare_configuration::Protocol::{Dns, Ipv4};
-	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+	use crate::tests::{MockIO, MockIOContext};
 
 	const KEY: &str = "962515971a22aa95706c2109ba6e9502c7f39b33bdf63024f46f77894424f1fe";
 	pub const CHAIN_NAME: &str = "partner_chains_template";
@@ -328,7 +328,6 @@ pub mod tests {
 		let result = establish_bootnodes(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -344,7 +343,6 @@ pub mod tests {
 		let result = establish_bootnodes(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -373,7 +371,6 @@ pub mod tests {
 		let result = establish_bootnodes(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -402,7 +399,6 @@ pub mod tests {
 		let result = establish_bootnodes(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -415,7 +411,6 @@ pub mod tests {
 
 		let error = result.expect_err("should return error");
 		assert_eq!(error.to_string(), NetworkKeyNotFoundError(network_key_file()).to_string());
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -438,7 +433,6 @@ pub mod tests {
 		let result = establish_bootnodes(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -458,7 +452,6 @@ pub mod tests {
 
 		let error = result.expect_err("should return error");
 		assert!(error.to_string().contains("⚠️ Invalid IP address"));
-		should_have_no_io_left!(mock_context);
 	}
 
 	pub fn save_to_existing_file<T>(

--- a/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -327,7 +327,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -343,7 +343,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -372,7 +372,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -401,7 +401,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -413,7 +413,7 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		let error = result.expect_err("Expected the result to be an error");
+		let error = result.expect_err("should return error");
 		assert_eq!(error.to_string(), NetworkKeyNotFoundError(network_key_file()).to_string());
 		should_have_no_io_left!(mock_context);
 	}
@@ -437,7 +437,7 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -456,7 +456,7 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		let error = result.expect_err("Expected the result to be an error");
+		let error = result.expect_err("should return error");
 		assert!(error.to_string().contains("⚠️ Invalid IP address"));
 		should_have_no_io_left!(mock_context);
 	}

--- a/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -192,7 +192,7 @@ pub mod tests {
 	use crate::config::{ConfigFieldDefinition, SelectOptions, RESOURCES_CONFIG_FILE_PATH};
 	use crate::prepare_configuration::PrepareConfigurationError::NetworkKeyNotFoundError;
 	use crate::prepare_configuration::Protocol::{Dns, Ipv4};
-	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 
 	const KEY: &str = "962515971a22aa95706c2109ba6e9502c7f39b33bdf63024f46f77894424f1fe";
 	pub const CHAIN_NAME: &str = "partner_chains_template";
@@ -327,7 +327,8 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -342,7 +343,8 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -370,7 +372,8 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -398,7 +401,8 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -409,9 +413,9 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		let error = should_be_failure!(result, mock_context);
-
+		let error = result.expect_err("Expected the result to be an error");
 		assert_eq!(error.to_string(), NetworkKeyNotFoundError(network_key_file()).to_string());
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -433,7 +437,8 @@ pub mod tests {
 
 		let result = establish_bootnodes(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -451,8 +456,9 @@ pub mod tests {
 
 		let result = PrepareConfigurationCmd {}.run(&mock_context);
 
-		let error = should_be_failure!(result, mock_context);
+		let error = result.expect_err("Expected the result to be an error");
 		assert!(error.to_string().contains("⚠️ Invalid IP address"));
+		should_have_no_io_left!(mock_context);
 	}
 
 	pub fn save_to_existing_file<T>(

--- a/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -204,7 +204,7 @@ pub mod tests {
 			.with_json_file(CARDANO_SECURITY_PARAMETER.config_file, serde_json::json!({}))
 			.with_expected_io(vec![save_cardano_params(cardano_parameters.clone())]);
 		let result = prepare_cardano_params(&mock_context, cardano_network);
-		let params = result.expect("Expected the result to be a success");
+		let params = result.expect("should succeed");
 		assert_eq!(params, cardano_parameters);
 		should_have_no_io_left!(mock_context);
 	}

--- a/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -76,7 +76,7 @@ pub mod tests {
 	use crate::config::config_fields::CARDANO_SECURITY_PARAMETER;
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 	use crate::prepare_configuration::prepare_cardano_params::tests::scenarios::save_cardano_params;
-	use crate::tests::{should_have_no_io_left, MockIOContext};
+	use crate::tests::MockIOContext;
 	use serde_json::Value;
 
 	const CUSTOM_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -206,7 +206,6 @@ pub mod tests {
 		let result = prepare_cardano_params(&mock_context, cardano_network);
 		let params = result.expect("should succeed");
 		assert_eq!(params, cardano_parameters);
-		should_have_no_io_left!(mock_context);
 	}
 
 	fn test_chain_config(cardano_parameters: CardanoParameters) -> Value {

--- a/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -76,7 +76,7 @@ pub mod tests {
 	use crate::config::config_fields::CARDANO_SECURITY_PARAMETER;
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 	use crate::prepare_configuration::prepare_cardano_params::tests::scenarios::save_cardano_params;
-	use crate::tests::MockIOContext;
+	use crate::tests::{should_be_success, MockIOContext};
 	use serde_json::Value;
 
 	const CUSTOM_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -203,8 +203,8 @@ pub mod tests {
 		let mock_context = MockIOContext::new()
 			.with_json_file(CARDANO_SECURITY_PARAMETER.config_file, serde_json::json!({}))
 			.with_expected_io(vec![save_cardano_params(cardano_parameters.clone())]);
-		let params = prepare_cardano_params(&mock_context, cardano_network).unwrap();
-		mock_context.no_more_io_expected();
+		let result = prepare_cardano_params(&mock_context, cardano_network);
+		let params = should_be_success!(result, mock_context);
 		assert_eq!(params, cardano_parameters)
 	}
 

--- a/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -76,7 +76,7 @@ pub mod tests {
 	use crate::config::config_fields::CARDANO_SECURITY_PARAMETER;
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 	use crate::prepare_configuration::prepare_cardano_params::tests::scenarios::save_cardano_params;
-	use crate::tests::{should_be_success, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIOContext};
 	use serde_json::Value;
 
 	const CUSTOM_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -204,8 +204,9 @@ pub mod tests {
 			.with_json_file(CARDANO_SECURITY_PARAMETER.config_file, serde_json::json!({}))
 			.with_expected_io(vec![save_cardano_params(cardano_parameters.clone())]);
 		let result = prepare_cardano_params(&mock_context, cardano_network);
-		let params = should_be_success!(result, mock_context);
-		assert_eq!(params, cardano_parameters)
+		let params = result.expect("Expected the result to be a success");
+		assert_eq!(params, cardano_parameters);
+		should_have_no_io_left!(mock_context);
 	}
 
 	fn test_chain_config(cardano_parameters: CardanoParameters) -> Value {

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -147,6 +147,7 @@ mod tests {
 		prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 		save_to_existing_file, save_to_new_file, CHAIN_CONFIG_PATH,
 	};
+	use crate::tests::should_be_success;
 	use crate::tests::{MockIO, MockIOContext};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
@@ -206,8 +207,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		assert!(result.is_ok());
-		mock_context.no_more_io_expected();
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -239,9 +239,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -277,9 +275,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -312,8 +308,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -367,8 +362,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	fn test_chain_config() -> Value {

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -147,7 +147,7 @@ mod tests {
 		prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 		save_to_existing_file, save_to_new_file, CHAIN_CONFIG_PATH,
 	};
-	use crate::tests::should_be_success;
+	use crate::tests::should_have_no_io_left;
 	use crate::tests::{MockIO, MockIOContext};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
@@ -207,7 +207,8 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -239,7 +240,8 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -275,7 +277,8 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -308,7 +311,8 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -362,7 +366,8 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	fn test_chain_config() -> Value {

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -207,7 +207,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -240,7 +240,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -277,7 +277,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -311,7 +311,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -366,7 +366,7 @@ mod tests {
 
 		let result = prepare_chain_params(&mock_context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 

--- a/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_chain_params.rs
@@ -147,7 +147,7 @@ mod tests {
 		prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 		save_to_existing_file, save_to_new_file, CHAIN_CONFIG_PATH,
 	};
-	use crate::tests::should_have_no_io_left;
+
 	use crate::tests::{MockIO, MockIOContext};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
@@ -208,7 +208,6 @@ mod tests {
 		let result = prepare_chain_params(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -241,7 +240,6 @@ mod tests {
 		let result = prepare_chain_params(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -278,7 +276,6 @@ mod tests {
 		let result = prepare_chain_params(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -312,7 +309,6 @@ mod tests {
 		let result = prepare_chain_params(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -367,7 +363,6 @@ mod tests {
 		let result = prepare_chain_params(&mock_context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	fn test_chain_config() -> Value {

--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -6,10 +6,10 @@ use crate::config::{
 	get_cardano_network_from_file, CardanoNetwork, SidechainParams, PC_CONTRACTS_CLI_PATH,
 };
 use crate::io::IOContext;
-use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 use crate::pc_contracts_cli_resources::{
 	establish_pc_contracts_cli_configuration, PcContractsCliResources,
 };
+use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 use crate::smart_contracts;
 use anyhow::anyhow;
 use serde_json::Value;
@@ -197,8 +197,8 @@ mod tests {
 	use crate::config::CHAIN_CONFIG_FILE_PATH;
 	use crate::prepare_configuration::prepare_cardano_params::PREPROD_CARDANO_PARAMS;
 	use crate::prepare_configuration::tests::save_to_existing_file;
-	use crate::tests::MockIO;
 	use crate::tests::MockIOContext;
+	use crate::tests::{should_be_success, MockIO};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
 	use std::str::FromStr;
@@ -289,8 +289,10 @@ mod tests {
 				),
 				MockIO::eprint(OUTRO),
 			]);
-		prepare_main_chain_config(&mock_context, test_sidechain_params()).unwrap();
-		mock_context.no_more_io_expected();
+		should_be_success!(
+			prepare_main_chain_config(&mock_context, test_sidechain_params()),
+			mock_context
+		);
 	}
 
 	#[test]
@@ -353,8 +355,10 @@ mod tests {
 				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
 				MockIO::eprint(OUTRO),
 			]);
-		prepare_main_chain_config(&mock_context, test_sidechain_params()).unwrap();
-		mock_context.no_more_io_expected();
+		should_be_success!(
+			prepare_main_chain_config(&mock_context, test_sidechain_params()),
+			mock_context
+		);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -289,8 +289,7 @@ mod tests {
 				),
 				MockIO::eprint(OUTRO),
 			]);
-		prepare_main_chain_config(&mock_context, test_sidechain_params())
-			.expect("Expected the result to be a success");
+		prepare_main_chain_config(&mock_context, test_sidechain_params()).expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -354,8 +353,7 @@ mod tests {
 				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
 				MockIO::eprint(OUTRO),
 			]);
-		prepare_main_chain_config(&mock_context, test_sidechain_params())
-			.expect("Expected the result to be a success");
+		prepare_main_chain_config(&mock_context, test_sidechain_params()).expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 

--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -198,7 +198,7 @@ mod tests {
 	use crate::prepare_configuration::prepare_cardano_params::PREPROD_CARDANO_PARAMS;
 	use crate::prepare_configuration::tests::save_to_existing_file;
 	use crate::tests::MockIOContext;
-	use crate::tests::{should_be_success, MockIO};
+	use crate::tests::{should_have_no_io_left, MockIO};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
 	use std::str::FromStr;
@@ -289,10 +289,9 @@ mod tests {
 				),
 				MockIO::eprint(OUTRO),
 			]);
-		should_be_success!(
-			prepare_main_chain_config(&mock_context, test_sidechain_params()),
-			mock_context
-		);
+		prepare_main_chain_config(&mock_context, test_sidechain_params())
+			.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -355,10 +354,9 @@ mod tests {
 				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
 				MockIO::eprint(OUTRO),
 			]);
-		should_be_success!(
-			prepare_main_chain_config(&mock_context, test_sidechain_params()),
-			mock_context
-		);
+		prepare_main_chain_config(&mock_context, test_sidechain_params())
+			.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -197,8 +197,8 @@ mod tests {
 	use crate::config::CHAIN_CONFIG_FILE_PATH;
 	use crate::prepare_configuration::prepare_cardano_params::PREPROD_CARDANO_PARAMS;
 	use crate::prepare_configuration::tests::save_to_existing_file;
+	use crate::tests::MockIO;
 	use crate::tests::MockIOContext;
-	use crate::tests::{should_have_no_io_left, MockIO};
 	use serde_json::Value;
 	use sidechain_domain::{MainchainAddressHash, UtxoId};
 	use std::str::FromStr;
@@ -290,7 +290,6 @@ mod tests {
 				MockIO::eprint(OUTRO),
 			]);
 		prepare_main_chain_config(&mock_context, test_sidechain_params()).expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -354,7 +353,6 @@ mod tests {
 				MockIO::eprint(OUTRO),
 			]);
 		prepare_main_chain_config(&mock_context, test_sidechain_params()).expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -283,7 +283,7 @@ fn parse_utxo_query_output(utxo_query_output: &UtxoQueryOutput) -> Vec<ValidUtxo
 mod tests {
 	use super::*;
 	use crate::config::config_fields::{CARDANO_CLI, CARDANO_PAYMENT_VERIFICATION_KEY_FILE};
-	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+	use crate::tests::{MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -317,7 +317,6 @@ mod tests {
 
 		let result = Register1Cmd {}.run(&mock_context);
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -331,7 +330,6 @@ mod tests {
 
 		let result = Register1Cmd {}.run(&mock_context);
 		result.expect_err("should return error");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -351,7 +349,6 @@ mod tests {
 
 		let result = Register1Cmd {}.run(&mock_context);
 		result.expect_err("should return error");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -283,7 +283,8 @@ fn parse_utxo_query_output(utxo_query_output: &UtxoQueryOutput) -> Vec<ValidUtxo
 mod tests {
 	use super::*;
 	use crate::config::config_fields::{CARDANO_CLI, CARDANO_PAYMENT_VERIFICATION_KEY_FILE};
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::should_be_success;
+	use crate::tests::{should_be_failure, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -316,8 +317,7 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -330,9 +330,7 @@ mod tests {
 		);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_err());
+		should_be_failure!(result, mock_context);
 	}
 
 	#[test]
@@ -351,9 +349,7 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		mock_context.no_more_io_expected();
-
-		assert!(result.is_err());
+		should_be_failure!(result, mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -283,7 +283,7 @@ fn parse_utxo_query_output(utxo_query_output: &UtxoQueryOutput) -> Vec<ValidUtxo
 mod tests {
 	use super::*;
 	use crate::config::config_fields::{CARDANO_CLI, CARDANO_PAYMENT_VERIFICATION_KEY_FILE};
-	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -316,7 +316,8 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -329,7 +330,8 @@ mod tests {
 		);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		should_be_failure!(result, mock_context);
+		result.expect_err("Expected the result to be an error");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -348,7 +350,8 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		should_be_failure!(result, mock_context);
+		result.expect_err("Expected the result to be an error");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -316,7 +316,7 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -330,7 +330,7 @@ mod tests {
 		);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		result.expect_err("Expected the result to be an error");
+		result.expect_err("should return error");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -350,7 +350,7 @@ mod tests {
 			);
 
 		let result = Register1Cmd {}.run(&mock_context);
-		result.expect_err("Expected the result to be an error");
+		result.expect_err("should return error");
 		should_have_no_io_left!(mock_context);
 	}
 

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -283,8 +283,7 @@ fn parse_utxo_query_output(utxo_query_output: &UtxoQueryOutput) -> Vec<ValidUtxo
 mod tests {
 	use super::*;
 	use crate::config::config_fields::{CARDANO_CLI, CARDANO_PAYMENT_VERIFICATION_KEY_FILE};
-	use crate::tests::should_be_success;
-	use crate::tests::{should_be_failure, MockIO, MockIOContext};
+	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {

--- a/partner-chains-cli/src/register/register2.rs
+++ b/partner-chains-cli/src/register/register2.rs
@@ -102,7 +102,7 @@ mod tests {
 			);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -120,7 +120,7 @@ mod tests {
 		]);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		result.expect_err("Expected the result to be an error");
+		result.expect_err("should return error");
 		should_have_no_io_left!(mock_context);
 	}
 

--- a/partner-chains-cli/src/register/register2.rs
+++ b/partner-chains-cli/src/register/register2.rs
@@ -88,7 +88,7 @@ fn get_mainchain_cold_skey<C: IOContext>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -102,7 +102,8 @@ mod tests {
 			);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -119,7 +120,8 @@ mod tests {
 		]);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		should_be_failure!(result, mock_context);
+		result.expect_err("Expected the result to be an error");
+		should_have_no_io_left!(mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register2.rs
+++ b/partner-chains-cli/src/register/register2.rs
@@ -88,8 +88,7 @@ fn get_mainchain_cold_skey<C: IOContext>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::tests::should_be_success;
-	use crate::tests::{should_be_failure, MockIO, MockIOContext};
+	use crate::tests::{should_be_failure, should_be_success, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {

--- a/partner-chains-cli/src/register/register2.rs
+++ b/partner-chains-cli/src/register/register2.rs
@@ -88,7 +88,7 @@ fn get_mainchain_cold_skey<C: IOContext>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+	use crate::tests::{MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -103,7 +103,6 @@ mod tests {
 
 		let result = mock_register2_cmd().run(&mock_context);
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -121,7 +120,6 @@ mod tests {
 
 		let result = mock_register2_cmd().run(&mock_context);
 		result.expect_err("should return error");
-		should_have_no_io_left!(mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register2.rs
+++ b/partner-chains-cli/src/register/register2.rs
@@ -88,7 +88,8 @@ fn get_mainchain_cold_skey<C: IOContext>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::should_be_success;
+	use crate::tests::{should_be_failure, MockIO, MockIOContext};
 
 	#[test]
 	fn happy_path() {
@@ -102,8 +103,7 @@ mod tests {
 			);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -120,8 +120,7 @@ mod tests {
 		]);
 
 		let result = mock_register2_cmd().run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_err());
+		should_be_failure!(result, mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register3.rs
+++ b/partner-chains-cli/src/register/register3.rs
@@ -174,7 +174,7 @@ mod tests {
 		pc_contracts_cli_resources::{
 			tests::establish_pc_contracts_cli_configuration_io, PcContractsCliResources,
 		},
-		tests::{should_have_no_io_left, MockIO, MockIOContext},
+		tests::{MockIO, MockIOContext},
 	};
 	use serde_json::json;
 	use sp_core::offchain::Timestamp;
@@ -204,7 +204,6 @@ mod tests {
 
 		let result = mock_register3_cmd().run(&mock_context);
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -230,7 +229,6 @@ mod tests {
 
 		let result = mock_register3_cmd().run(&mock_context);
 		result.expect_err("should return error");
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -257,7 +255,6 @@ mod tests {
 
 		let result = mock_register3_cmd().run(&mock_context);
 		result.expect("should succeed");
-		should_have_no_io_left!(mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register3.rs
+++ b/partner-chains-cli/src/register/register3.rs
@@ -169,6 +169,8 @@ mod tests {
 	use crate::config::config_fields::POSTGRES_CONNECTION_STRING;
 	use crate::pc_contracts_cli_resources::tests::establish_pc_contracts_cli_configuration_io;
 	use crate::pc_contracts_cli_resources::PcContractsCliResources;
+	use crate::tests::should_be_failure;
+	use crate::tests::should_be_success;
 	use crate::{
 		config::CHAIN_CONFIG_FILE_PATH,
 		config::RESOURCES_CONFIG_FILE_PATH,
@@ -201,8 +203,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	#[test]
@@ -227,8 +228,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_err());
+		should_be_failure!(result, mock_context);
 	}
 
 	#[test]
@@ -254,8 +254,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		mock_context.no_more_io_expected();
-		assert!(result.is_ok());
+		should_be_success!(result, mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register3.rs
+++ b/partner-chains-cli/src/register/register3.rs
@@ -203,7 +203,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -229,7 +229,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		result.expect_err("Expected the result to be an error");
+		result.expect_err("should return error");
 		should_have_no_io_left!(mock_context);
 	}
 
@@ -256,7 +256,7 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(mock_context);
 	}
 

--- a/partner-chains-cli/src/register/register3.rs
+++ b/partner-chains-cli/src/register/register3.rs
@@ -174,7 +174,7 @@ mod tests {
 		pc_contracts_cli_resources::{
 			tests::establish_pc_contracts_cli_configuration_io, PcContractsCliResources,
 		},
-		tests::{should_be_failure, should_be_success, MockIO, MockIOContext},
+		tests::{should_have_no_io_left, MockIO, MockIOContext},
 	};
 	use serde_json::json;
 	use sp_core::offchain::Timestamp;
@@ -203,7 +203,8 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -228,7 +229,8 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		should_be_failure!(result, mock_context);
+		result.expect_err("Expected the result to be an error");
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -254,7 +256,8 @@ mod tests {
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
-		should_be_success!(result, mock_context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(mock_context);
 	}
 
 	fn intro_msg_io() -> Vec<MockIO> {

--- a/partner-chains-cli/src/register/register3.rs
+++ b/partner-chains-cli/src/register/register3.rs
@@ -166,15 +166,15 @@ fn get_current_mainchain_epoch(context: &impl IOContext) -> Result<McEpochNumber
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::config::config_fields::POSTGRES_CONNECTION_STRING;
-	use crate::pc_contracts_cli_resources::tests::establish_pc_contracts_cli_configuration_io;
-	use crate::pc_contracts_cli_resources::PcContractsCliResources;
-	use crate::tests::should_be_failure;
-	use crate::tests::should_be_success;
 	use crate::{
-		config::CHAIN_CONFIG_FILE_PATH,
-		config::RESOURCES_CONFIG_FILE_PATH,
-		tests::{MockIO, MockIOContext},
+		config::{
+			config_fields::POSTGRES_CONNECTION_STRING, CHAIN_CONFIG_FILE_PATH,
+			RESOURCES_CONFIG_FILE_PATH,
+		},
+		pc_contracts_cli_resources::{
+			tests::establish_pc_contracts_cli_configuration_io, PcContractsCliResources,
+		},
+		tests::{should_be_failure, should_be_success, MockIO, MockIOContext},
 	};
 	use serde_json::json;
 	use sp_core::offchain::Timestamp;

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,12 +1,13 @@
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
 use crate::config::{config_fields, PC_CONTRACTS_CLI_PATH};
 use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
+use crate::pc_contracts_cli_resources::tests::establish_pc_contracts_cli_configuration_io;
+use crate::pc_contracts_cli_resources::PcContractsCliResources;
 use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 };
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
-use crate::pc_contracts_cli_resources::tests::establish_pc_contracts_cli_configuration_io;
-use crate::pc_contracts_cli_resources::PcContractsCliResources;
+use crate::tests::{should_be_failure, should_be_success};
 use crate::tests::{MockIO, MockIOContext};
 use crate::CmdRun;
 use serde_json::json;
@@ -29,8 +30,8 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+
+	should_be_success!(result, mock_context);
 }
 
 #[test]
@@ -52,8 +53,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context);
 }
 
 #[test]
@@ -74,8 +74,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context);
 }
 
 #[test]
@@ -98,8 +97,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context);
 }
 
 #[test]
@@ -118,8 +116,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 			update_permissioned_candidates_failed_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	assert!(result.is_err());
-	mock_context.no_more_io_expected();
+	should_be_failure!(result, mock_context);
 }
 
 #[test]
@@ -139,8 +136,7 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
-	assert!(result.is_ok());
+	should_be_success!(result, mock_context);
 }
 
 #[test]
@@ -149,9 +145,9 @@ fn should_return_error_message_if_pc_cli_missing() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_expected_io(vec![read_chain_config_io(), print_info_io()]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	mock_context.no_more_io_expected();
+	let err = should_be_failure!(result, mock_context);
 	assert_eq!(
-		result.unwrap_err().to_string(),
+		err.to_string(),
 		"Partner Chains Smart Contracts executable file (./pc-contracts-cli) is missing"
 	);
 }

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -31,7 +31,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -54,7 +54,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -76,7 +76,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -100,7 +100,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -120,7 +120,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 			update_permissioned_candidates_failed_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	result.expect_err("Expected the result to be an error");
+	result.expect_err("should return error");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -141,7 +141,7 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(mock_context);
 }
 
@@ -151,7 +151,7 @@ fn should_return_error_message_if_pc_cli_missing() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_expected_io(vec![read_chain_config_io(), print_info_io()]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	let err = result.expect_err("Expected the result to be an error");
+	let err = result.expect_err("should return error");
 	assert_eq!(
 		err.to_string(),
 		"Partner Chains Smart Contracts executable file (./pc-contracts-cli) is missing"

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -7,7 +7,7 @@ use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 };
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
-use crate::tests::should_have_no_io_left;
+
 use crate::tests::{MockIO, MockIOContext};
 use crate::CmdRun;
 use serde_json::json;
@@ -32,7 +32,6 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 	let result = SetupMainChainStateCmd.run(&mock_context);
 
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -55,7 +54,6 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -77,7 +75,6 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -101,7 +98,6 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -121,7 +117,6 @@ fn fails_if_update_permissioned_candidates_fail() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect_err("should return error");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -142,7 +137,6 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
-	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -156,7 +150,6 @@ fn should_return_error_message_if_pc_cli_missing() {
 		err.to_string(),
 		"Partner Chains Smart Contracts executable file (./pc-contracts-cli) is missing"
 	);
-	should_have_no_io_left!(mock_context);
 }
 
 fn read_chain_config_io() -> MockIO {

--- a/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -7,7 +7,7 @@ use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
 };
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
-use crate::tests::{should_be_failure, should_be_success};
+use crate::tests::should_have_no_io_left;
 use crate::tests::{MockIO, MockIOContext};
 use crate::CmdRun;
 use serde_json::json;
@@ -31,7 +31,8 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -53,7 +54,8 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -74,7 +76,8 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -97,7 +100,8 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -116,7 +120,8 @@ fn fails_if_update_permissioned_candidates_fail() {
 			update_permissioned_candidates_failed_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	should_be_failure!(result, mock_context);
+	result.expect_err("Expected the result to be an error");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -136,7 +141,8 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 			print_post_update_info_io(),
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	should_be_success!(result, mock_context);
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(mock_context);
 }
 
 #[test]
@@ -145,11 +151,12 @@ fn should_return_error_message_if_pc_cli_missing() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_expected_io(vec![read_chain_config_io(), print_info_io()]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
-	let err = should_be_failure!(result, mock_context);
+	let err = result.expect_err("Expected the result to be an error");
 	assert_eq!(
 		err.to_string(),
 		"Partner Chains Smart Contracts executable file (./pc-contracts-cli) is missing"
 	);
+	should_have_no_io_left!(mock_context);
 }
 
 fn read_chain_config_io() -> MockIO {

--- a/partner-chains-cli/src/start_node/tests.rs
+++ b/partner-chains-cli/src/start_node/tests.rs
@@ -1,4 +1,4 @@
-use crate::tests::{MockIO, MockIOContext};
+use crate::tests::{should_be_success, MockIO, MockIOContext};
 
 use super::*;
 
@@ -145,12 +145,12 @@ fn happy_path() {
 
 	let result = StartNodeCmd { silent: false }.run(&context);
 
-	context.no_more_io_expected();
-
-	assert!(result.is_ok());
+	should_be_success!(result, context)
 }
 
 mod check_chain_spec {
+	use crate::tests::should_have_no_io_left;
+
 	use super::*;
 
 	#[test]
@@ -158,9 +158,8 @@ mod check_chain_spec {
 		let context = MockIOContext::new().with_file(CHAIN_SPEC_FILE, "irrelevant");
 		let result = check_chain_spec(&context);
 
-		context.no_more_io_expected();
-
 		assert!(result);
+		should_have_no_io_left!(context);
 	}
 
 	#[test]
@@ -172,14 +171,13 @@ mod check_chain_spec {
 
 		let result = check_chain_spec(&context);
 
-		context.no_more_io_expected();
-
 		assert!(!result);
+		should_have_no_io_left!(context);
 	}
 }
 
 mod check_keystore {
-	use crate::tests::MockIOContext;
+	use crate::tests::{should_be_success, MockIOContext};
 
 	use super::*;
 
@@ -197,10 +195,7 @@ mod check_keystore {
 
 		let result = check_keystore(&default_config(), &context);
 
-		context.no_more_io_expected();
-
-		assert!(result.is_ok());
-		assert!(result.unwrap());
+		should_be_success!(result, context);
 	}
 
 	#[test]
@@ -217,11 +212,9 @@ mod check_keystore {
 		]);
 
 		let result = check_keystore(&default_config(), &context);
+		let result = should_be_success!(result, context);
 
-		context.no_more_io_expected();
-
-		assert!(result.is_ok());
-		assert!(!result.unwrap());
+		assert!(!result);
 	}
 }
 

--- a/partner-chains-cli/src/start_node/tests.rs
+++ b/partner-chains-cli/src/start_node/tests.rs
@@ -1,4 +1,4 @@
-use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+use crate::tests::{MockIO, MockIOContext};
 
 use super::*;
 
@@ -146,11 +146,9 @@ fn happy_path() {
 	let result = StartNodeCmd { silent: false }.run(&context);
 
 	result.expect("should succeed");
-	should_have_no_io_left!(context);
 }
 
 mod check_chain_spec {
-	use crate::tests::should_have_no_io_left;
 
 	use super::*;
 
@@ -160,7 +158,6 @@ mod check_chain_spec {
 		let result = check_chain_spec(&context);
 
 		assert!(result);
-		should_have_no_io_left!(context);
 	}
 
 	#[test]
@@ -173,12 +170,11 @@ mod check_chain_spec {
 		let result = check_chain_spec(&context);
 
 		assert!(!result);
-		should_have_no_io_left!(context);
 	}
 }
 
 mod check_keystore {
-	use crate::tests::{should_have_no_io_left, MockIOContext};
+	use crate::tests::MockIOContext;
 
 	use super::*;
 
@@ -197,7 +193,6 @@ mod check_keystore {
 		let result = check_keystore(&default_config(), &context);
 
 		result.expect("should succeed");
-		should_have_no_io_left!(context);
 	}
 
 	#[test]
@@ -216,7 +211,6 @@ mod check_keystore {
 		let result = check_keystore(&default_config(), &context);
 		let result = result.expect("should succeed");
 		assert!(!result);
-		should_have_no_io_left!(context);
 	}
 }
 

--- a/partner-chains-cli/src/start_node/tests.rs
+++ b/partner-chains-cli/src/start_node/tests.rs
@@ -145,7 +145,7 @@ fn happy_path() {
 
 	let result = StartNodeCmd { silent: false }.run(&context);
 
-	result.expect("Expected the result to be a success");
+	result.expect("should succeed");
 	should_have_no_io_left!(context);
 }
 
@@ -196,7 +196,7 @@ mod check_keystore {
 
 		let result = check_keystore(&default_config(), &context);
 
-		result.expect("Expected the result to be a success");
+		result.expect("should succeed");
 		should_have_no_io_left!(context);
 	}
 
@@ -214,7 +214,7 @@ mod check_keystore {
 		]);
 
 		let result = check_keystore(&default_config(), &context);
-		let result = result.expect("Expected the result to be a success");
+		let result = result.expect("should succeed");
 		assert!(!result);
 		should_have_no_io_left!(context);
 	}

--- a/partner-chains-cli/src/start_node/tests.rs
+++ b/partner-chains-cli/src/start_node/tests.rs
@@ -1,4 +1,4 @@
-use crate::tests::{should_be_success, MockIO, MockIOContext};
+use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 
 use super::*;
 
@@ -145,7 +145,8 @@ fn happy_path() {
 
 	let result = StartNodeCmd { silent: false }.run(&context);
 
-	should_be_success!(result, context)
+	result.expect("Expected the result to be a success");
+	should_have_no_io_left!(context);
 }
 
 mod check_chain_spec {
@@ -177,7 +178,7 @@ mod check_chain_spec {
 }
 
 mod check_keystore {
-	use crate::tests::{should_be_success, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIOContext};
 
 	use super::*;
 
@@ -195,7 +196,8 @@ mod check_keystore {
 
 		let result = check_keystore(&default_config(), &context);
 
-		should_be_success!(result, context);
+		result.expect("Expected the result to be a success");
+		should_have_no_io_left!(context);
 	}
 
 	#[test]
@@ -212,9 +214,9 @@ mod check_keystore {
 		]);
 
 		let result = check_keystore(&default_config(), &context);
-		let result = should_be_success!(result, context);
-
+		let result = result.expect("Expected the result to be a success");
 		assert!(!result);
+		should_have_no_io_left!(context);
 	}
 }
 

--- a/partner-chains-cli/src/tests/config.rs
+++ b/partner-chains-cli/src/tests/config.rs
@@ -2,7 +2,7 @@ use crate::config::*;
 
 mod config_field {
 
-	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
+	use crate::tests::{MockIO, MockIOContext};
 
 	use super::*;
 
@@ -32,8 +32,6 @@ mod config_field {
 		)]);
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
-
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -77,8 +75,6 @@ mod config_field {
 			]);
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
-
-		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/tests/config.rs
+++ b/partner-chains-cli/src/tests/config.rs
@@ -2,7 +2,7 @@ use crate::config::*;
 
 mod config_field {
 
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::{should_have_no_io_left, MockIO, MockIOContext};
 
 	use super::*;
 
@@ -33,7 +33,7 @@ mod config_field {
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
 
-		mock_context.no_more_io_expected();
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]
@@ -78,7 +78,7 @@ mod config_field {
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
 
-		mock_context.no_more_io_expected();
+		should_have_no_io_left!(mock_context);
 	}
 
 	#[test]

--- a/partner-chains-cli/src/tests/mod.rs
+++ b/partner-chains-cli/src/tests/mod.rs
@@ -147,7 +147,7 @@ pub(crate) use should_have_no_io_left;
 
 macro_rules! should_be_success {
 	($result:expr, $context:expr) => {{
-		let result = $result.unwrap();
+		let result = $result.expect("Expected the result to be a success");
 		assert!(
 			$context.expected_io.borrow().is_empty(),
 			"Expected IO operations left unperformed: {:?}",
@@ -160,7 +160,7 @@ pub(crate) use should_be_success;
 
 macro_rules! should_be_failure {
 	($result:expr, $context:expr) => {{
-		let err = $result.unwrap_err();
+		let err = $result.expect_err("Expected the result to be an error");
 		assert!(
 			$context.expected_io.borrow().is_empty(),
 			"Expected IO operations left unperformed: {:?}",

--- a/partner-chains-cli/src/tests/mod.rs
+++ b/partner-chains-cli/src/tests/mod.rs
@@ -145,32 +145,6 @@ macro_rules! should_have_no_io_left {
 }
 pub(crate) use should_have_no_io_left;
 
-macro_rules! should_be_success {
-	($result:expr, $context:expr) => {{
-		let result = $result.expect("Expected the result to be a success");
-		assert!(
-			$context.expected_io.borrow().is_empty(),
-			"Expected IO operations left unperformed: {:?}",
-			$context.expected_io
-		);
-		result
-	}};
-}
-pub(crate) use should_be_success;
-
-macro_rules! should_be_failure {
-	($result:expr, $context:expr) => {{
-		let err = $result.expect_err("Expected the result to be an error");
-		assert!(
-			$context.expected_io.borrow().is_empty(),
-			"Expected IO operations left unperformed: {:?}",
-			$context.expected_io
-		);
-		err
-	}};
-}
-pub(crate) use should_be_failure;
-
 impl IOContext for MockIOContext {
 	fn run_command(&self, cmd: &str) -> anyhow::Result<String> {
 		match self.pop_next_action() {

--- a/partner-chains-cli/src/tests/mod.rs
+++ b/partner-chains-cli/src/tests/mod.rs
@@ -99,8 +99,8 @@ impl MockIO {
 }
 
 pub struct MockIOContext {
-	expected_io: RefCell<Vec<MockIO>>,
-	files: RefCell<HashMap<String, String>>,
+	pub expected_io: RefCell<Vec<MockIO>>,
+	pub files: RefCell<HashMap<String, String>>,
 }
 
 impl MockIOContext {
@@ -132,14 +132,44 @@ impl MockIOContext {
 			None => None,
 		}
 	}
-	pub fn no_more_io_expected(&self) {
-		assert!(
-			self.expected_io.borrow().is_empty(),
-			"Expected IO operations left unperformed: {:?}",
-			self.expected_io
-		)
-	}
 }
+
+macro_rules! should_have_no_io_left {
+	($context:expr) => {{
+		assert!(
+			$context.expected_io.borrow().is_empty(),
+			"Expected IO operations left unperformed: {:?}",
+			$context.expected_io
+		);
+	}};
+}
+pub(crate) use should_have_no_io_left;
+
+macro_rules! should_be_success {
+	($result:expr, $context:expr) => {{
+		let result = $result.unwrap();
+		assert!(
+			$context.expected_io.borrow().is_empty(),
+			"Expected IO operations left unperformed: {:?}",
+			$context.expected_io
+		);
+		result
+	}};
+}
+pub(crate) use should_be_success;
+
+macro_rules! should_be_failure {
+	($result:expr, $context:expr) => {{
+		let err = $result.unwrap_err();
+		assert!(
+			$context.expected_io.borrow().is_empty(),
+			"Expected IO operations left unperformed: {:?}",
+			$context.expected_io
+		);
+		err
+	}};
+}
+pub(crate) use should_be_failure;
 
 impl IOContext for MockIOContext {
 	fn run_command(&self, cmd: &str) -> anyhow::Result<String> {


### PR DESCRIPTION
# Description

Changed the helpers that assert empty IO and results to macro rules, so the test errors show the line within the test case, not the helper definition.

I would love to find a way to show the error at the line of the `MockIO` that caused the error, but it's more tricky here in Rust than would be in Scala with the scope implicit. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

