### PR TITLE
chore: update rust toolchain after polkadot-sdk

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -12,7 +12,7 @@ ci:
   BUILD +docker --image=$image --tags=$tags
 
 setup:
-  FROM paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v202406031250
+  FROM paritytech/ci-unified:bullseye-1.81.0-2024-09-11-v202409111034
   WORKDIR /build
 
   # copy pre-existing $CARGO_HOME artifacts into the cache
@@ -164,4 +164,3 @@ chainspecs:
   SAVE ARTIFACT devnet_chain_spec.json AS LOCAL devnet_chain_spec.json
   SAVE ARTIFACT staging_preview_chain_spec.json AS LOCAL staging_preview_chain_spec.json
   SAVE ARTIFACT staging_preprod_chain_spec.json AS LOCAL staging_preprod_chain_spec.json
-      

--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,7 @@ provider will not query the main chain state or produce inherent data at all.
 * * Requires some downstream changes in the node code.
 * * See diff of the commit that adds this changelog line for hints.
 * * Specific changes will depend on the node implementation.
+* Update toolchain to 1.81.0
 
 ## Removed
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v202406031250 as builder
+FROM docker.io/paritytech/ci-unified:bullseye-1.81.0-2024-09-11-v202409111034 as builder
 
 WORKDIR /partner-chains-node
 COPY . /partner-chains-node

--- a/docker/chain-spec/Dockerfile
+++ b/docker/chain-spec/Dockerfile
@@ -1,4 +1,4 @@
-FROM paritytech/ci-unified:bullseye-1.77.0-2024-04-10-v202406031250
+FROM paritytech/ci-unified:bullseye-1.81.0-2024-09-11-v202409111034
 
 RUN apt-get update && apt-get install -y git protobuf-compiler jq &&  \
     rm -rf /var/lib/apt/lists/*

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -16,7 +16,7 @@
       fromToolchainFile {
         file = ../rust-toolchain.toml;
         # Probably should be a flake input instead
-        sha256 = "+syqAd2kX8KVa8/U2gz3blIQTTsYYt3U63xBWaGOSc8=";
+        sha256 = "VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
       };
     packages = with pkgs;
       [

--- a/partner-chains-cli/src/register/register1.rs
+++ b/partner-chains-cli/src/register/register1.rs
@@ -743,7 +743,9 @@ MockIO::run_command("cardano-cli address build --payment-verification-key-file p
 				RESOURCE_CONFIG_PATH,
 				serde_json::json!({"cardano_cli": "cardano-cli", "substrate_node_base_path": "/path/to/data", "cardano_node_socket_path": "node.socket"}),
 			),
-			MockIO::print("⚙️ Set `CARDANO_NODE_SOCKET_PATH` environment variable to `node.socket`"),
+			MockIO::print(
+				"⚙️ Set `CARDANO_NODE_SOCKET_PATH` environment variable to `node.socket`",
+			),
 			MockIO::set_env_var("CARDANO_NODE_SOCKET_PATH", "node.socket"),
 		]
 	}
@@ -784,7 +786,9 @@ MockIO::run_command("cardano-cli address build --payment-verification-key-file p
 				RESOURCE_CONFIG_PATH,
 				serde_json::json!({"cardano_cli": "cardano-cli", "substrate_node_base_path": "/path/to/data", "cardano_node_socket_path": "node.socket", "cardano_payment_verification_key_file": "payment.vkey"}),
 			),
-			MockIO::print("⚙️ Set `CARDANO_NODE_SOCKET_PATH` environment variable to `node.socket`"),
+			MockIO::print(
+				"⚙️ Set `CARDANO_NODE_SOCKET_PATH` environment variable to `node.socket`",
+			),
 			MockIO::set_env_var("CARDANO_NODE_SOCKET_PATH", "node.socket"),
 			MockIO::file_read(RESOURCE_CONFIG_PATH),
 			MockIO::prompt(

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.77.0"
+channel = "1.81.0"
 components = [
     "cargo",
     "clippy",


### PR DESCRIPTION
# Description

Polkadot-sdk has moved to 1.81.0. Perhaps we can do it as well.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

