### PR TITLE
change: simplify version-bound creation of native token IDP

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -29,7 +29,7 @@ on how to create these new data sources see `node/src/main_chain_follower.rs` fi
 ## Fixed
 
 ## Added
-* Added `new_for_runtime_version` factory for the native token inherent data provider,
+* Added `new_if_pallet_present` factory for the native token inherent data provider,
 allowing to selectively query main chain state based on runtime version
 
 # 1.2.0

--- a/docs/developer-guides/native-token-migration-guide.md
+++ b/docs/developer-guides/native-token-migration-guide.md
@@ -38,8 +38,8 @@ Consult the reference implementation in `node/src/main_chain_follower.rs` for an
 3. Add the inherent data provider to your inherent data provider creation logic.
 Consult the implementation in `node/src/inherent_data.rs` for an example.
 Because the inherent data provider should only run after the pallet is added and fully configured
-in the runtime, `new_if_pallet_present` factory function should be used instead of `new`.
-4. Release the new version of node and runtime.
+in the runtime, `new_if_pallet_present` factory function should be used instead of `new`, when added to an already running chain.
+4. Release or otherwise make available for deployment the new version of node and runtime.
 
 ### Upgrading the chain
 

--- a/docs/developer-guides/native-token-migration-guide.md
+++ b/docs/developer-guides/native-token-migration-guide.md
@@ -29,35 +29,29 @@ When using the `parner-chains-cli` wizard, these can be set up in the `prepare-c
 
 ## Migration Steps - adding the feature
 
+### Preparing the nodes
+1. Wire the data source into the node.
+Consult the reference implementation in `node/src/main_chain_follower.rs` for an example.
+2. Add the inherent data provider to your inherent data provider creation logic.
+Consult the implementation in `node/src/inherent_data.rs` for an example.
+Because the inherent data provider should only run after the pallet is added and fully configured
+in the runtime, `new_if_pallet_present` factory function should be used instead of `new`.
+3. Upgrade the nodes running the chain to the new node version containing the IDP added in previous steps.
+
+### Adding the pallet
 1. Add the pallet into the runtime. This requires implementing the trait `TokenTransferHandler`, which
 is left for the developers of each particular partner chain to implement according to their needs and
 ledger structure. Consult the implementation in `runtime/src/lib.rs` for an example with a mocked handler.
-2. Bump the runtime spec version and note its new value, we will refer to it as `start_version`.
-3. Wire the data source into the node.
-Consult the reference implementation in `node/src/main_chain_follower.rs` for an example.
-4. Add the inherent data provider to your inherent data provider creation logic.
-Consult the implementation in `node/src/inherent_data.rs` for an example.
-Because the inherent data provider should only run after the pallet is added and fully configured
-in the runtime, `new_for_runtime_version` factory function should be used, which accepts an additional predicate as argument, making it possible to specify the correct runtime version range:
-in this case `|version| version.spec_version >= start_version` should be used.
-5. Upgrade the nodes running the chain to the new node version containing the IDP added in previous steps.
-6. Perform a runtime upgrade (using `sudo` or other governance feature) to the spec version `start_version` containing the pallet.
-7. Invoke the `set_main_chain_scripts` extrinsic on the newly added pallet, using the governance mechanism,
+2. Perform a runtime upgrade (using `sudo` or other governance feature) to the version containing the pallet.
+3. Invoke the `set_main_chain_scripts` extrinsic on the newly added pallet, using the governance mechanism,
 to set the native token `policy ID` and `asset name`, and the `illiquid supply validator address`. After
 this step all information necessary is present, and the native token data provider will start producing
 the inherent data based on observed native token transfers, triggering the pallet's inherent when necessary. 
 
-
 ## Migration Steps - removing the feature
 
-1. Decide on a runtime version `stop_version` from which the native token observation should cease.
-2. Update the runtime version range predicate for `new_for_runtime_version` to use this runtime version as a limit.
-Assuming the "adding the feature" scenario was implemented earlier, the version bound will look like
-this: `|version| version.spec_version >= start_version && version.spec_version < stop_version`.
-3. Upgrade the nodes in the network to this new version.
-4. Remove the pallet completely from the runtime. The `TokenTransferHandler` can be removed as well.
-Bump the runtime spec version to `stop_version` with these changes.
-5. Perform runtime upgrade.
+1. Remove the pallet completely from the runtime. The `TokenTransferHandler` can be removed as well.
+2. Perform runtime upgrade.
 After this step _no further native token movement will be observed, even if performed on the main chain_.
 
 ---
@@ -65,5 +59,7 @@ After this step _no further native token movement will be observed, even if perf
 
 To support syncing and validating historical blocks, the data source and inherent data provider
 *must* not be removed from the node.
+
+Re-adding the pallet after it has been removed is not supported and its behaviour is left unspecified.
 
 ---

--- a/docs/developer-guides/native-token-migration-guide.md
+++ b/docs/developer-guides/native-token-migration-guide.md
@@ -29,20 +29,23 @@ When using the `parner-chains-cli` wizard, these can be set up in the `prepare-c
 
 ## Migration Steps - adding the feature
 
-### Preparing the nodes
-1. Wire the data source into the node.
-Consult the reference implementation in `node/src/main_chain_follower.rs` for an example.
-2. Add the inherent data provider to your inherent data provider creation logic.
-Consult the implementation in `node/src/inherent_data.rs` for an example.
-Because the inherent data provider should only run after the pallet is added and fully configured
-in the runtime, `new_if_pallet_present` factory function should be used instead of `new`.
-3. Upgrade the nodes running the chain to the new node version containing the IDP added in previous steps.
-
-### Adding the pallet
+### Preparing changes
 1. Add the pallet into the runtime. This requires implementing the trait `TokenTransferHandler`, which
 is left for the developers of each particular partner chain to implement according to their needs and
 ledger structure. Consult the implementation in `runtime/src/lib.rs` for an example with a mocked handler.
-2. Perform a runtime upgrade (using `sudo` or other governance feature) to the version containing the pallet.
+2. Wire the data source into the node.
+Consult the reference implementation in `node/src/main_chain_follower.rs` for an example.
+3. Add the inherent data provider to your inherent data provider creation logic.
+Consult the implementation in `node/src/inherent_data.rs` for an example.
+Because the inherent data provider should only run after the pallet is added and fully configured
+in the runtime, `new_if_pallet_present` factory function should be used instead of `new`.
+4. Release the new version of node and runtime.
+
+### Upgrading the chain
+
+The following steps need to be performed in order:
+1. Upgrade the nodes running the chain to the new node version containing the IDP.
+2. Perform a runtime upgrade (using `sudo` or other governance feature) to the new rutime version containing the pallet.
 3. Invoke the `set_main_chain_scripts` extrinsic on the newly added pallet, using the governance mechanism,
 to set the native token `policy ID` and `asset name`, and the `illiquid supply validator address`. After
 this step all information necessary is present, and the native token data provider will start producing

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -135,7 +135,7 @@ mod inherent_provider {
 	impl NativeTokenManagementInherentDataProvider {
 		/// Creates inherent data provider only if the pallet is present in the runtime.
 		/// Returns zero transfers if not.
-		pub async fn new_if_pallet_present<Block, C, E>(
+		pub async fn new_if_pallet_present<Block, C>(
 			client: Arc<C>,
 			data_source: &(dyn NativeTokenManagementDataSource + Send + Sync),
 			mc_hash: McBlockHash,


### PR DESCRIPTION
# Description

Changes the native tokens IDP's `new_for_runtime_version` to `new_if_pallet_present`, which only creates the IDP if the pallet is *currently* in the runtime. This should make adding the native token feature to an existing chain easier.

I tested the upgrade scenario with 3 local nodes.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

