### PR TITLE
change: ETCM-8716 prepare to support versioned datums

### DIFF
--- a/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
@@ -1,0 +1,45 @@
+use crate::DataSourceError::DatumDecodeError;
+use log::error;
+use num_traits::ToPrimitive;
+use plutus::Datum::*;
+use plutus::*;
+use sidechain_domain::*;
+
+pub enum DParamDatum {
+	/// Initial/legacy datum schema. If a datum doesn't contain a version, it is assumed to be V0
+	V0 { num_permissioned_candidates: u16, num_registered_candidates: u16 },
+}
+
+impl TryFrom<&Datum> for DParamDatum {
+	type Error = super::Error;
+	fn try_from(datum: &Datum) -> super::Result<Self> {
+		decode_legacy_d_parameter_datum(datum)
+	}
+}
+
+impl From<DParamDatum> for DParameter {
+	fn from(datum: DParamDatum) -> Self {
+		match datum {
+			DParamDatum::V0 { num_permissioned_candidates, num_registered_candidates } => {
+				Self { num_permissioned_candidates, num_registered_candidates }
+			},
+		}
+	}
+}
+
+fn decode_legacy_d_parameter_datum(datum: &Datum) -> super::Result<DParamDatum> {
+	let d_parameter = match datum {
+		ListDatum(items) => match items.first().zip(items.get(1)) {
+			Some((IntegerDatum(p), IntegerDatum(t))) => p.to_u16().zip(t.to_u16()).map(|(p, t)| {
+				DParamDatum::V0 { num_permissioned_candidates: p, num_registered_candidates: t }
+			}),
+			_ => None,
+		},
+		_ => None,
+	}
+	.ok_or(DatumDecodeError { datum: datum.clone(), to: "DParameter".to_string() });
+	if d_parameter.is_err() {
+		error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
+	}
+	Ok(d_parameter?)
+}

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
@@ -1,0 +1,11 @@
+pub use d_param::DParamDatum;
+pub use permissioned::PermissionedCandidateDatums;
+
+pub use registered::*;
+
+mod d_param;
+mod permissioned;
+mod registered;
+
+type Error = Box<dyn std::error::Error + Send + Sync>;
+type Result<T> = std::result::Result<T, Error>;

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
@@ -1,0 +1,77 @@
+use crate::DataSourceError::DatumDecodeError;
+use authority_selection_inherents::authority_selection_inputs::RawPermissionedCandidateData;
+use log::error;
+use plutus::Datum::*;
+use plutus::*;
+use sidechain_domain::*;
+
+pub enum PermissionedCandidateDatums {
+	/// Initial/legacy datum schema. If a datum doesn't contain a version, it is assumed to be V0
+	V0(Vec<PermissionedCandidateDatumV0>),
+}
+
+pub struct PermissionedCandidateDatumV0 {
+	sidechain_public_key: SidechainPublicKey,
+	aura_public_key: AuraPublicKey,
+	grandpa_public_key: GrandpaPublicKey,
+}
+
+impl TryFrom<&Datum> for PermissionedCandidateDatums {
+	type Error = super::Error;
+	fn try_from(datum: &Datum) -> super::Result<Self> {
+		Ok(PermissionedCandidateDatums::V0(decode_legacy_permissioned_candidates_datums(datum)?))
+	}
+}
+
+impl From<PermissionedCandidateDatumV0> for RawPermissionedCandidateData {
+	fn from(datum: PermissionedCandidateDatumV0) -> Self {
+		match datum {
+			PermissionedCandidateDatumV0 {
+				sidechain_public_key,
+				aura_public_key,
+				grandpa_public_key,
+			} => Self { sidechain_public_key, aura_public_key, grandpa_public_key },
+		}
+	}
+}
+
+impl From<PermissionedCandidateDatums> for Vec<RawPermissionedCandidateData> {
+	fn from(datums: PermissionedCandidateDatums) -> Self {
+		match datums {
+			PermissionedCandidateDatums::V0(datums) => datums.into_iter().map(From::from).collect(),
+		}
+	}
+}
+
+fn decode_legacy_permissioned_candidates_datums(
+	datum: &Datum,
+) -> super::Result<Vec<PermissionedCandidateDatumV0>> {
+	let permissioned_candidates: super::Result<Vec<PermissionedCandidateDatumV0>> = match datum {
+		ListDatum(list_datums) => list_datums
+			.iter()
+			.map(|keys_datum| match keys_datum {
+				ListDatum(d) => {
+					let sc = d.first().and_then(|d| d.as_bytestring())?;
+					let aura = d.get(1).and_then(|d| d.as_bytestring())?;
+					let grandpa = d.get(2).and_then(|d| d.as_bytestring())?;
+					Some(PermissionedCandidateDatumV0 {
+						sidechain_public_key: SidechainPublicKey(sc.clone()),
+						aura_public_key: AuraPublicKey(aura.clone()),
+						grandpa_public_key: GrandpaPublicKey(grandpa.clone()),
+					})
+				},
+				_ => None,
+			})
+			.collect::<Option<Vec<PermissionedCandidateDatumV0>>>(),
+		_ => None,
+	}
+	.ok_or(Box::new(DatumDecodeError {
+		datum: datum.clone(),
+		to: "PermissionedCandidateDatumV0".to_string(),
+	}));
+
+	if permissioned_candidates.is_err() {
+		error!("Could not decode {:?} to Permissioned candidates datum. Expected [[ByteString, ByteString, ByteString]].", datum.clone());
+	}
+	permissioned_candidates
+}

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -1,0 +1,136 @@
+use crate::candidates::{
+	AuraPublicKey, GrandpaPublicKey, MainchainSignature, McTxHash, SidechainPublicKey,
+	SidechainSignature, UtxoId, UtxoIndex,
+};
+use crate::Datum::{self, ByteStringDatum, ConstructorDatum, IntegerDatum};
+use sidechain_domain::*;
+
+/** Representation of the plutus type in the mainchain contract (rev 4ed2cc66c554ec8c5bec7b90ad9273e9069a1fb4)
+*
+* Note that the ECDSA secp256k1 public key is serialized in compressed format and the
+* sidechain signature does not contain the recovery bytes (it's just r an s concatenated).
+*
+* data BlockProducerRegistration = BlockProducerRegistration
+* { -- | Verification keys required by the stake ownership model
+*   -- | @since v4.0.0
+*  stakeOwnership :: StakeOwnership
+* , -- | public key in the sidechain's desired format
+*  sidechainPubKey :: LedgerBytes
+* , -- | Signature of the sidechain
+*   -- | @since v4.0.0
+*  sidechainSignature :: Signature
+* , -- | A UTxO that must be spent by the transaction
+*   -- | @since v4.0.0
+*  inputUtxo :: TxOutRef
+* , -- | Owner public key hash
+*   -- | @since v4.0.0
+*  ownPkh :: PubKeyHash
+* , -- | Sidechain authority discovery key
+*   -- | @since Unreleased
+*   auraKey :: LedgerBytes
+* , -- | Sidechain grandpa key
+*   -- | @since Unreleased
+*   grandpaKey :: LedgerBytes
+* }
+ */
+#[derive(Clone, Debug)]
+pub enum RegisterValidatorDatum {
+	/// Initial/legacy datum schema. If a datum doesn't contain a version, it is assumed to be V0
+	V0 {
+		stake_ownership: AdaBasedStaking,
+		sidechain_pub_key: SidechainPublicKey,
+		sidechain_signature: SidechainSignature,
+		consumed_input: UtxoId,
+		//ownPkh we don't use,
+		aura_pub_key: AuraPublicKey,
+		grandpa_pub_key: GrandpaPublicKey,
+	},
+}
+
+/// AdaBasedStaking is a variant of Plutus type StakeOwnership.
+/// The other variant, TokenBasedStaking, is not supported
+#[derive(Clone, Debug)]
+pub struct AdaBasedStaking {
+	pub pub_key: MainchainPublicKey,
+	pub signature: MainchainSignature,
+}
+
+impl TryFrom<&Datum> for RegisterValidatorDatum {
+	type Error = super::Error;
+
+	fn try_from(datum: &Datum) -> super::Result<Self> {
+		decode_legacy_register_validator_datum(datum).ok_or("Invalid registration datum".into())
+	}
+}
+
+pub fn decode_legacy_register_validator_datum(datum: &Datum) -> Option<RegisterValidatorDatum> {
+	match datum {
+		ConstructorDatum { constructor: 0, fields } => {
+			let stake_ownership = fields.first().and_then(decode_ada_based_staking_datum)?;
+			let sidechain_pub_key = fields
+				.get(1)
+				.and_then(|d| d.as_bytestring())
+				.map(|bytes| SidechainPublicKey(bytes.clone()))?;
+			let sidechain_signature = fields
+				.get(2)
+				.and_then(|d| d.as_bytestring())
+				.map(|bytes| SidechainSignature(bytes.clone()))?;
+			let consumed_input = fields.get(3).and_then(decode_utxo_id_datum)?;
+			let _own_pkh = fields.get(4).and_then(|d| d.as_bytestring())?;
+			let aura_pub_key = fields
+				.get(5)
+				.and_then(|d| d.as_bytestring())
+				.map(|bytes| AuraPublicKey(bytes.clone()))?;
+			let grandpa_pub_key = fields
+				.get(6)
+				.and_then(|d| d.as_bytestring())
+				.map(|bytes| GrandpaPublicKey(bytes.clone()))?;
+			Some(RegisterValidatorDatum::V0 {
+				stake_ownership,
+				sidechain_pub_key,
+				sidechain_signature,
+				consumed_input,
+				aura_pub_key,
+				grandpa_pub_key,
+			})
+		},
+
+		_ => None,
+	}
+}
+
+fn decode_ada_based_staking_datum(datum: &Datum) -> Option<AdaBasedStaking> {
+	match datum {
+		ConstructorDatum { constructor: 0, fields } => match fields.first().zip(fields.get(1)) {
+			Some((ByteStringDatum(f0), ByteStringDatum(f1))) => {
+				let pub_key = TryFrom::try_from(f0.clone()).ok()?;
+				Some(AdaBasedStaking { pub_key, signature: MainchainSignature(f1.clone()) })
+			},
+			_ => None,
+		},
+		_ => None,
+	}
+}
+fn decode_utxo_id_datum(datum: &Datum) -> Option<UtxoId> {
+	match datum {
+		ConstructorDatum { constructor: 0, fields } => match fields.first().zip(fields.get(1)) {
+			Some((f0, IntegerDatum(f1))) => {
+				let tx_hash = decode_tx_hash_datum(f0)?;
+				let index: u16 = TryFrom::try_from(f1.clone()).ok()?;
+				Some(UtxoId { tx_hash, index: UtxoIndex(index) })
+			},
+			_ => None,
+		},
+		_ => None,
+	}
+}
+/// Plutus type for TxHash is a sum type, we can parse only variant with constructor 0.
+fn decode_tx_hash_datum(datum: &Datum) -> Option<McTxHash> {
+	match datum {
+		ConstructorDatum { constructor: 0, fields } => {
+			let bytes = fields.first().and_then(|d| d.as_bytestring())?;
+			Some(McTxHash(TryFrom::try_from(bytes.clone()).ok()?))
+		},
+		_ => None,
+	}
+}

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -89,14 +89,6 @@ impl From<sidechain_domain::AssetName> for AssetName {
 }
 
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct DistributedSetData {
-	pub utxo_id_tx_hash: [u8; 32],
-	pub utxo_id_index: TxIndex,
-	pub asset_name: Vec<u8>,
-	pub datum: DbDatum,
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct Block {
 	pub block_no: BlockNumber,
 	pub hash: [u8; 32],

--- a/primitives/native-token-management/src/lib.rs
+++ b/primitives/native-token-management/src/lib.rs
@@ -95,7 +95,6 @@ mod inherent_provider {
 	use sidechain_mc_hash::get_mc_hash_for_block;
 	use sp_api::{ApiError, Core, ProvideRuntimeApi, RuntimeApiInfo};
 	use sp_blockchain::HeaderBackend;
-	use sp_version::RuntimeVersion;
 	use std::error::Error;
 	use std::sync::Arc;
 


### PR DESCRIPTION
# Description

This PR is quite big, but 90% of it is moving stuff around:

* Moves parsing of Ariadne datums in db-sync-follower to a separate `datum` module with minimal changes.
* For each datum that we parse, adds a new *Datum enum with a single variant `V0` as a starting point and uses it as an intermediate schema, castable to data expected by the *DataSource traits.

This PR doesn't yet add any logic to parse the new versioned datums, only prepares the structure and defaults to using the legacy parsing methods. I will do this in a separate PR after the implementation in smart contracts is finished and I can get some real datums onto preview.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

