### PR TITLE
change: ETCM-8366 handle initial loading of historical native token data

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,12 +9,15 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * Added 'deregister' command to partner-chains-cli.
 * Made `MainChainScripts` in the native token pallet optional. If they are not set, the inherent data
 provider will not query the main chain state or produce inherent data at all.
+* ETCM-8366 - native token management pallet can now observe historical transfers when added after the genesis block
 
 ## Removed
 
 ## Fixed
 
 ## Added
+* Added `new_for_runtime_version` factory for the native token inherent data provider,
+allowing to selectively query main chain state based on runtime version
 
 # 1.2.0
 
@@ -34,8 +37,6 @@ provider will not query the main chain state or produce inherent data at all.
   This change requires migration of the node, PartnerChainsProposerFactory has to be used.
   See `service.rs` in `partner-chains-node` crate for an example.
 * renamed sidechain-main-cli and relevant naming to pc-contracts-cli
-* Added `new_for_runtime_version` factory for the native token inherent data provider,
-allowing to selectively query main chain state based on runtime version
 
 ## Fixed
 * ETCM-8267 - fixed `partner-chains-cli` missing the native token configuration

--- a/node/src/tests/runtime_api_mock.rs
+++ b/node/src/tests/runtime_api_mock.rs
@@ -102,6 +102,10 @@ sp_api::mock_impl_runtime_apis! {
 				}
 			)
 		}
+
+		fn initialized() -> bool {
+			true
+		}
 	}
 }
 

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -147,7 +147,6 @@ pub mod pallet {
 			);
 			Initialized::<T>::mutate(|initialized| {
 				if !*initialized {
-					log::info!("");
 					*initialized = true
 				}
 				true

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -60,6 +60,9 @@ pub mod pallet {
 	pub type MainChainScriptsConfiguration<T: Config> =
 		StorageValue<_, sp_native_token_management::MainChainScripts, OptionQuery>;
 
+	#[pallet::storage]
+	pub type Initialized<T: Config> = StorageValue<_, bool, ValueQuery>;
+
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]
 	pub struct GenesisConfig<T: Config> {
@@ -142,6 +145,13 @@ pub mod pallet {
 				MainChainScriptsConfiguration::<T>::exists(),
 				"BUG: Inherent should not be run unless the main chain scripts are set."
 			);
+			Initialized::<T>::mutate(|initialized| {
+				if !*initialized {
+					log::info!("");
+					*initialized = true
+				}
+				true
+			});
 			T::TokenTransferHandler::handle_token_transfer(token_amount)
 		}
 
@@ -170,6 +180,9 @@ pub mod pallet {
 	impl<T: Config> Pallet<T> {
 		pub fn get_main_chain_scripts() -> Option<sp_native_token_management::MainChainScripts> {
 			MainChainScriptsConfiguration::<T>::get()
+		}
+		pub fn initialized() -> bool {
+			Initialized::<T>::get()
 		}
 	}
 }

--- a/pallets/native-token-management/src/tests.rs
+++ b/pallets/native-token-management/src/tests.rs
@@ -116,11 +116,13 @@ mod inherent {
 	#[test]
 	fn succeeds_and_calls_transfer_handler() {
 		new_test_ext().execute_with(|| {
+			assert_eq!(Initialized::<Test>::get(), false);
 			let inherent: Call<Test> = Call::transfer_tokens { token_amount: 1000.into() };
 
 			let _ = inherent.dispatch_bypass_filter(RuntimeOrigin::none()).unwrap();
 
-			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get().unwrap().0, 1000)
+			assert_eq!(mock_pallet::LastTokenTransfer::<Test>::get().unwrap().0, 1000);
+			assert_eq!(Initialized::<Test>::get(), true);
 		})
 	}
 

--- a/primitives/native-token-management/src/tests/runtime_api_mock.rs
+++ b/primitives/native-token-management/src/tests/runtime_api_mock.rs
@@ -32,6 +32,10 @@ sp_api::mock_impl_runtime_apis! {
 			self.main_chain_scripts.clone()
 		}
 
+		fn initialized() -> bool {
+			true
+		}
+
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -864,6 +864,9 @@ impl_runtime_apis! {
 		fn get_main_chain_scripts() -> Option<sp_native_token_management::MainChainScripts> {
 			NativeTokenManagement::get_main_chain_scripts()
 		}
+		fn initialized() -> bool {
+			NativeTokenManagement::initialized()
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

This PR adds a boolean storage `Initialized` to the native token pallet, which is used by the inherent data provider to optionally query for utxos without a lower bound. This is meant to handle the case when some token transfers were made before the pallet was added to an already running chain - since the usual mechanism queries from last to current MC hash, we'd be losing the old transactions; for a new chain this was handled by detecting genesis block as parent.

This PR is part of the work to enable the migration strategy submitted for review in https://github.com/input-output-hk/partner-chains/pull/97 .

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

