### PR TITLE
change: ETCM-8722 parse datums V0

### DIFF
--- a/toolkit/primitives/plutus-data/src/d_param.rs
+++ b/toolkit/primitives/plutus-data/src/d_param.rs
@@ -1,4 +1,4 @@
-use crate::{DataDecodingError, DecodingResult, PlutusDataExtensions};
+use crate::{DataDecodingError, DecodingResult, PlutusDataExtensions, VersionedDatum};
 use cardano_serialization_lib::{PlutusData, PlutusList};
 
 #[derive(Clone, Debug, PartialEq)]
@@ -10,7 +10,7 @@ pub enum DParamDatum {
 impl TryFrom<PlutusData> for DParamDatum {
 	type Error = DataDecodingError;
 	fn try_from(datum: PlutusData) -> DecodingResult<Self> {
-		decode_legacy_d_parameter_datum(datum)
+		Self::decode(&datum)
 	}
 }
 
@@ -31,27 +31,35 @@ pub fn d_parameter_to_plutus_data(d_param: &sidechain_domain::DParameter) -> Plu
 	PlutusData::new_list(&list)
 }
 
-/// Parses plutus data schema that was used before datum versioning was added. Kept for backwards compatibility.
-fn decode_legacy_d_parameter_datum(datum: PlutusData) -> DecodingResult<DParamDatum> {
-	let d_parameter = datum
-		.as_list()
-		.filter(|datum| datum.len() == 2)
-		.and_then(|items| {
-			Some(DParamDatum::V0 {
-				num_permissioned_candidates: items.get(0).as_u16()?,
-				num_registered_candidates: items.get(1).as_u16()?,
-			})
-		})
-		.ok_or_else(|| {
-			log::error!("Could not decode {:?} to DParameter. Expected [u16, u16].", datum.clone());
-			DataDecodingError {
-				datum: datum.clone(),
-				to: "DParameter".to_string(),
-				msg: "Expected [u16, u16]".to_string(),
-			}
-		})?;
+impl VersionedDatum for DParamDatum {
+	const NAME: &str = "DParamDatum";
 
-	Ok(d_parameter)
+	fn decode_legacy(data: &PlutusData) -> Result<Self, String> {
+		let d_parameter = data
+			.as_list()
+			.filter(|datum| datum.len() == 2)
+			.and_then(|items| {
+				Some(DParamDatum::V0 {
+					num_permissioned_candidates: items.get(0).as_u16()?,
+					num_registered_candidates: items.get(1).as_u16()?,
+				})
+			})
+			.ok_or_else(|| "Expected [u16, u16]")?;
+
+		Ok(d_parameter)
+	}
+
+	fn decode_versioned(
+		version: u32,
+		_const_data: &PlutusData,
+		mut_data: &PlutusData,
+	) -> Result<Self, String> {
+		match version {
+			0 => DParamDatum::decode_legacy(mut_data)
+				.map_err(|msg| format!("Can not parse mutable part of data: {msg}")),
+			_ => Err(format!("Unknown version: {version}")),
+		}
+	}
 }
 
 #[cfg(test)]
@@ -61,7 +69,7 @@ mod tests {
 	use pretty_assertions::assert_eq;
 
 	#[test]
-	fn valid_d_param_1() {
+	fn valid_legacy_d_param() {
 		let plutus_data = test_plutus_data!({"list": [{"int": 1}, {"int": 2}]});
 
 		let expected_datum =
@@ -80,5 +88,23 @@ mod tests {
 		let expected_plutus_data = test_plutus_data!({"list": [{"int": 1}, {"int": 2}]});
 
 		assert_eq!(d_parameter_to_plutus_data(&d_param), expected_plutus_data)
+	}
+	#[test]
+	fn valid_v0_d_param() {
+		let plutus_data = test_plutus_data!({
+			"list": [
+				{ "constructor": 0, "fields": [] },
+				{ "list": [
+					{ "int": 17 },
+					{ "int": 42 }
+				] },
+				{ "int": 0 }
+			]
+		});
+
+		let expected_datum =
+			DParamDatum::V0 { num_permissioned_candidates: 17, num_registered_candidates: 42 };
+
+		assert_eq!(DParamDatum::try_from(plutus_data).unwrap(), expected_datum)
 	}
 }

--- a/toolkit/primitives/plutus-data/src/lib.rs
+++ b/toolkit/primitives/plutus-data/src/lib.rs
@@ -16,16 +16,68 @@ pub struct DataDecodingError {
 type DecodingResult<T> = std::result::Result<T, DataDecodingError>;
 
 pub trait PlutusDataExtensions {
-	fn as_u16(self) -> Option<u16>;
 	fn as_u32(self) -> Option<u32>;
+	fn as_u16(self) -> Option<u16>;
 }
 
 impl PlutusDataExtensions for cardano_serialization_lib::PlutusData {
+	fn as_u32(self) -> Option<u32> {
+		u32::try_from(self.as_integer()?.as_u64()?).ok()
+	}
 	fn as_u16(self) -> Option<u16> {
 		u16::try_from(self.as_u32()?).ok()
 	}
-	fn as_u32(self) -> Option<u32> {
-		u32::try_from(self.as_integer()?.as_u64()?).ok()
+}
+
+/// Trait that provides decoding of versioned generic plutus data.
+///
+/// Versioned generic plutus data contain a version number and two data sections:
+/// - immutable section - the data with stable schema, read and validated by smart contracts
+/// - mutable section - generic data with evolving schema indicated by the version number, not used by smart contracts
+///
+/// The corresponding definition in the smart contracts repo is:
+/// ```haskell
+/// data VersionedGenericDatum a = VersionedGenericDatum
+///     { datum :: a
+///     , genericData :: BuiltinData
+///     , version :: Integer
+///     }
+/// ```
+pub(crate) trait VersionedDatum: Sized {
+	const NAME: &str;
+
+	/// Parses plutus data schema that was used before datum versioning was added. Kept for backwards compatibility.
+	fn decode_legacy(data: &PlutusData) -> Result<Self, String>;
+
+	/// Parses versioned plutus data.
+	///
+	/// Parameters:
+	/// * `version` - version number
+	/// * `const_data` - immutable part of the schema
+	/// * `mut_data` - mutable part of the schema
+	fn decode_versioned(
+		version: u32,
+		const_data: &PlutusData,
+		mut_data: &PlutusData,
+	) -> Result<Self, String>;
+
+	fn plutus_data_version_and_payload(data: &PlutusData) -> Option<(u32, PlutusData, PlutusData)> {
+		let fields = data.as_list().filter(|outer_list| outer_list.len() == 3)?;
+
+		Some((fields.get(2).as_u32()?, fields.get(0), fields.get(1)))
+	}
+
+	fn decode(data: &PlutusData) -> DecodingResult<Self> {
+		(match Self::plutus_data_version_and_payload(data) {
+			None => Self::decode_legacy(data),
+			Some((version, const_payload, mut_payload)) => {
+				Self::decode_versioned(version, &const_payload, &mut_payload)
+			},
+		})
+		.map_err(|msg| {
+			log::error!("Could not decode {data:?} to {}: {msg}", Self::NAME);
+			DataDecodingError { datum: data.clone(), to: Self::NAME.to_string(), msg }
+		})
 	}
 }
 


### PR DESCRIPTION
# Description

* Adds parsing of versioned datums of schema version 0, equivalent to the legacy schema
* Adds general framework for parsing versioned datums via `VersionedDatum` trait

The tests cases are taken from the golden tests in smart contracts repo. Once the smart contracts changes are merged, I will verify with local chain and real plutus data on preview before merging this PR.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

