### PR TITLE
feat: make RegisterValidatorDatum usable for offchain code

### DIFF
--- a/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/datum/registered.rs
@@ -42,7 +42,8 @@ pub enum RegisterValidatorDatum {
 		sidechain_pub_key: SidechainPublicKey,
 		sidechain_signature: SidechainSignature,
 		consumed_input: UtxoId,
-		//ownPkh we don't use,
+		//own_pkh is used by offchain code to find the registration UTXO when re-registering or deregistering
+		own_pkh: MainchainAddressHash,
 		aura_pub_key: AuraPublicKey,
 		grandpa_pub_key: GrandpaPublicKey,
 	},
@@ -75,7 +76,7 @@ pub fn decode_legacy_register_validator_datum(datum: PlutusData) -> Option<Regis
 	let sidechain_pub_key = fields.get(1).as_bytes().map(SidechainPublicKey)?;
 	let sidechain_signature = fields.get(2).as_bytes().map(SidechainSignature)?;
 	let consumed_input = decode_utxo_id_datum(fields.get(3))?;
-	let _own_pkh = fields.get(4).as_bytes()?;
+	let own_pkh = MainchainAddressHash(fields.get(4).as_bytes()?.try_into().ok()?);
 	let aura_pub_key = fields.get(5).as_bytes().map(AuraPublicKey)?;
 	let grandpa_pub_key = fields.get(6).as_bytes().map(GrandpaPublicKey)?;
 	Some(RegisterValidatorDatum::V0 {
@@ -83,6 +84,7 @@ pub fn decode_legacy_register_validator_datum(datum: PlutusData) -> Option<Regis
 		sidechain_pub_key,
 		sidechain_signature,
 		consumed_input,
+		own_pkh,
 		aura_pub_key,
 		grandpa_pub_key,
 	})

--- a/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -15,7 +15,7 @@ use std::collections::HashMap;
 use std::error::Error;
 
 pub mod cached;
-mod datum;
+pub mod datum;
 
 #[cfg(test)]
 pub mod tests;
@@ -212,6 +212,7 @@ impl CandidatesDataSourceImpl {
 					sidechain_pub_key,
 					sidechain_signature,
 					consumed_input,
+					own_pkh: _own_pkh,
 					aura_pub_key,
 					grandpa_pub_key,
 				} = c.datum;

--- a/mainchain-follower/db-sync-follower/testdata/migrations/6_insert_transactions.sql
+++ b/mainchain-follower/db-sync-follower/testdata/migrations/6_insert_transactions.sql
@@ -39,7 +39,7 @@ DECLARE
         ],
         "constructor": 0
       },
-      { "bytes": "aabbccddeeff" },
+      { "bytes": "aabbccddeeff00aabbccddeeff00aabbccddeeff00aabbccddeeff00" },
       { "bytes": "d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d" },
       { "bytes": "88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee" }
     ]
@@ -66,7 +66,7 @@ DECLARE
         ],
         "constructor": 0
       },
-      { "bytes": "020000000000b3432b1db5833ff5f2226d9cb5e65cee430558c18ed3a3c8111111" },
+      { "bytes": "aa112233445566aa112233445566aa112233445566aa112233445566" },
       { "bytes": "8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48" },
       { "bytes": "d17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69" }
     ]
@@ -93,7 +93,7 @@ DECLARE
         ],
         "constructor": 0
       },
-      { "bytes": "ffffffffffeeeeaaae88d7da1caa713307290291897f100efb911672d317147f72" },
+      { "bytes": "00112233445566001122334455660011223344556600112233445566" },
       { "bytes": "8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f23333" },
       { "bytes": "d17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fad3333" }
     ]


### PR DESCRIPTION
# Description

This part is required to make the RegisterValidatorDatum available to offchain code.
It is a clear indication that (as we call them) Datums are part of public interface and shouldn't really be buried in db-sync-follower, but I'm not going to fix this in this PR.

Another defect is the `MainchainAddressHash` name, which should be `MainchainKeyHash` instead. It can be observed by looking at the constructor:
```rust
impl MainchainAddressHash {
	pub fn from_vkey(vkey: [u8; 32]) -> Self {
		Self(blake2b(&vkey))
	}
}
```
where we literally hash the key, not the address.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ x Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

