### PR TITLE
change: ETCM-8366 Make native token scripts optional

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 ## Changed
 
 * Added 'deregister' command to partner-chains-cli.
+* Made `MainChainScripts` in the native token pallet optional. If they are not set, the inherent data
+provider will not query the main chain state or produce inherent data at all.
 
 ## Removed
 

--- a/mainchain-follower/main-chain-follower-api/src/mock_services.rs
+++ b/mainchain-follower/main-chain-follower-api/src/mock_services.rs
@@ -13,8 +13,8 @@ mod block {
 
 	#[derive(new, Clone)]
 	pub struct MockBlockDataSource {
-		mainchain_block: MainchainBlock,
-		stable_blocks: Vec<MainchainBlock>,
+		pub mainchain_block: MainchainBlock,
+		pub stable_blocks: Vec<MainchainBlock>,
 	}
 
 	impl Default for MockBlockDataSource {
@@ -237,6 +237,12 @@ impl TestDataSources {
 	#[cfg(feature = "candidate-source")]
 	pub fn with_candidate_data_source(mut self, s: MockCandidateDataSource) -> TestDataSources {
 		self.candidate = Arc::from(s);
+		self
+	}
+
+	#[cfg(feature = "native-token")]
+	pub fn with_native_token_data_source(mut self, s: MockNativeTokenDataSource) -> Self {
+		self.native_token = Arc::from(s);
 		self
 	}
 }

--- a/node/src/tests/inherent_data_tests.rs
+++ b/node/src/tests/inherent_data_tests.rs
@@ -20,12 +20,25 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 		"0x0000000000000000000000000000000000000000000000000000000000000001",
 	);
 
+	let block_data_source = MockBlockDataSource::default();
+	let native_token_data_source = MockNativeTokenDataSource::new(
+		[(
+			(None, block_data_source.stable_blocks.first().unwrap().hash.clone()),
+			NativeTokenAmount(1000),
+		)]
+		.into(),
+	);
+	let data_sources = TestDataSources::new()
+		.with_block_data_source(block_data_source)
+		.with_native_token_data_source(native_token_data_source)
+		.into();
+
 	let inherent_data_providers = ProposalCIDP::new(
 		test_create_inherent_data_config(),
 		TestApi::new(ScEpochNumber(2))
 			.with_headers([(H256::zero(), mock_header())])
 			.into(),
-		TestDataSources::new().into(),
+		data_sources,
 	)
 	.create_inherent_data_providers(H256::zero(), ())
 	.await
@@ -83,7 +96,17 @@ async fn block_verification_cidp_should_be_created_correctly() {
 		timestamp: parent_stable_block.timestamp + 101,
 		epoch: McEpochNumber(parent_stable_block.epoch.0),
 	});
-	let data_sources = TestDataSources::new().with_block_data_source(block_data_source).into();
+	let native_token_data_source = MockNativeTokenDataSource::new(
+		[(
+			(None, block_data_source.stable_blocks.last().unwrap().hash.clone()),
+			NativeTokenAmount(1000),
+		)]
+		.into(),
+	);
+	let data_sources = TestDataSources::new()
+		.with_block_data_source(block_data_source)
+		.with_native_token_data_source(native_token_data_source)
+		.into();
 
 	let create_inherent_data_config = test_create_inherent_data_config();
 

--- a/node/src/tests/runtime_api_mock.rs
+++ b/node/src/tests/runtime_api_mock.rs
@@ -92,13 +92,15 @@ sp_api::mock_impl_runtime_apis! {
 	}
 
 	impl sp_native_token_management::NativeTokenManagementApi<Block> for TestApi {
-		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
-			sp_native_token_management::MainChainScripts {
-				native_token_policy_id: Default::default(),
-				native_token_asset_name: Default::default(),
-				illiquid_supply_validator_address: Default::default(),
+		fn get_main_chain_scripts() -> Option<sp_native_token_management::MainChainScripts> {
+			Some(
+				sp_native_token_management::MainChainScripts {
+					native_token_policy_id: Default::default(),
+					native_token_asset_name: Default::default(),
+					illiquid_supply_validator_address: Default::default(),
 
-			}
+				}
+			)
 		}
 	}
 }

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -138,6 +138,10 @@ pub mod pallet {
 			token_amount: NativeTokenAmount,
 		) -> DispatchResult {
 			ensure_none(origin)?;
+			assert!(
+				MainChainScriptsConfiguration::<T>::exists(),
+				"BUG: Inherent should not be run unless the main chain scripts are set."
+			);
 			T::TokenTransferHandler::handle_token_transfer(token_amount)
 		}
 

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -58,7 +58,7 @@ pub mod pallet {
 
 	#[pallet::storage]
 	pub type MainChainScriptsConfiguration<T: Config> =
-		StorageValue<_, sp_native_token_management::MainChainScripts, ValueQuery>;
+		StorageValue<_, sp_native_token_management::MainChainScripts, OptionQuery>;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]
@@ -164,7 +164,7 @@ pub mod pallet {
 	}
 
 	impl<T: Config> Pallet<T> {
-		pub fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+		pub fn get_main_chain_scripts() -> Option<sp_native_token_management::MainChainScripts> {
 			MainChainScriptsConfiguration::<T>::get()
 		}
 	}

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -119,9 +119,12 @@ mod inherent_provider {
 			C::Api: NativeTokenManagementApi<Block>,
 		{
 			let api = client.runtime_api();
-			let scripts = api
+			let Some(scripts) = api
 				.get_main_chain_scripts(parent_hash)
-				.map_err(IDPCreationError::GetMainChainScriptsError)?;
+				.map_err(IDPCreationError::GetMainChainScriptsError)?
+			else {
+				return Ok(Self { token_amount: None });
+			};
 			let parent_mc_hash: Option<McBlockHash> =
 				get_mc_hash_for_block(client.as_ref(), parent_hash)
 					.map_err(IDPCreationError::McHashError)?;
@@ -134,6 +137,8 @@ mod inherent_provider {
 					scripts.illiquid_supply_validator_address,
 				)
 				.await?;
+
+			let token_amount = Some(token_amount).filter(|amount| amount.0 > 0);
 
 			Ok(Self { token_amount })
 		}

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -150,7 +150,7 @@ mod inherent_provider {
 			&self,
 			inherent_data: &mut InherentData,
 		) -> Result<(), sp_inherents::Error> {
-			if let Some(token_amount) = self.token_amount.clone() {
+			if let Some(token_amount) = self.token_amount {
 				inherent_data.put_data(INHERENT_IDENTIFIER, &TokenTransferData { token_amount })
 			} else {
 				Ok(())

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -52,7 +52,7 @@ impl MainChainScripts {
 
 sp_api::decl_runtime_apis! {
 	pub trait NativeTokenManagementApi {
-		fn get_main_chain_scripts() -> MainChainScripts;
+		fn get_main_chain_scripts() -> Option<MainChainScripts>;
 	}
 }
 
@@ -92,7 +92,7 @@ mod inherent_provider {
 	use std::sync::Arc;
 
 	pub struct NativeTokenManagementInherentDataProvider {
-		pub token_amount: NativeTokenAmount,
+		pub token_amount: Option<NativeTokenAmount>,
 	}
 
 	#[derive(thiserror::Error, sp_runtime::RuntimeDebug)]
@@ -145,10 +145,11 @@ mod inherent_provider {
 			&self,
 			inherent_data: &mut InherentData,
 		) -> Result<(), sp_inherents::Error> {
-			inherent_data.put_data(
-				INHERENT_IDENTIFIER,
-				&TokenTransferData { token_amount: self.token_amount.clone() },
-			)
+			if let Some(token_amount) = self.token_amount.clone() {
+				inherent_data.put_data(INHERENT_IDENTIFIER, &TokenTransferData { token_amount })
+			} else {
+				Ok(())
+			}
 		}
 
 		async fn try_handle_error(

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -36,7 +36,7 @@ mod inherent_provider {
 		.await
 		.expect("Should not fail");
 
-		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+		assert_eq!(inherent_provider.token_amount, Some(NativeTokenAmount(total_transfered)))
 	}
 
 	#[tokio::test]
@@ -61,7 +61,7 @@ mod inherent_provider {
 		.await
 		.expect("Should not fail");
 
-		assert_eq!(inherent_provider.token_amount.0, total_transfered)
+		assert_eq!(inherent_provider.token_amount, Some(NativeTokenAmount(total_transfered)))
 	}
 
 	#[tokio::test]
@@ -84,7 +84,7 @@ mod inherent_provider {
 		.await
 		.expect("Should not fail");
 
-		assert_eq!(inherent_provider.token_amount.0, 0)
+		assert_eq!(inherent_provider.token_amount, None);
 	}
 
 	#[tokio::test]
@@ -94,7 +94,7 @@ mod inherent_provider {
 		let mut inherent_data = InherentData::new();
 
 		let inherent_provider = NativeTokenManagementInherentDataProvider {
-			token_amount: NativeTokenAmount(token_amount),
+			token_amount: Some(NativeTokenAmount(token_amount)),
 		};
 
 		inherent_provider.provide_inherent_data(&mut inherent_data).await.unwrap();

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod runtime_api_mock;
 mod inherent_provider {
 	use super::runtime_api_mock::*;
 	use crate::inherent_provider::*;
+	use crate::MainChainScripts;
 	use crate::INHERENT_IDENTIFIER;
 	use main_chain_follower_api::mock_services::MockNativeTokenDataSource;
 	use sidechain_domain::*;
@@ -25,7 +26,8 @@ mod inherent_provider {
 
 		let data_source =
 			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
-		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+		let main_chain_scripts = Some(MainChainScripts::default());
+		let client = create_client(parent_hash, parent_mc_hash, parent_number, main_chain_scripts);
 
 		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
 			client,
@@ -50,7 +52,8 @@ mod inherent_provider {
 
 		let data_source =
 			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
-		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+		let main_chain_scripts = Some(MainChainScripts::default());
+		let client = create_client(parent_hash, parent_mc_hash, parent_number, main_chain_scripts);
 
 		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
 			client,
@@ -65,7 +68,7 @@ mod inherent_provider {
 	}
 
 	#[tokio::test]
-	async fn defaults_to_zero_when_no_data() {
+	async fn defaults_to_none_when_no_data() {
 		let parent_number = 1;
 
 		let mc_hash = McBlockHash([1; 32]);
@@ -73,7 +76,8 @@ mod inherent_provider {
 		let parent_mc_hash = Some(McBlockHash([3; 32]));
 
 		let data_source = MockNativeTokenDataSource::new([].into());
-		let client = create_client(parent_hash, parent_mc_hash, parent_number);
+		let main_chain_scripts = Some(MainChainScripts::default());
+		let client = create_client(parent_hash, parent_mc_hash, parent_number, main_chain_scripts);
 
 		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
 			client,
@@ -85,6 +89,32 @@ mod inherent_provider {
 		.expect("Should not fail");
 
 		assert_eq!(inherent_provider.token_amount, None);
+	}
+
+	#[tokio::test]
+	async fn defaults_to_none_when_scripts_are_unset() {
+		let parent_number = 1; // not genesis
+
+		let mc_hash = McBlockHash([1; 32]);
+		let parent_hash = Hash::from([2; 32]);
+		let parent_mc_hash = Some(McBlockHash([3; 32]));
+		let total_transfered = 103;
+
+		let data_source =
+			create_data_source(parent_mc_hash.clone(), mc_hash.clone(), total_transfered);
+		let main_chain_scripts = None;
+		let client = create_client(parent_hash, parent_mc_hash, parent_number, main_chain_scripts);
+
+		let inherent_provider = NativeTokenManagementInherentDataProvider::new(
+			client,
+			&data_source,
+			mc_hash,
+			parent_hash,
+		)
+		.await
+		.expect("Should not fail");
+
+		assert_eq!(inherent_provider.token_amount, None)
 	}
 
 	#[tokio::test]
@@ -122,6 +152,7 @@ mod inherent_provider {
 		parent_hash: Hash,
 		parent_mc_hash: Option<McBlockHash>,
 		parent_number: u32,
+		main_chain_scripts: Option<MainChainScripts>,
 	) -> Arc<TestApi> {
 		Arc::new(TestApi {
 			headers: [(
@@ -143,6 +174,7 @@ mod inherent_provider {
 				},
 			)]
 			.into(),
+			main_chain_scripts,
 		})
 	}
 }

--- a/primitives/native-token-management/src/tests/runtime_api_mock.rs
+++ b/primitives/native-token-management/src/tests/runtime_api_mock.rs
@@ -15,6 +15,7 @@ pub type Header = <Block as sp_runtime::traits::Block>::Header;
 #[derive(Clone)]
 pub struct TestApi {
 	pub headers: HashMap<<Block as BlockT>::Hash, <Block as BlockT>::Header>,
+	pub main_chain_scripts: Option<MainChainScripts>,
 }
 
 impl sp_api::ProvideRuntimeApi<Block> for TestApi {
@@ -28,7 +29,7 @@ impl sp_api::ProvideRuntimeApi<Block> for TestApi {
 sp_api::mock_impl_runtime_apis! {
 	impl crate::NativeTokenManagementApi<Block> for TestApi {
 		fn get_main_chain_scripts() -> Option<MainChainScripts> {
-			Some(MainChainScripts::default())
+			self.main_chain_scripts.clone()
 		}
 
 	}

--- a/primitives/native-token-management/src/tests/runtime_api_mock.rs
+++ b/primitives/native-token-management/src/tests/runtime_api_mock.rs
@@ -27,8 +27,8 @@ impl sp_api::ProvideRuntimeApi<Block> for TestApi {
 
 sp_api::mock_impl_runtime_apis! {
 	impl crate::NativeTokenManagementApi<Block> for TestApi {
-		fn get_main_chain_scripts() -> MainChainScripts {
-			MainChainScripts::default()
+		fn get_main_chain_scripts() -> Option<MainChainScripts> {
+			Some(MainChainScripts::default())
 		}
 
 	}

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -861,7 +861,7 @@ impl_runtime_apis! {
 	}
 
 	impl sp_native_token_management::NativeTokenManagementApi<Block> for Runtime {
-		fn get_main_chain_scripts() -> sp_native_token_management::MainChainScripts {
+		fn get_main_chain_scripts() -> Option<sp_native_token_management::MainChainScripts> {
 			NativeTokenManagement::get_main_chain_scripts()
 		}
 	}


### PR DESCRIPTION
# Description

Makes the scripts optional in the native token pallet. If they're absent, the IDP will not query the main chain state at all and will not trigger the inherent.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

