### PR TITLE
fix: 'cargo build' should not fail because of missing perl

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -29,6 +29,7 @@
         gnumake
         gawk
         cargo-edit
+        perl
       ]
       ++ (
         if isDarwin


### PR DESCRIPTION
# Description

On a fresh OS, my build failed:
```
   Compiling openssl v0.10.64
   Compiling webpki-roots v0.25.4
error: failed to run custom build command for `openssl-sys v0.9.102`

Caused by:
  process didn't exit successfully: `/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-b78964e6dae045b0/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_NO_VENDOR
  X86_64_UNKNOWN_LINUX_GNU_OPENSSL_NO_VENDOR unset
  cargo:rerun-if-env-changed=OPENSSL_NO_VENDOR
  OPENSSL_NO_VENDOR unset
  OUT_DIR = Some(/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-a3de202ef55a8efc/out)
  cargo:rerun-if-env-changed=CC_x86_64-unknown-linux-gnu
  CC_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CC_x86_64_unknown_linux_gnu
  CC_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CC
  HOST_CC = None
  cargo:rerun-if-env-changed=CC
  CC = None
  cargo:rerun-if-env-changed=CC_ENABLE_DEBUG_OUTPUT
  RUSTC_WRAPPER = Some(/home/lglo/.cargo/bin/sccache)
  cargo:rerun-if-env-changed=CRATE_CC_NO_DEFAULTS
  CRATE_CC_NO_DEFAULTS = None
  DEBUG = Some(false)
  cargo:rerun-if-env-changed=CFLAGS_x86_64-unknown-linux-gnu
  CFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=CFLAGS_x86_64_unknown_linux_gnu
  CFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_CFLAGS
  HOST_CFLAGS = None
  cargo:rerun-if-env-changed=CFLAGS
  CFLAGS = None
  cargo:rerun-if-env-changed=AR_x86_64-unknown-linux-gnu
  AR_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=AR_x86_64_unknown_linux_gnu
  AR_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_AR
  HOST_AR = None
  cargo:rerun-if-env-changed=AR
  AR = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64-unknown-linux-gnu
  ARFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=ARFLAGS_x86_64_unknown_linux_gnu
  ARFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_ARFLAGS
  HOST_ARFLAGS = None
  cargo:rerun-if-env-changed=ARFLAGS
  ARFLAGS = None
  cargo:rerun-if-env-changed=RANLIB_x86_64-unknown-linux-gnu
  RANLIB_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=RANLIB_x86_64_unknown_linux_gnu
  RANLIB_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_RANLIB
  HOST_RANLIB = None
  cargo:rerun-if-env-changed=RANLIB
  RANLIB = None
  cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64-unknown-linux-gnu
  RANLIBFLAGS_x86_64-unknown-linux-gnu = None
  cargo:rerun-if-env-changed=RANLIBFLAGS_x86_64_unknown_linux_gnu
  RANLIBFLAGS_x86_64_unknown_linux_gnu = None
  cargo:rerun-if-env-changed=HOST_RANLIBFLAGS
  HOST_RANLIBFLAGS = None
  cargo:rerun-if-env-changed=RANLIBFLAGS
  RANLIBFLAGS = None
  running cd "/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-a3de202ef55a8efc/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-a3de202ef55a8efc/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "--target=x86_64-unknown-linux-gnu"

  --- stderr
  Can't locate FindBin.pm in @INC (you may need to install the FindBin module) (@INC entries checked: /usr/local/lib64/perl5/5.38 /usr/local/share/perl5/5.38 /usr/lib64/perl5/vendor_perl /usr/share/perl5/vendor_perl /usr/lib64/perl5 /usr/share/perl5) at ./Configure line 15.
  BEGIN failed--compilation aborted at ./Configure line 15.
  thread 'main' panicked at /home/lglo/.cargo/registry/src/index.crates.io-6f17d22bba15001f/openssl-src-300.3.1+3.3.1/src/lib.rs:621:9:



  Error configuring OpenSSL build:
      Command: cd "/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-a3de202ef55a8efc/out/openssl-build/build/src" && env -u CROSS_COMPILE AR="ar" CC="cc" RANLIB="ranlib" "perl" "./Configure" "--prefix=/home/lglo/iohk/partner-chains/target/release/build/openssl-sys-a3de202ef55a8efc/out/openssl-build/install" "--openssldir=/usr/local/ssl" "no-dso" "no-shared" "no-ssl3" "no-tests" "no-comp" "no-zlib" "no-zlib-dynamic" "--libdir=lib" "no-md2" "no-rc5" "no-weak-ssl-ciphers" "no-camellia" "no-idea" "no-seed" "linux-x86_64" "-O2" "-ffunction-sections" "-fdata-sections" "-fPIC" "-m64" "--target=x86_64-unknown-linux-gnu"
      Exit status: exit status: 2
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

