### PR TITLE
fix: don't return empty list of registrations

### DIFF
--- a/E2E-tests/src/blockchain_api.py
+++ b/E2E-tests/src/blockchain_api.py
@@ -251,7 +251,7 @@ class BlockchainApi(ABC):
 
         Arguments:
             mc_epoch {int}
-            valid_only {bool} -- if True, returns only valid candidates
+            valid_only {bool} -- if True returns only valid registrations for an SPO.
 
         Return: A dict of SPOs. Example response:
         ```

--- a/E2E-tests/src/substrate_api.py
+++ b/E2E-tests/src/substrate_api.py
@@ -460,6 +460,7 @@ class SubstrateApi(BlockchainApi):
             registrations = {
                 spo: [candidate for candidate in candidates if candidate["isValid"]]
                 for spo, candidates in registrations.items()
+                if any(candidate["isValid"] for candidate in candidates)
             }
         return registrations
 

--- a/E2E-tests/tests/committee/test_committee.py
+++ b/E2E-tests/tests/committee/test_committee.py
@@ -337,6 +337,8 @@ class TestCommitteeMembers:
         """Test that the configured d-parameter has at least one trustless candidate"""
         if api.get_d_param(current_mc_epoch).trustless_candidates_number == 0:
             skip("T==0, test is irrelevant")
+        if current_mc_epoch < 3:
+            skip("Stake pool is not yet initialized")
         assert len(api.get_trustless_candidates(current_mc_epoch, valid_only=True)) > 0
 
     @mark.skip_blockchain("pc_evm", reason="not implemented yet on pc_evm")


### PR DESCRIPTION
# Description

fixes:
- For cases where an SPO had all registrations invalid we no longer return empty list. That fixes the issue with calculating committee participation probability if T > 0 and SPO has no valid registrations.

Refs: ETCM-8662

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

