### PR TITLE
fix: CardanoNetwork in pc-cli should not be feed with 'network-magic' but with 'network'

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,6 +14,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Fixed
 
+* CardanoNetwork bug in `partner-chains-cli`, that would cause the CLI to fail with the mainnet.
+
 ## Added
 
 # v1.3.0

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -261,16 +261,26 @@ impl SelectOptions for NetworkProtocol {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-pub struct CardanoNetwork(pub u32);
+#[serde(rename_all = "lowercase")]
+pub enum CardanoNetwork {
+	Mainnet,
+	Testnet,
+}
 
 impl CardanoNetwork {
-	pub fn to_id(&self) -> u32 {
-		self.0
-	}
 	pub fn to_network_param(&self) -> String {
 		match self {
-			CardanoNetwork(0) => "mainnet".into(),
-			_ => "testnet".into(),
+			CardanoNetwork::Mainnet => "mainnet".into(),
+			CardanoNetwork::Testnet => "testnet".into(),
+		}
+	}
+}
+
+impl From<ogmios_client::query_network::Network> for CardanoNetwork {
+	fn from(network: ogmios_client::query_network::Network) -> CardanoNetwork {
+		match network {
+			ogmios_client::query_network::Network::Mainnet => CardanoNetwork::Mainnet,
+			ogmios_client::query_network::Network::Testnet => CardanoNetwork::Testnet,
 		}
 	}
 }
@@ -278,8 +288,8 @@ impl CardanoNetwork {
 impl From<CardanoNetwork> for cardano_serialization_lib::NetworkIdKind {
 	fn from(network: CardanoNetwork) -> cardano_serialization_lib::NetworkIdKind {
 		match network {
-			CardanoNetwork(0) => cardano_serialization_lib::NetworkIdKind::Mainnet,
-			_ => cardano_serialization_lib::NetworkIdKind::Testnet,
+			CardanoNetwork::Mainnet => cardano_serialization_lib::NetworkIdKind::Mainnet,
+			CardanoNetwork::Testnet => cardano_serialization_lib::NetworkIdKind::Testnet,
 		}
 	}
 }
@@ -287,10 +297,8 @@ impl From<CardanoNetwork> for cardano_serialization_lib::NetworkIdKind {
 impl std::fmt::Display for CardanoNetwork {
 	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
 		match self {
-			CardanoNetwork(0) => write!(f, "mainnet"),
-			CardanoNetwork(1) => write!(f, "preprod"),
-			CardanoNetwork(2) => write!(f, "preview"),
-			CardanoNetwork(n) => write!(f, "custom({})", n),
+			CardanoNetwork::Mainnet => write!(f, "mainnet"),
+			CardanoNetwork::Testnet => write!(f, "testnet"),
 		}
 	}
 }
@@ -494,7 +502,7 @@ pub mod config_fields {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano", "network"],
 			name: "cardano network",
-			default: Some("0"),
+			default: None,
 			_marker: PhantomData,
 		};
 
@@ -751,9 +759,7 @@ mod tests {
 
 	#[test]
 	fn test_from_network_id() {
-		assert_eq!(NetworkIdKind::from(CardanoNetwork(0)), NetworkIdKind::Mainnet);
-		assert_eq!(NetworkIdKind::from(CardanoNetwork(1)), NetworkIdKind::Testnet);
-		assert_eq!(NetworkIdKind::from(CardanoNetwork(2)), NetworkIdKind::Testnet);
-		assert_eq!(NetworkIdKind::from(CardanoNetwork(42)), NetworkIdKind::Testnet);
+		assert_eq!(NetworkIdKind::from(CardanoNetwork::Mainnet), NetworkIdKind::Mainnet);
+		assert_eq!(NetworkIdKind::from(CardanoNetwork::Testnet), NetworkIdKind::Testnet);
 	}
 }

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -173,7 +173,7 @@ fn test_chain_config_content() -> serde_json::Value {
 			"epoch_duration_millis": 86400000,
 			"first_epoch_number": 1,
 			"first_slot_number": 4320,
-			"network": 1
+			"network": "testnet"
 		},
 		"cardano_addresses": {
 			"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
@@ -201,7 +201,7 @@ fn invalid_chain_config_content() -> serde_json::Value {
 			"epoch_duration_millis": 86400000,
 			"first_epoch_number": 1,
 			"first_slot_number": 4320,
-			"network": 1
+			"network": "testnet"
 		},
 	})
 }

--- a/toolkit/partner-chains-cli/src/ogmios/mod.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/mod.rs
@@ -1,3 +1,4 @@
+use crate::config::CardanoNetwork;
 use anyhow::anyhow;
 use jsonrpsee::http_client::HttpClient;
 use ogmios_client::{
@@ -39,7 +40,7 @@ pub struct EpochParameters {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ShelleyGenesisConfiguration {
-	pub network_magic: u32,
+	pub network: CardanoNetwork,
 	pub security_parameter: u32,
 	pub active_slots_coefficient: f64,
 	pub epoch_length: u32,
@@ -129,7 +130,7 @@ impl TryFrom<ogmios_client::query_network::ShelleyGenesisConfigurationResponse>
 		let active_slots_coefficient = TryFrom::try_from(shelley_genesis.active_slots_coefficient)
 			.map_err(|_| anyhow!("Cannot convert active_slots_coefficient"))?;
 		Ok(Self {
-			network_magic: shelley_genesis.network_magic,
+			network: shelley_genesis.network.into(),
 			security_parameter: shelley_genesis.security_parameter,
 			active_slots_coefficient,
 			epoch_length: shelley_genesis.epoch_length,

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -1,4 +1,4 @@
-use crate::config::{CardanoNetwork, CardanoParameters, ServiceConfig};
+use crate::config::{CardanoParameters, ServiceConfig};
 use crate::io::IOContext;
 use crate::ogmios::{EraSummary, OgmiosRequest, OgmiosResponse, ShelleyGenesisConfiguration};
 
@@ -51,7 +51,7 @@ fn caradano_parameters(
 			.checked_add(first_epoch_era.start.time_seconds)
 			.and_then(|seconds| seconds.checked_mul(1000))
 			.ok_or_else(|| anyhow::anyhow!("First epoch timestamp overflow"))?,
-		network: CardanoNetwork(shelley_config.network_magic),
+		network: shelley_config.network.into(),
 	})
 }
 
@@ -79,7 +79,7 @@ fn get_first_epoch_era(eras_summaries: Vec<EraSummary>) -> Result<EraSummary, an
 #[cfg(test)]
 pub mod tests {
 	use super::*;
-	use crate::config::{NetworkProtocol, CHAIN_CONFIG_FILE_PATH};
+	use crate::config::{CardanoNetwork, NetworkProtocol, CHAIN_CONFIG_FILE_PATH};
 	use crate::ogmios::{EpochBoundary, EpochParameters, EraSummary};
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 	use crate::tests::{MockIO, MockIOContext};
@@ -91,7 +91,7 @@ pub mod tests {
 		first_slot_number: 86400,
 		epoch_duration_millis: 432000000,
 		first_epoch_timestamp_millis: 1655769600000,
-		network: CardanoNetwork(1),
+		network: CardanoNetwork::Testnet,
 	};
 
 	pub(crate) const PREVIEW_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -101,7 +101,7 @@ pub mod tests {
 		first_slot_number: 0,
 		epoch_duration_millis: 86400000,
 		first_epoch_timestamp_millis: 1666656000000,
-		network: CardanoNetwork(2),
+		network: CardanoNetwork::Testnet,
 	};
 
 	#[test]
@@ -190,7 +190,7 @@ pub mod tests {
 
 	pub(crate) fn preprod_shelley_config() -> ShelleyGenesisConfiguration {
 		ShelleyGenesisConfiguration {
-			network_magic: 1,
+			network: CardanoNetwork::Testnet,
 			security_parameter: 2160,
 			active_slots_coefficient: 0.05,
 			epoch_length: 432000,
@@ -234,7 +234,7 @@ pub mod tests {
 
 	pub(crate) fn preview_shelley_config() -> ShelleyGenesisConfiguration {
 		ShelleyGenesisConfiguration {
-			network_magic: 2,
+			network: CardanoNetwork::Testnet,
 			security_parameter: 432,
 			active_slots_coefficient: 0.05,
 			epoch_length: 86400,

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -139,10 +139,7 @@ mod tests {
 
 		pub fn save_cardano_params() -> MockIO {
 			MockIO::Group(vec![
-				save_to_existing_file(
-					CARDANO_NETWORK,
-					&PREPROD_CARDANO_PARAMS.network.0.to_string(),
-				),
+				save_to_existing_file(CARDANO_NETWORK, &PREPROD_CARDANO_PARAMS.network.to_string()),
 				save_to_existing_file(
 					CARDANO_SECURITY_PARAMETER,
 					&PREPROD_CARDANO_PARAMS.security_parameter.to_string(),
@@ -352,7 +349,7 @@ mod tests {
 	fn test_chain_config() -> Value {
 		serde_json::json!({
 			"cardano": {
-				"network": 1,
+				"network": "testnet",
 				"security_parameter": PREPROD_CARDANO_PARAMS.security_parameter,
 				"active_slots_coeff": PREPROD_CARDANO_PARAMS.active_slots_coeff,
 				"first_epoch_number": PREPROD_CARDANO_PARAMS.first_epoch_number,

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -609,7 +609,7 @@ mod tests {
 				"governance_authority": "0x00112233445566778899001122334455667788990011223344556677",
 			},
 			"cardano": {
-				"network": 2
+				"network": "testnet"
 			}
 		})
 	}

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -349,7 +349,7 @@ mod tests {
 				"epoch_duration_millis": 86400000,
 				"first_epoch_number": 1,
 				"first_slot_number": 4320,
-				"network": 0
+				"network": "mainnet"
 			},
 			"cardano_addresses": {
 				"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -342,7 +342,7 @@ fn test_chain_config_content() -> serde_json::Value {
 			"epoch_duration_millis": 86400000,
 			"first_epoch_number": 1,
 			"first_slot_number": 4320,
-			"network": 1
+			"network": "testnet"
 		},
 		"cardano_addresses": {
 			"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",

--- a/toolkit/partner-chains-cli/src/start_node/tests.rs
+++ b/toolkit/partner-chains-cli/src/start_node/tests.rs
@@ -47,7 +47,7 @@ fn default_chain_config() -> serde_json::Value {
 			"/ip4/127.0.0.1/tcp/30333/p2p/12D3KooWEyoppNCUx8Yx66oV9fJnriXwCcXwDDUA2kj6vnc6iDEp"
 		],
 		"cardano": {
-			"network": 1,
+			"network": "testnet",
 			"security_parameter": SECURITY_PARAMETER,
 			"active_slots_coeff": ACTIVE_SLOTS_COEFF,
 			"first_epoch_number": FIRST_EPOCH_NUMBER,


### PR DESCRIPTION
# Description
network id wasn't  network_magic - it was a bug.
`CardanoNetwork`, since we query ogmios for network parameters, doesn't need to know network id, so the type can now be simplified and it's sole purpose is for invoking pc-smart-contracts. When we write offchain in Rust, it will go away completly. 
BTW#2 - this parameter is redundant in pc-smart-contracts, they should be able to figure out network from Ogmios.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
~- [ ] Relevant logging and metrics added~
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

