### PR TITLE
change: ETCM-8721 parse datums with cardano-serialization-lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +972,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "cardano-serialization-lib"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a060cf6912878c0132ce9ac8577eb62f151ba8f00fe2e75a57f85260c696e421"
+dependencies = [
+ "bech32",
+ "cbor_event",
+ "cfg-if",
+ "clear_on_drop",
+ "cryptoxide",
+ "digest 0.9.0",
+ "ed25519-bip32",
+ "getrandom",
+ "hashlink 0.9.1",
+ "hex",
+ "itertools 0.10.5",
+ "js-sys",
+ "noop_proc_macro",
+ "num",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_os",
+ "schemars",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1027,12 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "cbor_event"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
 
 [[package]]
 name = "cc"
@@ -1196,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cli-commands"
 version = "1.2.0"
 dependencies = [
@@ -1215,6 +1270,15 @@ dependencies = [
  "sidechain-domain",
  "sp-io",
  "thiserror",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1573,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1585,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1608,6 +1672,12 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle 2.6.1",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "ctor"
@@ -1781,6 +1851,7 @@ dependencies = [
  "authority-selection-inherents",
  "bigdecimal 0.4.5",
  "blake2b_simd",
+ "cardano-serialization-lib",
  "chrono",
  "ctor",
  "derive-new",
@@ -2103,6 +2174,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2110,7 +2190,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -2127,7 +2207,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "zeroize",
@@ -2155,7 +2235,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -2365,7 +2445,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -2824,6 +2904,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3021,8 +3107,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3032,7 +3120,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
  "rand",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3105,7 +3193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3206,6 +3294,15 @@ name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4961,7 +5058,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -5025,7 +5122,7 @@ dependencies = [
  "c2-chacha",
  "curve25519-dalek",
  "either",
- "hashlink",
+ "hashlink 0.8.4",
  "lioness",
  "log",
  "parking_lot 0.12.3",
@@ -5404,6 +5501,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5524,6 +5627,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
  "serde",
@@ -6046,7 +6150,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
  "rand",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -6301,7 +6405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -7176,7 +7280,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7186,8 +7290,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7209,12 +7328,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7223,7 +7357,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7271,6 +7405,15 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7490,7 +7633,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle 2.6.1",
@@ -8919,6 +9062,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8941,7 +9108,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -9130,6 +9297,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9143,6 +9321,17 @@ name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9408,7 +9597,6 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
- "plutus",
  "pretty_assertions",
  "scale-info",
  "serde_json",
@@ -9495,7 +9683,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9569,7 +9757,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "ring 0.17.8",
  "rustc_version",
  "sha2 0.10.8",
@@ -10463,7 +10651,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashlink",
+ "hashlink 0.8.4",
  "hex",
  "indexmap 2.2.6",
  "log",
@@ -11827,7 +12015,7 @@ dependencies = [
  "digest 0.10.7",
  "rand",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -12605,7 +12793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,6 +645,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "bech32"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
+
+[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,6 +972,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "cardano-serialization-lib"
+version = "13.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a060cf6912878c0132ce9ac8577eb62f151ba8f00fe2e75a57f85260c696e421"
+dependencies = [
+ "bech32",
+ "cbor_event",
+ "cfg-if",
+ "clear_on_drop",
+ "cryptoxide",
+ "digest 0.9.0",
+ "ed25519-bip32",
+ "getrandom",
+ "hashlink 0.9.1",
+ "hex",
+ "itertools 0.10.5",
+ "js-sys",
+ "noop_proc_macro",
+ "num",
+ "num-bigint",
+ "num-derive",
+ "num-integer",
+ "num-traits",
+ "rand",
+ "rand_os",
+ "schemars",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha2 0.9.9",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -987,6 +1027,12 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
+
+[[package]]
+name = "cbor_event"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
 
 [[package]]
 name = "cc"
@@ -1196,6 +1242,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
+name = "clear_on_drop"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "cli-commands"
 version = "1.2.0"
 dependencies = [
@@ -1215,6 +1270,15 @@ dependencies = [
  "sidechain-domain",
  "sp-io",
  "thiserror",
+]
+
+[[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1573,7 +1637,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1585,7 +1649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1608,6 +1672,12 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle 2.6.1",
 ]
+
+[[package]]
+name = "cryptoxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "ctor"
@@ -1781,6 +1851,7 @@ dependencies = [
  "authority-selection-inherents",
  "bigdecimal 0.4.5",
  "blake2b_simd",
+ "cardano-serialization-lib",
  "chrono",
  "ctor",
  "derive-new",
@@ -2104,6 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ed25519-bip32"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
+dependencies = [
+ "cryptoxide",
+]
+
+[[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2111,7 +2191,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -2128,7 +2208,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "sha2 0.10.8",
  "zeroize",
@@ -2156,7 +2236,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -2366,7 +2446,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -2825,6 +2905,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,8 +3108,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3033,7 +3121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
  "rand",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3106,7 +3194,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -3207,6 +3295,15 @@ name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -4962,7 +5059,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core",
+ "rand_core 0.6.4",
  "zeroize",
 ]
 
@@ -5026,7 +5123,7 @@ dependencies = [
  "c2-chacha",
  "curve25519-dalek",
  "either",
- "hashlink",
+ "hashlink 0.8.4",
  "lioness",
  "log",
  "parking_lot 0.12.3",
@@ -5405,6 +5502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5525,6 +5628,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
  "serde",
@@ -6047,7 +6151,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
  "rand",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
 ]
@@ -6302,7 +6406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core",
+ "rand_core 0.6.4",
  "subtle 2.6.1",
 ]
 
@@ -7177,7 +7281,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7187,8 +7291,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7210,12 +7329,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_os"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
+dependencies = [
+ "cloudabi",
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.4.2",
+ "rdrand",
+ "wasm-bindgen",
+ "winapi",
+]
+
+[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7224,7 +7358,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -7272,6 +7406,15 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7491,7 +7634,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle 2.6.1",
@@ -8920,6 +9063,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "schnellru"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8942,7 +9109,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core",
+ "rand_core 0.6.4",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -9131,6 +9298,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9144,6 +9322,17 @@ name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9496,7 +9685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -9570,7 +9759,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "ring 0.17.8",
  "rustc_version",
  "sha2 0.10.8",
@@ -10464,7 +10653,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashlink",
+ "hashlink 0.8.4",
  "hex",
  "indexmap 2.2.6",
  "log",
@@ -11828,7 +12017,7 @@ dependencies = [
  "digest 0.10.7",
  "rand",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -12606,7 +12795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core",
+ "rand_core 0.6.4",
  "serde",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1865,7 +1865,6 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "pallet-sidechain-rpc",
- "plutus",
  "serde",
  "serde_json",
  "sidechain-domain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -645,12 +645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
-name = "bech32"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dabbe35f96fb9507f7330793dc490461b2962659ac5d427181e451a623751d1"
-
-[[package]]
 name = "bigdecimal"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,40 +966,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cardano-serialization-lib"
-version = "13.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a060cf6912878c0132ce9ac8577eb62f151ba8f00fe2e75a57f85260c696e421"
-dependencies = [
- "bech32",
- "cbor_event",
- "cfg-if",
- "clear_on_drop",
- "cryptoxide",
- "digest 0.9.0",
- "ed25519-bip32",
- "getrandom",
- "hashlink 0.9.1",
- "hex",
- "itertools 0.10.5",
- "js-sys",
- "noop_proc_macro",
- "num",
- "num-bigint",
- "num-derive",
- "num-integer",
- "num-traits",
- "rand",
- "rand_os",
- "schemars",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "sha2 0.9.9",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "cargo-platform"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,12 +987,6 @@ dependencies = [
  "serde_json",
  "thiserror",
 ]
-
-[[package]]
-name = "cbor_event"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "089a0261d1bc59e54e8e11860031efd88593f0e61b921172c474f1f38c2f2d3c"
 
 [[package]]
 name = "cc"
@@ -1242,15 +1196,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
 
 [[package]]
-name = "clear_on_drop"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38508a63f4979f0048febc9966fadbd48e5dab31fd0ec6a3f151bbf4a74f7423"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "cli-commands"
 version = "1.2.0"
 dependencies = [
@@ -1270,15 +1215,6 @@ dependencies = [
  "sidechain-domain",
  "sp-io",
  "thiserror",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1637,7 +1573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle 2.6.1",
  "zeroize",
 ]
@@ -1649,7 +1585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.7",
- "rand_core 0.6.4",
+ "rand_core",
  "typenum",
 ]
 
@@ -1672,12 +1608,6 @@ dependencies = [
  "generic-array 0.14.7",
  "subtle 2.6.1",
 ]
-
-[[package]]
-name = "cryptoxide"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382ce8820a5bb815055d3553a610e8cb542b2d767bbacea99038afda96cd760d"
 
 [[package]]
 name = "ctor"
@@ -1851,7 +1781,6 @@ dependencies = [
  "authority-selection-inherents",
  "bigdecimal 0.4.5",
  "blake2b_simd",
- "cardano-serialization-lib",
  "chrono",
  "ctor",
  "derive-new",
@@ -2174,15 +2103,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ed25519-bip32"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb588f93c0d91b2f668849fd6d030cddb0b2e31f105963be189da5acdf492a21"
-dependencies = [
- "cryptoxide",
-]
-
-[[package]]
 name = "ed25519-dalek"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,7 +2110,7 @@ checksum = "4a3daa8e81a3963a60642bcc1f90a670680bd4a77535faa384e9d1c79d620871"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -2207,7 +2127,7 @@ dependencies = [
  "ed25519",
  "hashbrown 0.14.5",
  "hex",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "sha2 0.10.8",
  "zeroize",
@@ -2235,7 +2155,7 @@ dependencies = [
  "generic-array 0.14.7",
  "group",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "serdect",
  "subtle 2.6.1",
@@ -2445,7 +2365,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle 2.6.1",
 ]
 
@@ -2904,12 +2824,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3107,10 +3021,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -3120,7 +3032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
  "rand",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -3193,7 +3105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle 2.6.1",
 ]
 
@@ -3294,15 +3206,6 @@ name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
-dependencies = [
- "hashbrown 0.14.5",
-]
-
-[[package]]
-name = "hashlink"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
@@ -5058,7 +4961,7 @@ checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
 dependencies = [
  "byteorder",
  "keccak",
- "rand_core 0.6.4",
+ "rand_core",
  "zeroize",
 ]
 
@@ -5122,7 +5025,7 @@ dependencies = [
  "c2-chacha",
  "curve25519-dalek",
  "either",
- "hashlink 0.8.4",
+ "hashlink",
  "lioness",
  "log",
  "parking_lot 0.12.3",
@@ -5501,12 +5404,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
-name = "noop_proc_macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
-
-[[package]]
 name = "normalize-line-endings"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,7 +5524,6 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "num-bigint",
  "num-integer",
  "num-traits",
  "serde",
@@ -6150,7 +6046,7 @@ checksum = "4e69bf016dc406eff7d53a7d3f7cf1c2e72c82b9088aac1118591e36dd2cd3e9"
 dependencies = [
  "bitcoin_hashes",
  "rand",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "unicode-normalization",
 ]
@@ -6405,7 +6301,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
 dependencies = [
  "base64ct",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle 2.6.1",
 ]
 
@@ -7280,7 +7176,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -7290,23 +7186,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -7328,27 +7209,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "wasm-bindgen",
- "winapi",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59cad018caf63deb318e5a4586d99a24424a364f40f1e5778c29aca23f4fc73e"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -7357,7 +7223,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -7405,15 +7271,6 @@ dependencies = [
  "ring 0.16.20",
  "time",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -7633,7 +7490,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core 0.6.4",
+ "rand_core",
  "signature",
  "spki",
  "subtle 2.6.1",
@@ -9062,30 +8919,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.71",
-]
-
-[[package]]
 name = "schnellru"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9108,7 +8941,7 @@ dependencies = [
  "curve25519-dalek",
  "getrandom_or_panic",
  "merlin",
- "rand_core 0.6.4",
+ "rand_core",
  "serde_bytes",
  "sha2 0.10.8",
  "subtle 2.6.1",
@@ -9297,17 +9130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9321,17 +9143,6 @@ name = "serde_derive"
 version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.71",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9684,7 +9495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -9758,7 +9569,7 @@ dependencies = [
  "blake2 0.10.6",
  "chacha20poly1305",
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "ring 0.17.8",
  "rustc_version",
  "sha2 0.10.8",
@@ -10652,7 +10463,7 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashlink 0.8.4",
+ "hashlink",
  "hex",
  "indexmap 2.2.6",
  "log",
@@ -12016,7 +11827,7 @@ dependencies = [
  "digest 0.10.7",
  "rand",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
  "sha2 0.10.8",
  "sha3",
  "thiserror",
@@ -12794,7 +12605,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
  "curve25519-dalek",
- "rand_core 0.6.4",
+ "rand_core",
  "serde",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9597,6 +9597,7 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-transaction-payment-rpc-runtime-api",
  "parity-scale-codec",
+ "plutus",
  "pretty_assertions",
  "scale-info",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,6 +152,7 @@ sp-consensus-grandpa = { default-features = false, git = "https://github.com/par
 sp-consensus-slots = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-core = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-crypto-hashing = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
+sp-genesis-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-inherents = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-io = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-keyring = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
@@ -172,7 +173,6 @@ substrate-frame-rpc-system = { default-features = false, git = "https://github.c
 substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 substrate-test-runtime-client = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 substrate-wasm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
-sp-genesis-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 cardano-serialization-lib = { default-features = false, version = "13.1.0" }
 
 # local dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -173,6 +173,7 @@ substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git
 substrate-test-runtime-client = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 substrate-wasm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
 sp-genesis-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }
+cardano-serialization-lib = { default-features = false, version = "13.1.0" }
 
 # local dependencies
 sidechain-runtime = { path = "runtime" }

--- a/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/mainchain-follower/db-sync-follower/Cargo.toml
@@ -13,7 +13,6 @@ chrono = "0.4.31"
 hex = { workspace = true }
 hex-literal = { workspace = true }
 itertools = { workspace = true }
-plutus = { workspace = true, default-features = true }
 sidechain-domain = { workspace = true, default-features = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/mainchain-follower/db-sync-follower/Cargo.toml
@@ -33,6 +33,7 @@ sp-native-token-management = { workspace = true, features = ["std"], optional = 
 sidechain-mc-hash = { workspace = true, optional = true }
 pallet-sidechain-rpc = { workspace = true, optional = true }
 authority-selection-inherents = { workspace = true, features = ["std"], optional = true }
+cardano-serialization-lib = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio-test = "0.4.3"
@@ -41,7 +42,7 @@ ctor = "0.2.5"
 [features]
 default = []
 block-source = []
-candidate-source = ["authority-selection-inherents"]
+candidate-source = ["authority-selection-inherents", "cardano-serialization-lib"]
 native-token = ["sp-native-token-management"]
 mc-hash = ["sidechain-mc-hash", "block-source"]
 sidechain-rpc = ["pallet-sidechain-rpc", "block-source"]

--- a/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/mainchain-follower/db-sync-follower/Cargo.toml
@@ -32,7 +32,7 @@ sp-native-token-management = { workspace = true, features = ["std"], optional = 
 sidechain-mc-hash = { workspace = true, optional = true }
 pallet-sidechain-rpc = { workspace = true, optional = true }
 authority-selection-inherents = { workspace = true, features = ["std"], optional = true }
-cardano-serialization-lib = { workspace = true, optional = true }
+cardano-serialization-lib = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "0.4.3"
@@ -41,7 +41,7 @@ ctor = "0.2.5"
 [features]
 default = []
 block-source = []
-candidate-source = ["authority-selection-inherents", "cardano-serialization-lib"]
+candidate-source = ["authority-selection-inherents"]
 native-token = ["sp-native-token-management"]
 mc-hash = ["sidechain-mc-hash", "block-source"]
 sidechain-rpc = ["pallet-sidechain-rpc", "block-source"]

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
@@ -1,9 +1,6 @@
 use crate::DataSourceError::DatumDecodeError;
 use cardano_serialization_lib::PlutusData;
 use log::error;
-use num_traits::ToPrimitive;
-use plutus::Datum::*;
-use plutus::*;
 use sidechain_domain::*;
 
 pub enum DParamDatum {
@@ -11,9 +8,9 @@ pub enum DParamDatum {
 	V0 { num_permissioned_candidates: u16, num_registered_candidates: u16 },
 }
 
-impl TryFrom<&Datum> for DParamDatum {
+impl TryFrom<PlutusData> for DParamDatum {
 	type Error = super::Error;
-	fn try_from(datum: &Datum) -> super::Result<Self> {
+	fn try_from(datum: PlutusData) -> super::Result<Self> {
 		decode_legacy_d_parameter_datum(datum)
 	}
 }
@@ -28,13 +25,26 @@ impl From<DParamDatum> for DParameter {
 	}
 }
 
-fn decode_legacy_d_parameter_datum(datum: &Datum) -> super::Result<DParamDatum> {
-	let d_parameter = match datum {
-		ListDatum(items) => match items.first().zip(items.get(1)) {
-			Some((IntegerDatum(p), IntegerDatum(t))) => p.to_u16().zip(t.to_u16()).map(|(p, t)| {
-				DParamDatum::V0 { num_permissioned_candidates: p, num_registered_candidates: t }
-			}),
-			_ => None,
+fn decode_legacy_d_parameter_datum(datum: PlutusData) -> super::Result<DParamDatum> {
+	let d_parameter = match datum.as_list() {
+		Some(items) if items.len() == 2 => {
+			match (items.get(0).as_integer(), items.get(1).as_integer()) {
+				(Some(p), Some(t)) => {
+					let p: Option<u16> = p
+						.as_u64()
+						.and_then(|v| u32::try_from(v).ok())
+						.and_then(|v| u16::try_from(v).ok());
+					let t: Option<u16> = t
+						.as_u64()
+						.and_then(|v| u32::try_from(v).ok())
+						.and_then(|v| u16::try_from(v).ok());
+					p.zip(t).map(|(p, t)| DParamDatum::V0 {
+						num_permissioned_candidates: p,
+						num_registered_candidates: t,
+					})
+				},
+				_ => None,
+			}
 		},
 		_ => None,
 	}
@@ -43,40 +53,4 @@ fn decode_legacy_d_parameter_datum(datum: &Datum) -> super::Result<DParamDatum> 
 		error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
 	}
 	Ok(d_parameter?)
-}
-
-#[allow(dead_code)]
-mod csl {
-	use super::*;
-
-	fn decode_legacy_d_parameter_datum(datum: &PlutusData) -> super::super::Result<DParamDatum> {
-		let d_parameter = match datum.as_list() {
-			Some(items) if items.len() == 2 => {
-				match (items.get(0).as_integer(), items.get(1).as_integer()) {
-					(Some(p), Some(t)) => {
-						let p: Option<u16> = p
-							.as_u64()
-							.and_then(|v| u32::try_from(v).ok())
-							.and_then(|v| u16::try_from(v).ok());
-						let t: Option<u16> = t
-							.as_u64()
-							.and_then(|v| u32::try_from(v).ok())
-							.and_then(|v| u16::try_from(v).ok());
-						p.zip(t).map(|(p, t)| DParamDatum::V0 {
-							num_permissioned_candidates: p,
-							num_registered_candidates: t,
-						})
-					},
-					_ => None,
-				}
-			},
-			_ => None,
-		}
-		.ok_or(format!("error").into());
-		// .ok_or(DatumDecodeError { datum: datum.clone(), to: "DParameter".to_string() });
-		if d_parameter.is_err() {
-			error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
-		}
-		d_parameter
-	}
 }

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
@@ -1,4 +1,5 @@
 use crate::DataSourceError::DatumDecodeError;
+use cardano_serialization_lib::PlutusData;
 use log::error;
 use num_traits::ToPrimitive;
 use plutus::Datum::*;
@@ -42,4 +43,40 @@ fn decode_legacy_d_parameter_datum(datum: &Datum) -> super::Result<DParamDatum> 
 		error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
 	}
 	Ok(d_parameter?)
+}
+
+#[allow(dead_code)]
+mod csl {
+	use super::*;
+
+	fn decode_legacy_d_parameter_datum(datum: &PlutusData) -> super::super::Result<DParamDatum> {
+		let d_parameter = match datum.as_list() {
+			Some(items) if items.len() == 2 => {
+				match (items.get(0).as_integer(), items.get(1).as_integer()) {
+					(Some(p), Some(t)) => {
+						let p: Option<u16> = p
+							.as_u64()
+							.and_then(|v| u32::try_from(v).ok())
+							.and_then(|v| u16::try_from(v).ok());
+						let t: Option<u16> = t
+							.as_u64()
+							.and_then(|v| u32::try_from(v).ok())
+							.and_then(|v| u16::try_from(v).ok());
+						p.zip(t).map(|(p, t)| DParamDatum::V0 {
+							num_permissioned_candidates: p,
+							num_registered_candidates: t,
+						})
+					},
+					_ => None,
+				}
+			},
+			_ => None,
+		}
+		.ok_or(format!("error").into());
+		// .ok_or(DatumDecodeError { datum: datum.clone(), to: "DParameter".to_string() });
+		if d_parameter.is_err() {
+			error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
+		}
+		d_parameter
+	}
 }

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
@@ -25,6 +25,7 @@ impl From<DParamDatum> for DParameter {
 	}
 }
 
+/// Parses plutus data schema that was used before datum versioning was added. Kept for backwards compatibility.
 fn decode_legacy_d_parameter_datum(datum: PlutusData) -> super::Result<DParamDatum> {
 	let d_parameter = datum
 		.as_list()

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/d_param.rs
@@ -1,9 +1,7 @@
+use super::PlutusDataExtensions;
 use crate::DataSourceError::DatumDecodeError;
 use cardano_serialization_lib::PlutusData;
-use log::error;
 use sidechain_domain::*;
-
-use super::PlutusDataExtensions;
 
 pub enum DParamDatum {
 	/// Initial/legacy datum schema. If a datum doesn't contain a version, it is assumed to be V0
@@ -28,19 +26,19 @@ impl From<DParamDatum> for DParameter {
 }
 
 fn decode_legacy_d_parameter_datum(datum: PlutusData) -> super::Result<DParamDatum> {
-	let d_parameter = match datum.as_list() {
-		Some(items) if items.len() == 2 => match (items.get(0).as_u16(), items.get(1).as_u16()) {
-			(Some(p), Some(t)) => Some(DParamDatum::V0 {
-				num_permissioned_candidates: p,
-				num_registered_candidates: t,
-			}),
-			_ => None,
-		},
-		_ => None,
-	}
-	.ok_or(DatumDecodeError { datum: datum.clone(), to: "DParameter".to_string() });
-	if d_parameter.is_err() {
-		error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
-	}
-	Ok(d_parameter?)
+	let d_parameter = datum
+		.as_list()
+		.filter(|datum| datum.len() == 2)
+		.and_then(|items| {
+			Some(DParamDatum::V0 {
+				num_permissioned_candidates: items.get(0).as_u16()?,
+				num_registered_candidates: items.get(1).as_u16()?,
+			})
+		})
+		.ok_or_else(|| {
+			log::error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
+			DatumDecodeError { datum: datum.clone(), to: "DParameter".to_string() }
+		})?;
+
+	Ok(d_parameter)
 }

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
@@ -9,3 +9,13 @@ mod registered;
 
 type Error = Box<dyn std::error::Error + Send + Sync>;
 type Result<T> = std::result::Result<T, Error>;
+
+trait PlutusDataExtensions {
+	fn as_u16(self) -> Option<u16>;
+}
+
+impl PlutusDataExtensions for cardano_serialization_lib::PlutusData {
+	fn as_u16(self) -> Option<u16> {
+		u16::try_from(u32::try_from(self.as_integer()?.as_u64()?).ok()?).ok()
+	}
+}

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/mod.rs
@@ -1,6 +1,5 @@
 pub use d_param::DParamDatum;
 pub use permissioned::PermissionedCandidateDatums;
-
 pub use registered::*;
 
 mod d_param;

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
@@ -41,6 +41,7 @@ impl From<PermissionedCandidateDatums> for Vec<RawPermissionedCandidateData> {
 	}
 }
 
+/// Parses plutus data schema that was used before datum versioning was added. Kept for backwards compatibility.
 fn decode_legacy_permissioned_candidates_datums(
 	datum: PlutusData,
 ) -> super::Result<Vec<PermissionedCandidateDatumV0>> {

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
@@ -52,19 +52,7 @@ fn decode_legacy_permissioned_candidates_datums(
 
 	let permissioned_candidates: Vec<PermissionedCandidateDatumV0> = list_datums
 		.into_iter()
-		.map(|keys_datum| match keys_datum.as_list() {
-			Some(d) if d.len() == 3 => {
-				let sc = d.get(0).as_bytes()?;
-				let aura = d.get(1).as_bytes()?;
-				let grandpa = d.get(2).as_bytes()?;
-				Some(PermissionedCandidateDatumV0 {
-					sidechain_public_key: SidechainPublicKey(sc),
-					aura_public_key: AuraPublicKey(aura),
-					grandpa_public_key: GrandpaPublicKey(grandpa),
-				})
-			},
-			_ => None,
-		})
+		.map(decode_legacy_candidate_datum)
 		.collect::<Option<Vec<PermissionedCandidateDatumV0>>>()
 		.ok_or_else(|| {
 			log::error!("Could not decode {:?} to Permissioned candidates datum. Expected [[ByteString, ByteString, ByteString]].", datum.clone());
@@ -75,4 +63,18 @@ fn decode_legacy_permissioned_candidates_datums(
 		})?;
 
 	Ok(permissioned_candidates)
+}
+
+fn decode_legacy_candidate_datum(datum: &PlutusData) -> Option<PermissionedCandidateDatumV0> {
+	let datums = datum.as_list().filter(|datums| datums.len() == 3)?;
+
+	let sc = datums.get(0).as_bytes()?;
+	let aura = datums.get(1).as_bytes()?;
+	let grandpa = datums.get(2).as_bytes()?;
+
+	Some(PermissionedCandidateDatumV0 {
+		sidechain_public_key: SidechainPublicKey(sc),
+		aura_public_key: AuraPublicKey(aura),
+		grandpa_public_key: GrandpaPublicKey(grandpa),
+	})
 }

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/permissioned.rs
@@ -75,3 +75,44 @@ fn decode_legacy_permissioned_candidates_datums(
 	}
 	permissioned_candidates
 }
+
+#[allow(dead_code)]
+mod csl {
+	use cardano_serialization_lib::PlutusData;
+
+	use super::*;
+	fn decode_legacy_permissioned_candidates_datums(
+		datum: &PlutusData,
+	) -> super::super::Result<Vec<PermissionedCandidateDatumV0>> {
+		let permissioned_candidates: super::super::Result<Vec<PermissionedCandidateDatumV0>> =
+			match datum.as_list() {
+				Some(list_datums) => list_datums
+					.into_iter()
+					.map(|keys_datum| match keys_datum.as_list() {
+						Some(d) if d.len() == 3 => {
+							let sc = d.get(0).as_bytes()?;
+							let aura = d.get(1).as_bytes()?;
+							let grandpa = d.get(2).as_bytes()?;
+							Some(PermissionedCandidateDatumV0 {
+								sidechain_public_key: SidechainPublicKey(sc.clone()),
+								aura_public_key: AuraPublicKey(aura.clone()),
+								grandpa_public_key: GrandpaPublicKey(grandpa.clone()),
+							})
+						},
+						_ => None,
+					})
+					.collect::<Option<Vec<PermissionedCandidateDatumV0>>>(),
+				_ => None,
+			}
+			.ok_or(format!("error").into());
+		// .ok_or(Box::new(DatumDecodeError {
+		// 	datum: datum.clone(),
+		// 	to: "PermissionedCandidateDatumV0".to_string(),
+		// }));
+
+		if permissioned_candidates.is_err() {
+			error!("Could not decode {:?} to Permissioned candidates datum. Expected [[ByteString, ByteString, ByteString]].", datum.clone());
+		}
+		permissioned_candidates
+	}
+}

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -1,12 +1,10 @@
+use super::PlutusDataExtensions;
 use crate::candidates::{
 	AuraPublicKey, GrandpaPublicKey, MainchainSignature, McTxHash, SidechainPublicKey,
 	SidechainSignature, UtxoId, UtxoIndex,
 };
-
 use cardano_serialization_lib::PlutusData;
 use sidechain_domain::*;
-
-use super::PlutusDataExtensions;
 
 /** Representation of the plutus type in the mainchain contract (rev 4ed2cc66c554ec8c5bec7b90ad9273e9069a1fb4)
 *
@@ -67,68 +65,55 @@ impl TryFrom<PlutusData> for RegisterValidatorDatum {
 }
 
 pub fn decode_legacy_register_validator_datum(datum: PlutusData) -> Option<RegisterValidatorDatum> {
-	match datum.as_constr_plutus_data() {
-		Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 7 => {
-			let fields = datum.data();
-			let stake_ownership = decode_ada_based_staking_datum(fields.get(0))?;
-			let sidechain_pub_key = fields.get(1).as_bytes().map(SidechainPublicKey)?;
-			let sidechain_signature = fields.get(2).as_bytes().map(SidechainSignature)?;
-			let consumed_input = decode_utxo_id_datum(fields.get(3))?;
-			let _own_pkh = fields.get(4).as_bytes()?;
-			let aura_pub_key = fields.get(5).as_bytes().map(AuraPublicKey)?;
-			let grandpa_pub_key = fields.get(6).as_bytes().map(GrandpaPublicKey)?;
-			Some(RegisterValidatorDatum::V0 {
-				stake_ownership,
-				sidechain_pub_key,
-				sidechain_signature,
-				consumed_input,
-				aura_pub_key,
-				grandpa_pub_key,
-			})
-		},
-
-		_ => None,
-	}
+	let fields = datum
+		.as_constr_plutus_data()
+		.filter(|datum| datum.alternative().is_zero())
+		.filter(|datum| datum.data().len() >= 7)?
+		.data();
+	let stake_ownership = decode_ada_based_staking_datum(fields.get(0))?;
+	let sidechain_pub_key = fields.get(1).as_bytes().map(SidechainPublicKey)?;
+	let sidechain_signature = fields.get(2).as_bytes().map(SidechainSignature)?;
+	let consumed_input = decode_utxo_id_datum(fields.get(3))?;
+	let _own_pkh = fields.get(4).as_bytes()?;
+	let aura_pub_key = fields.get(5).as_bytes().map(AuraPublicKey)?;
+	let grandpa_pub_key = fields.get(6).as_bytes().map(GrandpaPublicKey)?;
+	Some(RegisterValidatorDatum::V0 {
+		stake_ownership,
+		sidechain_pub_key,
+		sidechain_signature,
+		consumed_input,
+		aura_pub_key,
+		grandpa_pub_key,
+	})
 }
 
 fn decode_ada_based_staking_datum(datum: PlutusData) -> Option<AdaBasedStaking> {
-	match datum.as_constr_plutus_data() {
-		Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 2 => {
-			let fields = datum.data();
-			match (fields.get(0).as_bytes(), fields.get(1).as_bytes()) {
-				(Some(f0), Some(f1)) => {
-					let pub_key = TryFrom::try_from(f0).ok()?;
-					Some(AdaBasedStaking { pub_key, signature: MainchainSignature(f1) })
-				},
-				_ => None,
-			}
-		},
-		_ => None,
-	}
+	let fields = datum
+		.as_constr_plutus_data()
+		.filter(|datum| datum.alternative().is_zero())
+		.filter(|datum| datum.data().len() >= 2)?
+		.data();
+	let pub_key = TryFrom::try_from(fields.get(0).as_bytes()?).ok()?;
+	let signature = MainchainSignature(fields.get(1).as_bytes()?);
+	Some(AdaBasedStaking { pub_key, signature })
 }
 fn decode_utxo_id_datum(datum: PlutusData) -> Option<UtxoId> {
-	match datum.as_constr_plutus_data() {
-		Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 2 => {
-			let fields = datum.data();
-			match (fields.get(0), fields.get(1).as_u16()) {
-				(f0, Some(f1)) => {
-					let tx_hash = decode_tx_hash_datum(f0)?;
-					let index = UtxoIndex(f1);
-					Some(UtxoId { tx_hash, index })
-				},
-				_ => None,
-			}
-		},
-		_ => None,
-	}
+	let fields = datum
+		.as_constr_plutus_data()
+		.filter(|datum| datum.alternative().is_zero())
+		.filter(|datum| datum.data().len() >= 2)?
+		.data();
+	let tx_hash = decode_tx_hash_datum(fields.get(0))?;
+	let index = UtxoIndex(fields.get(1).as_u16()?);
+	Some(UtxoId { tx_hash, index })
 }
 /// Plutus type for TxHash is a sum type, we can parse only variant with constructor 0.
 fn decode_tx_hash_datum(datum: PlutusData) -> Option<McTxHash> {
-	match datum.as_constr_plutus_data() {
-		Some(datum) if datum.alternative().is_zero() && datum.data().len() > 0 => {
-			let bytes = datum.data().get(0).as_bytes()?;
-			Some(McTxHash(TryFrom::try_from(bytes.clone()).ok()?))
-		},
-		_ => None,
-	}
+	let constructor_datum = datum
+		.as_constr_plutus_data()
+		.filter(|datum| datum.alternative().is_zero())
+		.filter(|datum| datum.data().len() >= 1)?;
+	let bytes = constructor_datum.data().get(0).as_bytes()?;
+
+	Some(McTxHash(TryFrom::try_from(bytes).ok()?))
 }

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -6,6 +6,8 @@ use crate::candidates::{
 use cardano_serialization_lib::PlutusData;
 use sidechain_domain::*;
 
+use super::PlutusDataExtensions;
+
 /** Representation of the plutus type in the mainchain contract (rev 4ed2cc66c554ec8c5bec7b90ad9273e9069a1fb4)
 *
 * Note that the ECDSA secp256k1 public key is serialized in compressed format and the
@@ -108,11 +110,11 @@ fn decode_utxo_id_datum(datum: PlutusData) -> Option<UtxoId> {
 	match datum.as_constr_plutus_data() {
 		Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 2 => {
 			let fields = datum.data();
-			match (fields.get(0), fields.get(1).as_integer()) {
+			match (fields.get(0), fields.get(1).as_u16()) {
 				(f0, Some(f1)) => {
 					let tx_hash = decode_tx_hash_datum(f0)?;
-					let index: u16 = TryFrom::try_from(u32::try_from(f1.as_u64()?).ok()?).ok()?;
-					Some(UtxoId { tx_hash, index: UtxoIndex(index) })
+					let index = UtxoIndex(f1);
+					Some(UtxoId { tx_hash, index })
 				},
 				_ => None,
 			}

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -64,6 +64,7 @@ impl TryFrom<PlutusData> for RegisterValidatorDatum {
 	}
 }
 
+/// Parses plutus data schema that was used before datum versioning was added. Kept for backwards compatibility.
 pub fn decode_legacy_register_validator_datum(datum: PlutusData) -> Option<RegisterValidatorDatum> {
 	let fields = datum
 		.as_constr_plutus_data()

--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -134,3 +134,80 @@ fn decode_tx_hash_datum(datum: &Datum) -> Option<McTxHash> {
 		_ => None,
 	}
 }
+
+#[allow(dead_code)]
+mod csl {
+	use cardano_serialization_lib::PlutusData;
+
+	use super::*;
+
+	pub fn decode_legacy_register_validator_datum(
+		datum: &PlutusData,
+	) -> Option<RegisterValidatorDatum> {
+		match datum.as_constr_plutus_data() {
+			Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 7 => {
+				let fields = datum.data();
+				let stake_ownership = decode_ada_based_staking_datum(fields.get(0))?;
+				let sidechain_pub_key = fields.get(1).as_bytes().map(SidechainPublicKey)?;
+				let sidechain_signature = fields.get(2).as_bytes().map(SidechainSignature)?;
+				let consumed_input = decode_utxo_id_datum(fields.get(3))?;
+				let _own_pkh = fields.get(4).as_bytes()?;
+				let aura_pub_key = fields.get(5).as_bytes().map(AuraPublicKey)?;
+				let grandpa_pub_key = fields.get(6).as_bytes().map(GrandpaPublicKey)?;
+				Some(RegisterValidatorDatum::V0 {
+					stake_ownership,
+					sidechain_pub_key,
+					sidechain_signature,
+					consumed_input,
+					aura_pub_key,
+					grandpa_pub_key,
+				})
+			},
+
+			_ => None,
+		}
+	}
+
+	fn decode_ada_based_staking_datum(datum: PlutusData) -> Option<AdaBasedStaking> {
+		match datum.as_constr_plutus_data() {
+			Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 2 => {
+				let fields = datum.data();
+				match (fields.get(0).as_bytes(), fields.get(1).as_bytes()) {
+					(Some(f0), Some(f1)) => {
+						let pub_key = TryFrom::try_from(f0).ok()?;
+						Some(AdaBasedStaking { pub_key, signature: MainchainSignature(f1) })
+					},
+					_ => None,
+				}
+			},
+			_ => None,
+		}
+	}
+	fn decode_utxo_id_datum(datum: PlutusData) -> Option<UtxoId> {
+		match datum.as_constr_plutus_data() {
+			Some(datum) if datum.alternative().is_zero() && datum.data().len() >= 2 => {
+				let fields = datum.data();
+				match (fields.get(0), fields.get(1).as_integer()) {
+					(f0, Some(f1)) => {
+						let tx_hash = decode_tx_hash_datum(f0)?;
+						let index: u16 =
+							TryFrom::try_from(u32::try_from(f1.as_u64()?).ok()?).ok()?;
+						Some(UtxoId { tx_hash, index: UtxoIndex(index) })
+					},
+					_ => None,
+				}
+			},
+			_ => None,
+		}
+	}
+	/// Plutus type for TxHash is a sum type, we can parse only variant with constructor 0.
+	fn decode_tx_hash_datum(datum: PlutusData) -> Option<McTxHash> {
+		match datum.as_constr_plutus_data() {
+			Some(datum) if datum.alternative().is_zero() && datum.data().len() > 0 => {
+				let bytes = datum.data().get(0).as_bytes()?;
+				Some(McTxHash(TryFrom::try_from(bytes.clone()).ok()?))
+			},
+			_ => None,
+		}
+	}
+}

--- a/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -71,7 +71,7 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 			.map(|d| d.0)
 			.ok_or(ExpectedDataNotFound("DParameter Datum".to_string()))?;
 
-		let d_parameter = DParamDatum::try_from(&d_datum)?.into();
+		let d_parameter = DParamDatum::try_from(d_datum)?.into();
 
 		let candidates_output = candidates_output_opt
 			.ok_or(ExpectedDataNotFound("Permissioned Candidates List".to_string()))?;
@@ -81,7 +81,7 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 			.map(|d| d.0)
 			.ok_or(ExpectedDataNotFound("Permissioned Candidates List Datum".to_string()))?;
 
-		let permissioned_candidates = PermissionedCandidateDatums::try_from(&candidates_datum)?.into();
+		let permissioned_candidates = PermissionedCandidateDatums::try_from(candidates_datum)?.into();
 
 		Ok(AriadneParameters { d_parameter, permissioned_candidates })
 	}
@@ -242,7 +242,7 @@ impl CandidatesDataSourceImpl {
 					output.clone().utxo_id
 				))?;
 				let register_validator_datum =
-					RegisterValidatorDatum::try_from(&datum).map_err(|_| {
+					RegisterValidatorDatum::try_from(datum).map_err(|_| {
 						format!("Invalid registration datum for {:?}", output.clone().utxo_id)
 					})?;
 				Ok(ParsedCandidate {

--- a/mainchain-follower/db-sync-follower/src/db_datum.rs
+++ b/mainchain-follower/db-sync-follower/src/db_datum.rs
@@ -1,4 +1,6 @@
-use cardano_serialization_lib::PlutusData;
+use cardano_serialization_lib::{
+	encode_json_value_to_plutus_datum, PlutusData, PlutusDatumSchema::DetailedSchema,
+};
 use sqlx::database::HasValueRef;
 use sqlx::error::BoxDynError;
 use sqlx::postgres::{types::Oid, PgTypeInfo};
@@ -21,10 +23,7 @@ where
 {
 	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
 		let value: JsonValue = <JsonValue as Decode<Postgres>>::decode(value)?;
-		let datum = PlutusData::from_json(
-			&value.to_string(),
-			cardano_serialization_lib::PlutusDatumSchema::DetailedSchema,
-		);
+		let datum = encode_json_value_to_plutus_datum(value, DetailedSchema);
 		Ok(DbDatum(datum?))
 	}
 }

--- a/mainchain-follower/db-sync-follower/src/db_datum.rs
+++ b/mainchain-follower/db-sync-follower/src/db_datum.rs
@@ -1,14 +1,13 @@
-use plutus::{Datum, FromJsonError};
+use cardano_serialization_lib::PlutusData;
 use sqlx::database::HasValueRef;
 use sqlx::error::BoxDynError;
 use sqlx::postgres::{types::Oid, PgTypeInfo};
 use sqlx::types::JsonValue;
 use sqlx::{Decode, Postgres};
-use std::fmt::{Display, Formatter};
 
-/// Wraps plutus::Datum to provide sqlx::Decode and sqlx::Type implementations
+/// Wraps PlutusData to provide sqlx::Decode and sqlx::Type implementations
 #[derive(Debug, Clone, PartialEq)]
-pub struct DbDatum(pub Datum);
+pub struct DbDatum(pub PlutusData);
 
 impl sqlx::Type<Postgres> for DbDatum {
 	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
@@ -22,18 +21,10 @@ where
 {
 	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
 		let value: JsonValue = <JsonValue as Decode<Postgres>>::decode(value)?;
-		let datum: Datum = TryFrom::try_from(&value).map_err(DbDatumDecodeError)?;
-		Ok(DbDatum(datum))
+		let datum = PlutusData::from_json(
+			&value.to_string(),
+			cardano_serialization_lib::PlutusDatumSchema::DetailedSchema,
+		);
+		Ok(DbDatum(datum?))
 	}
 }
-
-#[derive(Clone, Debug)]
-pub struct DbDatumDecodeError(pub FromJsonError);
-
-impl Display for DbDatumDecodeError {
-	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-		write!(f, "{:?}", self.0)
-	}
-}
-
-impl std::error::Error for DbDatumDecodeError {}

--- a/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -1,9 +1,9 @@
 use crate::db_datum::DbDatum;
 use crate::SqlxError;
+use cardano_serialization_lib::PlutusData;
 use chrono::NaiveDateTime;
 use log::info;
 use num_traits::ToPrimitive;
-use plutus::Datum;
 use sidechain_domain::*;
 use sqlx::database::{HasArguments, HasValueRef};
 use sqlx::encode::IsNull;
@@ -151,7 +151,7 @@ pub(crate) struct MainchainTxOutput {
 	pub tx_epoch_no: EpochNumber,
 	pub tx_index_in_block: TxIndexInBlock,
 	pub address: String,
-	pub datum: Option<Datum>,
+	pub datum: Option<PlutusData>,
 	pub tx_inputs: Vec<UtxoId>,
 }
 

--- a/mainchain-follower/db-sync-follower/src/lib.rs
+++ b/mainchain-follower/db-sync-follower/src/lib.rs
@@ -1,5 +1,6 @@
 //! Provides implementations of Data Sources that read from db-sync postgres
-use plutus::Datum;
+
+use cardano_serialization_lib::PlutusData;
 
 pub mod data_sources;
 mod db_datum;
@@ -44,7 +45,7 @@ pub enum DataSourceError {
 	#[error("Internal error of data source: `{0}`.")]
 	InternalDataSourceError(String),
 	#[error("Could not decode {datum:?} to {to:?}, this means that there is an error in Plutus scripts or chain-follower is obsolete.")]
-	DatumDecodeError { datum: Datum, to: String },
+	DatumDecodeError { datum: PlutusData, to: String },
 	#[error("'{0}' not found. Possible causes: main chain follower configuration error, db-sync not synced fully, or data not set on the main chain.")]
 	ExpectedDataNotFound(String),
 	#[error("Invalid data. {0} Possible cause it an error in Plutus scripts or chain-follower is obsolete.")]

--- a/mainchain-follower/db-sync-follower/src/lib.rs
+++ b/mainchain-follower/db-sync-follower/src/lib.rs
@@ -1,5 +1,4 @@
 //! Provides implementations of Data Sources that read from db-sync postgres
-
 use cardano_serialization_lib::PlutusData;
 
 pub mod data_sources;

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,7 +80,6 @@ sp-keyring = { workspace = true }
 hex = { workspace = true }
 sp-consensus-slots = { workspace = true }
 minicbor = { workspace = true }
-plutus = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
 

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -82,6 +82,7 @@ sp-consensus-slots = { workspace = true }
 minicbor = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
+plutus = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -80,9 +80,9 @@ sp-keyring = { workspace = true }
 hex = { workspace = true }
 sp-consensus-slots = { workspace = true }
 minicbor = { workspace = true }
+plutus = { workspace = true }
 pretty_assertions = { workspace = true }
 serde_json = { workspace = true }
-plutus = { workspace = true }
 
 [build-dependencies]
 substrate-wasm-builder = { workspace = true, optional = true }


### PR DESCRIPTION
# Description

Removes dependency on our `plutus` crate from `db-sync-follower` and replaces it with `cardano-serialization-lib`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

