### PR TITLE
fix: do not panic again in mock IO context's drop

### DIFF
--- a/partner-chains-cli/src/tests/mod.rs
+++ b/partner-chains-cli/src/tests/mod.rs
@@ -136,6 +136,10 @@ impl MockIOContext {
 
 impl Drop for MockIOContext {
 	fn drop(&mut self) {
+		if std::thread::panicking() {
+			// the test has already failed, do not panic again
+			return;
+		}
 		if let Some(next_expected) = self.expected_io.borrow().first() {
 			panic!("IO operations left unperformed. Next expected: {:?}", next_expected);
 		}


### PR DESCRIPTION
# Description

Quick fix to https://github.com/input-output-hk/partner-chains/pull/91 . `Drop` was triggered when the test
already failed and the thread was unwinding, which killed the whole test runner.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

