### PR TITLE
fix: wait for n2 epoch

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -315,7 +315,7 @@ jobs:
       contents: read
     needs: [partner-chain-ready, wait-for-n1-epoch]
     runs-on: eks
-    timeout-minutes: 1440
+    timeout-minutes: 1450
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

fixes:
- wait-for-n2-epoch is running exactly 24h so I'm adding 10 minutes more

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

