### PR TITLE
change: use boxed error for native token IDP error

### DIFF
--- a/mainchain-follower/db-sync-follower/src/native_token/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/native_token/mod.rs
@@ -25,8 +25,6 @@ pub struct NativeTokenManagementDataSourceImpl {
 
 observed_async_trait!(
 impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
-	type Error = DataSourceError;
-
 	// after_block is always less or equal to_block
 	// to_block is always a stable block
 	async fn get_total_native_token_transfer(
@@ -36,7 +34,7 @@ impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
 		policy_id: PolicyId,
 		asset_name: AssetName,
 		address: MainchainAddress,
-	) -> std::result::Result<NativeTokenAmount, Self::Error> {
+	) -> std::result::Result<NativeTokenAmount, Box<dyn std::error::Error + Send + Sync>> {
 		if let Some(after_block) = after_block {
 			if after_block == to_block {
 				Ok(NativeTokenAmount(0))

--- a/mainchain-follower/mock/src/native_token.rs
+++ b/mainchain-follower/mock/src/native_token.rs
@@ -1,5 +1,4 @@
 use async_trait::async_trait;
-use main_chain_follower_api::*;
 use sidechain_domain::*;
 use sp_native_token_management::NativeTokenManagementDataSource;
 
@@ -19,8 +18,6 @@ impl Default for NativeTokenDataSourceMock {
 
 #[async_trait]
 impl NativeTokenManagementDataSource for NativeTokenDataSourceMock {
-	type Error = DataSourceError;
-
 	async fn get_total_native_token_transfer(
 		&self,
 		_after_block: Option<McBlockHash>,
@@ -28,7 +25,7 @@ impl NativeTokenManagementDataSource for NativeTokenDataSourceMock {
 		_native_token_policy_id: PolicyId,
 		_native_token_asset_name: AssetName,
 		_illiquid_supply_address: MainchainAddress,
-	) -> Result<NativeTokenAmount> {
+	) -> Result<NativeTokenAmount, Box<dyn std::error::Error + Send + Sync>> {
 		Ok(NativeTokenAmount(1000))
 	}
 }

--- a/node/src/main_chain_follower.rs
+++ b/node/src/main_chain_follower.rs
@@ -2,7 +2,7 @@ use db_sync_follower::native_token::NativeTokenManagementDataSourceImpl;
 use db_sync_follower::{
 	block::BlockDataSourceImpl, candidates::CandidatesDataSourceImpl, metrics::McFollowerMetrics,
 };
-use main_chain_follower_api::{BlockDataSource, CandidateDataSource, DataSourceError};
+use main_chain_follower_api::{BlockDataSource, CandidateDataSource};
 use main_chain_follower_mock::{
 	block::BlockDataSourceMock, candidate::MockCandidateDataSource,
 	native_token::NativeTokenDataSourceMock,
@@ -16,8 +16,7 @@ use std::sync::Arc;
 pub struct DataSources {
 	pub block: Arc<dyn BlockDataSource + Send + Sync>,
 	pub candidate: Arc<dyn CandidateDataSource + Send + Sync>,
-	pub native_token:
-		Arc<dyn NativeTokenManagementDataSource<Error = DataSourceError> + Send + Sync>,
+	pub native_token: Arc<dyn NativeTokenManagementDataSource + Send + Sync>,
 }
 
 pub(crate) async fn create_cached_main_chain_follower_data_sources(

--- a/primitives/native-token-management/src/tests/mod.rs
+++ b/primitives/native-token-management/src/tests/mod.rs
@@ -15,13 +15,6 @@ mod inherent_provider {
 	use sp_runtime::testing::DigestItem;
 	use std::sync::Arc;
 
-	#[derive(thiserror::Error, sp_runtime::RuntimeDebug)]
-	pub enum TestErr {
-		#[allow(unused)]
-		#[error("Test error")]
-		Err,
-	}
-
 	#[tokio::test]
 	async fn correctly_fetches_total_transfer_between_two_hashes() {
 		let parent_number = 1; // not genesis
@@ -82,7 +75,7 @@ mod inherent_provider {
 		let parent_hash = Hash::from([2; 32]);
 		let parent_mc_hash = Some(McBlockHash([3; 32]));
 
-		let data_source = MockNativeTokenDataSource::<TestErr>::new([].into());
+		let data_source = MockNativeTokenDataSource::new([].into());
 		let main_chain_scripts = Some(MainChainScripts::default());
 		let client = create_client(parent_hash, parent_mc_hash, parent_number, main_chain_scripts);
 
@@ -150,7 +143,7 @@ mod inherent_provider {
 		parent_mc_hash: Option<McBlockHash>,
 		mc_hash: McBlockHash,
 		total_transfered: u128,
-	) -> MockNativeTokenDataSource<TestErr> {
+	) -> MockNativeTokenDataSource {
 		let total_transfered = NativeTokenAmount(total_transfered);
 		MockNativeTokenDataSource::new([((parent_mc_hash, mc_hash), total_transfered)].into())
 	}


### PR DESCRIPTION
# Description

Removes the type parameter `Error` of the `NativeTokenDataSource` trait and uses `Box<dyn Error + Send + Sync>` instead. There was no real benefit to keeping it generic.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

