### PR TITLE
Remove unused import

### DIFF
--- a/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -12,7 +12,7 @@ use crate::pc_contracts_cli_resources::{
 };
 use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 use crate::smart_contracts;
-use anyhow::{anyhow, Context};
+use anyhow::{anyhow};
 use serde_json::Value;
 use sidechain_domain::PolicyId;
 


### PR DESCRIPTION
# Description

Fix the following warning about unused imports
```
warning: unused import: `Context`
  --> partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs:15:22
   |
15 | use anyhow::{anyhow, Context};
   |                      ^^^^^^^
   |
   = note: `#[warn(unused_imports)]` on by default

warning: `partner-chains-cli` (bin "partner-chains-cli") generated 1 warning (run `cargo fix --bin "partner-chains-cli"` to apply 1 suggestion) 
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

