### PR TITLE
fix: remove xray link from slack notifier if xray id is null

### DIFF
--- a/E2E-tests/report_slack.sh
+++ b/E2E-tests/report_slack.sh
@@ -61,7 +61,7 @@ fields="{
     \"text\": \"<$job_url|CI job>\"
 }"
 
-if [ -n "$xray_id" ]; then
+if [[ "$jira_url" == *"https://"* ]] && [ -n "$xray_id" ] && [ "$xray_id" != "null" ]; then
     fields+=",{
         \"type\": \"mrkdwn\",
         \"text\": \"<$xray_exec_url|Xray report>\"


### PR DESCRIPTION
# Description

Remove xray report links for non-testing slack notifications

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages.
- [X] CI passes. See note on CI.
- [X] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

