### PR TITLE
fix: upgrade some previously missed crates to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "chain-params"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "envy",
@@ -5730,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-native-token-management"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6202,7 +6202,7 @@ dependencies = [
 
 [[package]]
 name = "partner-chains-node-commands"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "authority-selection-inherents",
  "clap",
@@ -8328,7 +8328,7 @@ dependencies = [
 
 [[package]]
 name = "sc-partner-chains-consensus-aura"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "futures",
@@ -9211,7 +9211,7 @@ dependencies = [
 
 [[package]]
 name = "sidechain-runtime"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "authority-selection-inherents",
  "chain-params",
@@ -9831,7 +9831,7 @@ dependencies = [
 
 [[package]]
 name = "sp-native-token-management"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "envy",
@@ -9871,7 +9871,7 @@ dependencies = [
 
 [[package]]
 name = "sp-partner-chains-consensus-aura"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "futures",
  "sp-blockchain",
@@ -9983,7 +9983,7 @@ dependencies = [
 
 [[package]]
 name = "sp-session-validator-management-query"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "async-trait",
  "authority-selection-inherents",

--- a/cli/node-commands/Cargo.toml
+++ b/cli/node-commands/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "partner-chains-node-commands"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 license = "GPLv3 with a classpath exception"
 

--- a/client/consensus/aura/Cargo.toml
+++ b/client/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sc-partner-chains-consensus-aura"
-version = "1.0.0"
+version = "1.1.0"
 description = "Partner Chains modification to the Substrate Aura consensus engine"
 authors = [ "IOG "]
 homepage = "https://iohk.io/"

--- a/pallets/native-token-management/Cargo.toml
+++ b/pallets/native-token-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pallet-native-token-management"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 description = "Pallet responsible for handling changes to the illiquid supply of the native token on main chain."
 

--- a/primitives/chain-params/Cargo.toml
+++ b/primitives/chain-params/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-params"
-version = "1.0.0"
+version = "1.1.0"
 authors = [ "IOG" ]
 edition = "2021"
 

--- a/primitives/consensus/aura/Cargo.toml
+++ b/primitives/consensus/aura/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-partner-chains-consensus-aura"
-version = "1.0.0"
+version = "1.1.0"
 description = "Primitives required by Partner Chains customized Aura consensus"
 authors = [ "IOG "]
 homepage = "https://iohk.io/"

--- a/primitives/native-token-management/Cargo.toml
+++ b/primitives/native-token-management/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-native-token-management"
-version = "0.1.0"
+version = "1.1.0"
 edition = "2021"
 
 [package.metadata.docs.rs]

--- a/primitives/session-validator-management/query/Cargo.toml
+++ b/primitives/session-validator-management/query/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-session-validator-management-query"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 [dependencies]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sidechain-runtime"
-version = "1.0.0"
+version = "1.1.0"
 description = "A reference implementation of a partner chain runtime"
 authors = ["IOG"]
 edition = "2021"


### PR DESCRIPTION
# Description

Some crates were missed when upgrading to 1.1.0 in https://github.com/input-output-hk/partner-chains/commit/41a924a615583979225becefef48e9f084deca32

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

