### PR TITLE
change: use new_if_pallet_present to create native token IDP

### DIFF
--- a/node/node/src/inherent_data.rs
+++ b/node/node/src/inherent_data.rs
@@ -104,6 +104,16 @@ where
 				"SIDECHAIN_BLOCK_BENEFICIARY",
 			)?;
 
+		// Mock runtime provided by Substrate doesn't implement Runtime version API used by `new_if_pallet_present`
+		#[cfg(not(test))]
+		let native_token = NativeTokenIDP::new_if_pallet_present(
+			client.clone(),
+			native_token_data_source.as_ref(),
+			mc_hash.mc_hash(),
+			parent_hash,
+		)
+		.await?;
+		#[cfg(test)]
 		let native_token = NativeTokenIDP::new(
 			client.clone(),
 			native_token_data_source.as_ref(),
@@ -191,6 +201,15 @@ where
 		)
 		.await?;
 
+		#[cfg(not(test))]
+		let native_token = NativeTokenIDP::new_if_pallet_present(
+			client.clone(),
+			native_token_data_source.as_ref(),
+			mc_hash,
+			parent_hash,
+		)
+		.await?;
+		#[cfg(test)]
 		let native_token = NativeTokenIDP::new(
 			client.clone(),
 			native_token_data_source.as_ref(),


### PR DESCRIPTION
# Description

Uses `new_if_pallet_present` in our reference node implementation. Unfortunately, Substrate's mock runtime version API is `uninmplemented!`, so this has to go behind a feature flag so our tests don't fail.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

