### PR TITLE
chore: bump partner-chains-smart-contracts to v6.2.2

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ on how to create these new data sources see `node/src/main_chain_follower.rs` fi
 * `partner-chains-cli` does not use `cardano-cli` to derive address not to query utxos.
 * `partner-chains-cli` does not use `pc-contracts-cli` in `prepare-configuration` wizard, it uses `partner-chains-cardano-offchain` crate instead.
 * Update cardano-node to 10.1.2
+* Bumped `partner-chains-smart-contracts` version to v6.2.2
 
 ## Removed
 

--- a/dev/local-environment/setup.sh
+++ b/dev/local-environment/setup.sh
@@ -8,7 +8,7 @@ OGMIOS_IMAGE="cardanosolutions/ogmios:v6.8.0"
 POSTGRES_IMAGE="postgres:15.3"
 SIDECHAIN_MAIN_CLI_IMAGE="node:22-bookworm"
 TESTS_IMAGE="python:3.10-slim"
-PC_CONTRACTS_CLI_ZIP_URL="https://github.com/input-output-hk/partner-chains-smart-contracts/releases/download/v6.2.1/pc-contracts-cli-v6.2.1.zip"
+PC_CONTRACTS_CLI_ZIP_URL="https://github.com/input-output-hk/partner-chains-smart-contracts/releases/download/v6.2.2/pc-contracts-cli-v6.2.2.zip"
 PARTNER_CHAINS_NODE_URL="https://github.com/input-output-hk/partner-chains/releases/download/v1.2.0/partner-chains-node-v1.2.0-x86_64-linux"
 PARTNER_CHAINS_CLI_URL="https://github.com/input-output-hk/partner-chains/releases/download/v1.2.0/partner-chains-cli-v1.2.0-x86_64-linux"
 

--- a/flake.lock
+++ b/flake.lock
@@ -271,16 +271,16 @@
     "smart-contracts": {
       "flake": false,
       "locked": {
-        "lastModified": 1729167752,
-        "narHash": "sha256-CLjah5IoQyaPEhV6bhNlktdmPHFwAe7RbXJYr8eFSOY=",
+        "lastModified": 1730297011,
+        "narHash": "sha256-BjJrzMvkeXYCuqHZhIMRL+IkjcTAFxDaCL9wtlGyghA=",
         "owner": "input-output-hk",
         "repo": "partner-chains-smart-contracts",
-        "rev": "fda17bf3857200ce63f31decd2bda5ceeed50f63",
+        "rev": "87a1d421fc77198c1af24d07c3e3d9aa1c2f410d",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "v6.2.1",
+        "ref": "v6.2.2",
         "repo": "partner-chains-smart-contracts",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
 
     # Partner Chains deps
     smart-contracts = {
-      url = "github:input-output-hk/partner-chains-smart-contracts/v6.2.1";
+      url = "github:input-output-hk/partner-chains-smart-contracts/v6.2.2";
       flake = false;
     };
     cardano-node = {


### PR DESCRIPTION
# Description

Bump partner-chains-smart-contracts to v6.2.2 (https://github.com/input-output-hk/partner-chains-smart-contracts/releases/tag/v6.2.2)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages.
- [X] CI passes. See note on CI.
- [X] Any changes are noted in the `changelog.md` for affected crate
- [X] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.
