### PR TITLE
fix: correct macos shell errors with native deps

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,11 +21,13 @@
     packages = with pkgs;
       [
         coreutils
+        pkg-config
         protobuf
-        rustToolchain # The rust toolchain we constructed above
+        rustToolchain
         nodejs
-        clang
         nodePackages.npm
+        pkgs.libiconv
+        pkgs.openssl
         gnumake
         gawk
         cargo-edit
@@ -34,37 +36,22 @@
       ++ (
         if isDarwin
         then
-          with pkgs.darwin.apple_sdk_11_0; [
-            frameworks.SystemConfiguration
-            frameworks.CoreFoundation
-            darwin.Libsystem
-          ]
-        else []
+           [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ]
+        else [ pkgs.clang ]
       );
     env = [
       {
         name = "RUST_SRC_PATH";
         value = "${rustToolchain}/lib/rustlib/src/rust/library";
       }
-      {
-        name = "LIBCLANG_PATH";
-        value = "${pkgs.libclang.lib}/lib";
-      }
-      {
-        name = "LD_LIBRARY_PATH";
-        value = "${rustToolchain}/lib";
-      }
-      {
-        name = "BINDGEN_EXTRA_CLANG_ARGS";
-        value = with pkgs;
-          if isDarwin
-          then "-isystem ${darwin.Libsystem}/include"
-          else "-isystem ${libclang.lib}/lib/clang/${lib.getVersion libclang}/include";
-      }
-      {
-        name = "PATH";
-        prefix = "${pkgs.coreutils}/bin";
-      }
+      { name = "LIBCLANG_PATH"; value = "${pkgs.libclang.lib}/lib"; }
+      { name = "LD_LIBRARY_PATH"; value = "${rustToolchain}/lib"; }
+      { name = "ROCKSDB_LIB_DIR"; value = "${pkgs.rocksdb}/lib/"; }
+      { name = "OPENSSL_NO_VENDOR"; value = 1; }
+      { name = "OPENSSL_DIR"; value = "${pkgs.openssl.dev}"; }
+      { name = "OPENSSL_INCLUDE_DIR"; value = "${pkgs.openssl.dev}/include"; }
+      { name = "OPENSSL_LIB_DIR"; value = "${pkgs.openssl.out}/lib"; }
+
     ];
     # Main Categories which can include pkgs, or devShell-like sets
     # for commands and helpers


### PR DESCRIPTION
# Description
macOS devShells would build, but cargo itself was not able to build the project because of native dependency mixup with having clang provided by pkgs.clang instead of the apple-sdk specific versions. The project now builds the same with cargo on macOS as it does on linux.

Test by entering the devshell and running `cargo clean` and `cargo build`, to verify the whole project builds.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

