### PR TITLE
change: ETCM-8366 Runtime version-bound native token IDP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9845,6 +9845,7 @@ dependencies = [
  "sp-blockchain",
  "sp-inherents",
  "sp-runtime",
+ "sp-version",
  "thiserror",
  "tokio",
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -34,6 +34,8 @@ provider will not query the main chain state or produce inherent data at all.
   This change requires migration of the node, PartnerChainsProposerFactory has to be used.
   See `service.rs` in `partner-chains-node` crate for an example.
 * renamed sidechain-main-cli and relevant naming to pc-contracts-cli
+* Added `new_for_runtime_version` factory for the native token inherent data provider,
+allowing to selectively query main chain state based on runtime version
 
 ## Fixed
 * ETCM-8267 - fixed `partner-chains-cli` missing the native token configuration

--- a/primitives/native-token-management/Cargo.toml
+++ b/primitives/native-token-management/Cargo.toml
@@ -20,6 +20,7 @@ sp-inherents = { workspace = true }
 sp-runtime = { workspace = true }
 thiserror = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
+sp-version = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
@@ -38,7 +39,9 @@ std = [
     "sp-inherents/std",
     "sp-runtime/std",
     "thiserror",
-    "envy"
+    "envy",
+    "sp-version",
+    "sp-version/std",
 ]
 serde = [
 	"dep:serde",

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -133,7 +133,7 @@ mod inherent_provider {
 			if version_check(version) {
 				Self::new(client, data_source, mc_hash, parent_hash).await
 			} else {
-				Ok(Self { token_amount: Some(0.into()) })
+				Ok(Self { token_amount: None })
 			}
 		}
 

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -133,7 +133,7 @@ mod inherent_provider {
 			if version_check(version) {
 				Self::new(client, data_source, mc_hash, parent_hash).await
 			} else {
-				Ok(Self { token_amount: 0.into() })
+				Ok(Self { token_amount: Some(0.into()) })
 			}
 		}
 
@@ -166,7 +166,7 @@ mod inherent_provider {
 				)
 				.await?;
 
-			let token_amount = Some(token_amount).filter(|amount| amount.0 > 0);
+			let token_amount = if token_amount.0 > 0 { Some(token_amount) } else { None };
 
 			Ok(Self { token_amount })
 		}

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -86,8 +86,9 @@ mod inherent_provider {
 	use super::*;
 	use main_chain_follower_api::{DataSourceError, NativeTokenManagementDataSource};
 	use sidechain_mc_hash::get_mc_hash_for_block;
-	use sp_api::{ApiError, ProvideRuntimeApi};
+	use sp_api::{ApiError, Core, ProvideRuntimeApi};
 	use sp_blockchain::HeaderBackend;
+	use sp_version::RuntimeVersion;
 	use std::error::Error;
 	use std::sync::Arc;
 
@@ -99,13 +100,43 @@ mod inherent_provider {
 	pub enum IDPCreationError {
 		#[error("Failed to read native token data from data source: {0:?}")]
 		DataSourceError(#[from] DataSourceError),
-		#[error("Failed to retrieve main chain scripts from the runtime: {0:?}")]
-		GetMainChainScriptsError(ApiError),
+		#[error("Failed to call runtime API: {0:?}")]
+		ApiError(ApiError),
 		#[error("Failed to retrieve previous MC hash: {0:?}")]
 		McHashError(Box<dyn Error + Send + Sync>),
 	}
 
+	impl From<ApiError> for IDPCreationError {
+		fn from(err: ApiError) -> Self {
+			Self::ApiError(err)
+		}
+	}
+
 	impl NativeTokenManagementInherentDataProvider {
+		/// Checks the current runtime version against `version_check` predicate, returns zero transfers
+		/// if outside the version bounds.
+		pub async fn new_for_runtime_version<Block, C>(
+			version_check: fn(RuntimeVersion) -> bool,
+			client: Arc<C>,
+			data_source: &(dyn NativeTokenManagementDataSource + Send + Sync),
+			mc_hash: McBlockHash,
+			parent_hash: <Block as BlockT>::Hash,
+		) -> Result<Self, IDPCreationError>
+		where
+			Block: BlockT,
+			C: HeaderBackend<Block>,
+			C: ProvideRuntimeApi<Block> + Send + Sync,
+			C::Api: NativeTokenManagementApi<Block>,
+		{
+			let version = client.runtime_api().version(parent_hash)?;
+
+			if version_check(version) {
+				Self::new(client, data_source, mc_hash, parent_hash).await
+			} else {
+				Ok(Self { token_amount: 0.into() })
+			}
+		}
+
 		pub async fn new<Block, C>(
 			client: Arc<C>,
 			data_source: &(dyn NativeTokenManagementDataSource + Send + Sync),
@@ -119,10 +150,7 @@ mod inherent_provider {
 			C::Api: NativeTokenManagementApi<Block>,
 		{
 			let api = client.runtime_api();
-			let Some(scripts) = api
-				.get_main_chain_scripts(parent_hash)
-				.map_err(IDPCreationError::GetMainChainScriptsError)?
-			else {
+			let Some(scripts) = api.get_main_chain_scripts(parent_hash)? else {
 				return Ok(Self { token_amount: None });
 			};
 			let parent_mc_hash: Option<McBlockHash> =

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -38,7 +38,7 @@ mod inherent_provider {
 		.await
 		.expect("Should not fail");
 
-		assert_eq!(inherent_provider.token_amount, Some(NativeTokenAmount(total_transfered)))
+		assert_eq!(inherent_provider.token_amount, Some(total_transfered.into()))
 	}
 
 	#[tokio::test]
@@ -64,7 +64,7 @@ mod inherent_provider {
 		.await
 		.expect("Should not fail");
 
-		assert_eq!(inherent_provider.token_amount, Some(NativeTokenAmount(total_transfered)))
+		assert_eq!(inherent_provider.token_amount, Some(total_transfered.into()))
 	}
 
 	#[tokio::test]


### PR DESCRIPTION
# Description

This PR:
* adds a `new_for_runtime_version` factory for the native token inherent data provider, which accepts an additional predicate `RuntimeVersion -> bool` to determine whether data should be produced.
* makes the `token_amount` in the IDP an `Option` with `Some` values being non-zero

This PR is part of the work to enable the migration strategy submitted for review in https://github.com/input-output-hk/partner-chains/pull/97 .

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

