### PR TITLE
feat: rename pallet_session in reference runtime

### DIFF
--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -152,7 +152,7 @@ pub fn staging_genesis(
 			params: SidechainParams::read_from_env_with_defaults()?,
 			..Default::default()
 		},
-		polkadot_session_stub_for_grandpa: Default::default(),
+		pallet_session: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -32,7 +32,7 @@ pub fn chain_spec() -> Result<ChainSpec, envy::Error> {
 			params: SidechainParams::read_from_env_with_defaults()?,
 			..Default::default()
 		},
-		polkadot_session_stub_for_grandpa: Default::default(),
+		pallet_session: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			// Same as SessionConfig
 			initial_authorities: vec![],

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -192,7 +192,7 @@ pub fn testnet_genesis(
 			slots_per_epoch: SlotsPerEpoch::read_from_env()?,
 			..Default::default()
 		},
-		polkadot_session_stub_for_grandpa: Default::default(),
+		pallet_session: Default::default(),
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -497,11 +497,11 @@ construct_runtime!(
 		Sidechain: pallet_sidechain,
 		SessionCommitteeManagement: pallet_session_validator_management,
 		BlockRewards: pallet_block_rewards,
-		// pallet_grandpa depends on pallet_session CurrentIndex storage.
+		// pallet_grandpa reads pallet_session::pallet::CurrentIndex storage.
 		// Only stub implementation of pallet_session should be wired.
-		// Partner Chains session_manager ValidatorManagementSessionManager writes to this storage.
-		// It is wired in by pallet_partner_chains_session.
-		PolkadotSessionStubForGrandpa: pallet_session,
+		// Partner Chains session_manager ValidatorManagementSessionManager writes to pallet_session::pallet::CurrentIndex.
+		// ValidatorManagementSessionManager is wired in by pallet_partner_chains_session.
+		PalletSession: pallet_session,
 		// The order matters!! pallet_partner_chains_session needs to come last for correct initialization order
 		Session: pallet_partner_chains_session,
 		NativeTokenManagement: pallet_native_token_management,


### PR DESCRIPTION
# Description

This change is done with possible migration to usage of properly wired polkadot-sdk `pallet_session`, which is currently wired in with stub implementations only.
Names that are currently used in this implementation do matter and affect storage keys and are present in polkadot-ui.
For this reason I think that `polkadot_session_stub_for_grandpa` name was a mistake.

Name `session` is already used by our pallet, so I've chosen `pallet_session`.  I was wondering about `polkadot_session` as well.


