### PR TITLE
Implement pallet_session_validator_managment and pallet_session integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9223,6 +9223,8 @@ dependencies = [
  "pallet-session-validator-management",
  "pallet-sidechain",
  "sidechain-domain",
+ "sp-runtime",
+ "sp-session-validator-management",
  "sp-staking",
  "sp-std",
 ]

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,7 @@ provider will not query the main chain state or produce inherent data at all.
 * Removed the `main-chain-follower-api` completely. Each crate that depended on it now defines its own `*DataSource`
 trait, implemented by separate types in `db-sync-follower` and `main-chain-follower-mock` crates. For reference
 on how to create these new data sources see `node/src/main_chain_follower.rs` file.
+* Added `pallet-session` integration for `pallet-session-validator-management`. Not wired in the node.
 
 ## Removed
 

--- a/primitives/domain/src/lib.rs
+++ b/primitives/domain/src/lib.rs
@@ -229,7 +229,7 @@ impl TryFrom<Vec<u8>> for MainchainPublicKey {
 pub const MAINCHAIN_ADDRESS_HASH_LEN: usize = 28;
 
 /// Some hash of MainchainAddress, 28 bytes. Presumably blake2b_224.
-/// Way to get it: cardano-cli address key-hash --payment-verification-key-file <path to vkey>
+/// Way to get it: cardano-cli address key-hash --payment-verification-key-file FILE
 #[derive(
 	Clone, Copy, Decode, Default, Eq, Encode, Hash, MaxEncodedLen, PartialEq, ToDatum, TypeInfo,
 )]
@@ -524,7 +524,7 @@ impl CandidateRegistrations {
 /// -- keyi - 33 bytes compressed ECDSA public key of a committee member
 /// -- @
 /// newtype ATMSPlainAggregatePubKey = ATMSPlainAggregatePubKey ByteString
-/// https://github.com/input-output-hk/partner-chains-smart-contracts/blob/5b19d25a95c3ab49ae0e4c6ce0ec3376f13b3766/docs/Specification.md#L554-L561
+/// <https://github.com/input-output-hk/partner-chains-smart-contracts/blob/5b19d25a95c3ab49ae0e4c6ce0ec3376f13b3766/docs/Specification.md#L554-L561>
 #[derive(Clone, Debug, Decode, Encode, Eq, PartialEq, ToDatum, TypeInfo)]
 pub struct ATMSPlainAggregatePubKey(pub [u8; 32]);
 

--- a/primitives/session-manager/Cargo.toml
+++ b/primitives/session-manager/Cargo.toml
@@ -11,9 +11,11 @@ frame-system = { workspace = true }
 log = { workspace = true }
 pallet-session = { workspace = true }
 pallet-session-validator-management = { workspace = true }
+sp-session-validator-management = { workspace = true, optional = true }
 pallet-sidechain = { workspace = true }
 pallet-partner-chains-session = { workspace = true }
 sidechain-domain = { workspace = true }
+sp-runtime = { workspace = true, optional = true }
 sp-staking = { workspace = true }
 sp-std = { workspace = true }
 
@@ -23,12 +25,16 @@ pallet-session-validator-management = { workspace = true, features = ["mock"] }
 [features]
 default = ["std"]
 std = [
-	"frame-system/std",
-	"pallet-session-validator-management/std",
-	"pallet-sidechain/std",
-	"pallet-partner-chains-session/std",
-	"sidechain-domain/std",
-	"sp-staking/std",
-	"sp-std/std",
+    "frame-system/std",
+    "pallet-session-validator-management/std",
+    "sp-session-validator-management/std",
+    "sp-session-validator-management/serde",
+    "pallet-session/std",
+    "pallet-sidechain/std",
+    "pallet-partner-chains-session/std",
+    "sidechain-domain/std",
+    "sp-runtime/std",
+    "sp-staking/std",
+    "sp-std/std",
     "log/std",
 ]

--- a/primitives/session-manager/src/lib.rs
+++ b/primitives/session-manager/src/lib.rs
@@ -7,6 +7,9 @@ use log::info;
 use sp_staking::SessionIndex;
 use sp_std::vec::Vec;
 
+/// [`pallet_session`] and [`pallet_session_validator_management`] integration.
+pub mod pallet_session_support;
+
 #[derive(new)]
 pub struct ValidatorManagementSessionManager<T> {
 	_phantom: PhantomData<T>,

--- a/primitives/session-manager/src/pallet_session_support.rs
+++ b/primitives/session-manager/src/pallet_session_support.rs
@@ -1,0 +1,108 @@
+#![cfg_attr(not(feature = "std"), no_std)]
+
+use core::marker::PhantomData;
+use derive_new::new;
+use frame_system::pallet_prelude::BlockNumberFor;
+use log::debug;
+use sp_staking::SessionIndex;
+use sp_std::vec::Vec;
+
+/// Implements [`pallet_session::SessionManager`] and [`pallet_session::ShouldEndSession`] integrated with [`pallet_session_validator_management`].
+///
+/// To use it, wire it in runtime configuration of [`pallet_session`].
+#[allow(dead_code)]
+#[derive(new)]
+pub struct PalletSessionSupport<T> {
+	_phantom: PhantomData<T>,
+}
+
+impl<T: pallet_session_validator_management::Config + pallet_session::Config>
+	pallet_session::SessionManager<T::AccountId> for PalletSessionSupport<T>
+{
+	/// Sets the first validator-set by mapping the current committee from [`pallet_session_validator_management`]
+	fn new_session_genesis(_new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+		Some(
+			pallet_session_validator_management::Pallet::<T>::current_committee_storage()
+				.committee
+				.into_iter()
+				.map(|(id, _)| id.into())
+				.collect::<Vec<_>>(),
+		)
+	}
+
+	/// Rotates the committee in [`pallet_session_validator_management`] and plans this new committee as upcoming validator-set.
+	/// Updates the session index of [`pallet_session`].
+	// Instead of Some((*).expect) we could just use (*). However, we rather panic in presence of important programming errors.
+	fn new_session(new_index: SessionIndex) -> Option<Vec<T::AccountId>> {
+		debug!("PalletSessionSupport: New session {new_index}");
+		pallet_session::pallet::CurrentIndex::<T>::put(new_index);
+		Some(
+			pallet_session_validator_management::Pallet::<T>::rotate_committee_to_next_epoch()
+				.expect(
+					"PalletSessionSupport: Session should never end without current epoch validators defined. \
+				Check ShouldEndSession implementation or if it is used before starting new session",
+				).into_iter().map(|(id, _)| id.into()).collect::<Vec<_>>(),
+		)
+	}
+
+	fn end_session(end_index: SessionIndex) {
+		debug!("PalletSessionSupport: End session {end_index}");
+	}
+
+	// Session is expected to be at least 1 block behind sidechain epoch.
+	fn start_session(start_index: SessionIndex) {
+		let epoch_number = T::current_epoch_number();
+		debug!("PalletSessionSupport: Start session {start_index}, epoch {epoch_number}");
+	}
+}
+
+/// Tries to end each session in the first block of each partner chains epoch in which the committee for the epoch is defined.
+impl<T, EpochNumber> pallet_session::ShouldEndSession<BlockNumberFor<T>> for PalletSessionSupport<T>
+where
+	T: pallet_session_validator_management::Config<ScEpochNumber = EpochNumber>,
+	EpochNumber: Clone + PartialOrd,
+{
+	fn should_end_session(n: BlockNumberFor<T>) -> bool {
+		let current_epoch_number = T::current_epoch_number();
+
+		let should_end = current_epoch_number
+			> pallet_session_validator_management::Pallet::<T>::current_committee_storage().epoch
+			&& pallet_session_validator_management::Pallet::<T>::next_committee().is_some();
+		debug!("PalletSessionValidatorManagementSessionManager: should_end_session({n:?}) = {should_end}");
+		should_end
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::pallet_session_support::PalletSessionSupport;
+	use pallet_session::ShouldEndSession;
+	use pallet_session_validator_management::{
+		mock::mock_pallet::CurrentEpoch, mock::*, CommitteeInfo, CurrentCommittee, NextCommittee,
+	};
+	pub const IRRELEVANT: u64 = 2;
+
+	type Manager = PalletSessionSupport<Test>;
+
+	#[test]
+	fn should_end_session_if_last_one_ended_late_and_new_committee_is_defined() {
+		let current_committee_epoch = 100;
+		let current_committee = ids_and_keys_fn(&[ALICE]);
+		let next_committee_epoch = 102;
+		let next_committee = ids_and_keys_fn(&[BOB]);
+
+		new_test_ext().execute_with(|| {
+			CurrentCommittee::<Test>::put(CommitteeInfo {
+				epoch: current_committee_epoch,
+				committee: current_committee,
+			});
+			CurrentEpoch::<Test>::set(current_committee_epoch + 2);
+			assert!(!Manager::should_end_session(IRRELEVANT));
+			NextCommittee::<Test>::put(CommitteeInfo {
+				epoch: next_committee_epoch,
+				committee: next_committee,
+			});
+			assert!(Manager::should_end_session(IRRELEVANT));
+		});
+	}
+}

--- a/utils/plutus/plutus-datum-derive/src/lib.rs
+++ b/utils/plutus/plutus-datum-derive/src/lib.rs
@@ -12,7 +12,7 @@ use syn::{GenericParam, TypeParamBound};
 /// `constructor_datum` parameter should be used on a single field structs to decide if the field
 /// should be mapped to datum directly or wrapped in constructor datum with one variant and single
 /// field. Such distinction is required because exactly same Datum encoding, as in
-/// https://github.com/input-output-hk/trustless-sidechain, is required.
+/// <https://github.com/input-output-hk/partner-chains-smart-contracts>, is required.
 #[proc_macro_derive(ToDatum, attributes(constructor_datum))]
 pub fn to_datum_derive(input: TokenStream) -> TokenStream {
 	let ast = syn::parse(input).expect("Cannot parse source");


### PR DESCRIPTION
# Description

This simple integration allows to run a partner chain without using our custom `pallet-partner-chains-session`, using standard polkadot-sdk `pallet-session`.

It is known that this implementation has additional lag of one partner chains epoch when applying committees to sessions.

When `pallet-session` is used instead of `pallet-partner-chains-session` users have to call `setKeys` in `pallet-session`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

