### PR TITLE
change: Migrate to a common Cardano network type in domain crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5787,6 +5787,7 @@ dependencies = [
  "jsonrpsee",
  "serde",
  "serde_json",
+ "sidechain-domain",
  "thiserror",
  "time",
  "tokio",
@@ -9860,6 +9861,7 @@ version = "1.3.0"
 dependencies = [
  "blake2b_simd",
  "byte-string-derive",
+ "clap",
  "derive_more",
  "figment",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9861,7 +9861,6 @@ version = "1.3.0"
 dependencies = [
  "blake2b_simd",
  "byte-string-derive",
- "clap",
  "derive_more",
  "figment",
  "hex",

--- a/toolkit/offchain/src/csl.rs
+++ b/toolkit/offchain/src/csl.rs
@@ -7,6 +7,7 @@ use ogmios_client::{
 	transactions::OgmiosBudget,
 	types::{OgmiosUtxo, OgmiosValue},
 };
+use sidechain_domain::NetworkType;
 
 pub(crate) fn plutus_script_hash(script_bytes: &[u8], language: LanguageKind) -> [u8; 28] {
 	// Before hashing the script, we need to prepend with byte denoting the language.
@@ -43,10 +44,15 @@ pub fn key_hash_address(pub_key_hash: &Ed25519KeyHash, network: NetworkIdKind) -
 		.to_address()
 }
 
-pub fn ogmios_network_to_csl(network: ogmios_client::query_network::Network) -> NetworkIdKind {
-	match network {
-		ogmios_client::query_network::Network::Mainnet => NetworkIdKind::Mainnet,
-		ogmios_client::query_network::Network::Testnet => NetworkIdKind::Testnet,
+pub trait NetworkTypeExt {
+	fn to_csl(&self) -> NetworkIdKind;
+}
+impl NetworkTypeExt for NetworkType {
+	fn to_csl(&self) -> NetworkIdKind {
+		match self {
+			Self::Mainnet => NetworkIdKind::Mainnet,
+			Self::Testnet => NetworkIdKind::Testnet,
+		}
 	}
 }
 

--- a/toolkit/offchain/src/scripts_data.rs
+++ b/toolkit/offchain/src/scripts_data.rs
@@ -1,4 +1,4 @@
-use crate::{csl::ogmios_network_to_csl, plutus_script::PlutusScript, OffchainError};
+use crate::{csl::NetworkTypeExt, plutus_script::PlutusScript, OffchainError};
 use cardano_serialization_lib::{LanguageKind::PlutusV2, NetworkIdKind};
 use chain_params::SidechainParams;
 use ogmios_client::query_network::QueryNetwork;
@@ -64,12 +64,12 @@ impl<T: QueryNetwork> GetScriptsData for T {
 		&self,
 		pc_params: SidechainParams,
 	) -> Result<ScriptsData, OffchainError> {
-		let network = ogmios_network_to_csl(
-			self.shelley_genesis_configuration()
-				.await
-				.map_err(|e| OffchainError::OgmiosError(e.to_string()))?
-				.network,
-		);
+		let network = self
+			.shelley_genesis_configuration()
+			.await
+			.map_err(|e| OffchainError::OgmiosError(e.to_string()))?
+			.network
+			.to_csl();
 		get_scripts_data(pc_params, network)
 			.map_err(|e| OffchainError::InternalError(e.to_string()))
 	}

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -7,7 +7,7 @@ use crate::io::IOContext;
 use anyhow::anyhow;
 use clap::{arg, Parser};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::{MainchainAddressHash, NetworkType, UtxoId};
 use sp_core::offchain::{Duration, Timestamp};
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
@@ -260,49 +260,6 @@ impl SelectOptions for NetworkProtocol {
 	}
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
-pub enum CardanoNetwork {
-	Mainnet,
-	Testnet,
-}
-
-impl CardanoNetwork {
-	pub fn to_network_param(&self) -> String {
-		match self {
-			CardanoNetwork::Mainnet => "mainnet".into(),
-			CardanoNetwork::Testnet => "testnet".into(),
-		}
-	}
-}
-
-impl From<ogmios_client::query_network::Network> for CardanoNetwork {
-	fn from(network: ogmios_client::query_network::Network) -> CardanoNetwork {
-		match network {
-			ogmios_client::query_network::Network::Mainnet => CardanoNetwork::Mainnet,
-			ogmios_client::query_network::Network::Testnet => CardanoNetwork::Testnet,
-		}
-	}
-}
-
-impl From<CardanoNetwork> for cardano_serialization_lib::NetworkIdKind {
-	fn from(network: CardanoNetwork) -> cardano_serialization_lib::NetworkIdKind {
-		match network {
-			CardanoNetwork::Mainnet => cardano_serialization_lib::NetworkIdKind::Mainnet,
-			CardanoNetwork::Testnet => cardano_serialization_lib::NetworkIdKind::Testnet,
-		}
-	}
-}
-
-impl std::fmt::Display for CardanoNetwork {
-	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-		match self {
-			CardanoNetwork::Mainnet => write!(f, "mainnet"),
-			CardanoNetwork::Testnet => write!(f, "testnet"),
-		}
-	}
-}
-
 #[derive(Deserialize)]
 pub struct MainChainAddresses {
 	pub committee_candidates_address: String,
@@ -318,7 +275,7 @@ pub struct CardanoParameters {
 	pub first_slot_number: u64,
 	pub epoch_duration_millis: u64,
 	pub first_epoch_timestamp_millis: u64,
-	pub network: CardanoNetwork,
+	pub network: NetworkType,
 }
 
 impl CardanoParameters {
@@ -415,7 +372,7 @@ pub fn load_chain_config(context: &impl IOContext) -> anyhow::Result<ChainConfig
 	}
 }
 
-pub fn get_cardano_network_from_file(context: &impl IOContext) -> anyhow::Result<CardanoNetwork> {
+pub fn get_cardano_network_from_file(context: &impl IOContext) -> anyhow::Result<NetworkType> {
 	CARDANO_NETWORK.load_from_file(context).ok_or(anyhow!(
 		"Cardano network not configured. Please run prepare-main-chain-config command first."
 	))
@@ -497,7 +454,7 @@ pub mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub const CARDANO_NETWORK: ConfigFieldDefinition<'static, CardanoNetwork> =
+	pub const CARDANO_NETWORK: ConfigFieldDefinition<'static, NetworkType> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano", "network"],
@@ -731,8 +688,7 @@ pub mod config_values {
 
 #[cfg(test)]
 mod tests {
-	use crate::config::{config_fields::GOVERNANCE_AUTHORITY, CardanoNetwork};
-	use cardano_serialization_lib::NetworkIdKind;
+	use crate::config::config_fields::GOVERNANCE_AUTHORITY;
 	use sidechain_domain::MainchainAddressHash;
 
 	#[test]
@@ -755,11 +711,5 @@ mod tests {
 				"000000b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"
 			))
 		);
-	}
-
-	#[test]
-	fn test_from_network_id() {
-		assert_eq!(NetworkIdKind::from(CardanoNetwork::Mainnet), NetworkIdKind::Mainnet);
-		assert_eq!(NetworkIdKind::from(CardanoNetwork::Testnet), NetworkIdKind::Testnet);
 	}
 }

--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -5,8 +5,7 @@ use crate::config::config_fields::{
 	CARDANO_COLD_VERIFICATION_KEY_FILE, CARDANO_PAYMENT_SIGNING_KEY_FILE,
 };
 use crate::config::{
-	get_cardano_network_from_file, CardanoNetwork, ChainConfig, CHAIN_CONFIG_FILE_PATH,
-	PC_CONTRACTS_CLI_PATH,
+	get_cardano_network_from_file, ChainConfig, CHAIN_CONFIG_FILE_PATH, PC_CONTRACTS_CLI_PATH,
 };
 use crate::io::IOContext;
 use crate::pc_contracts_cli_resources::{
@@ -14,6 +13,7 @@ use crate::pc_contracts_cli_resources::{
 };
 use crate::{smart_contracts, CmdRun};
 use anyhow::{anyhow, Context};
+use sidechain_domain::NetworkType;
 
 #[derive(Debug, clap::Parser)]
 pub struct DeregisterCmd;
@@ -43,7 +43,7 @@ impl CmdRun for DeregisterCmd {
 
 fn read_chain_config_file<C: IOContext>(
 	context: &C,
-) -> Result<(crate::config::ChainConfig, crate::config::CardanoNetwork), anyhow::Error> {
+) -> Result<(crate::config::ChainConfig, NetworkType), anyhow::Error> {
 	let chain_config = crate::config::load_chain_config(context);
 	let cardano_network = get_cardano_network_from_file(context);
 	chain_config.and_then(|chain_config| cardano_network.map(|cardano_network| (chain_config, cardano_network)))
@@ -81,7 +81,7 @@ fn get_mainchain_key_hex<C: IOContext>(
 }
 
 fn build_command(
-	cardano_network: CardanoNetwork,
+	cardano_network: NetworkType,
 	cold_vkey: String,
 	chain_config: ChainConfig,
 	pc_contracts_cli_resources: PcContractsCliResources,
@@ -89,7 +89,7 @@ fn build_command(
 ) -> String {
 	format!(
         "{PC_CONTRACTS_CLI_PATH} deregister --network {} --ada-based-staking --spo-public-key {} {} {}",
-        cardano_network.to_network_param(),
+        cardano_network,
         cold_vkey,
         smart_contracts::sidechain_params_arguments(&chain_config.chain_parameters),
         smart_contracts::runtime_config_arguments(

--- a/toolkit/partner-chains-cli/src/ogmios/mod.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/mod.rs
@@ -1,9 +1,9 @@
-use crate::config::CardanoNetwork;
 use anyhow::anyhow;
 use jsonrpsee::http_client::HttpClient;
 use ogmios_client::{
 	query_ledger_state::QueryLedgerState, query_network::QueryNetwork, types::OgmiosUtxo,
 };
+use sidechain_domain::NetworkType;
 
 #[derive(Debug, Eq, PartialEq)]
 pub enum OgmiosRequest {
@@ -40,7 +40,7 @@ pub struct EpochParameters {
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct ShelleyGenesisConfiguration {
-	pub network: CardanoNetwork,
+	pub network: NetworkType,
 	pub security_parameter: u32,
 	pub active_slots_coefficient: f64,
 	pub epoch_length: u32,

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -78,8 +78,10 @@ fn get_first_epoch_era(eras_summaries: Vec<EraSummary>) -> Result<EraSummary, an
 
 #[cfg(test)]
 pub mod tests {
+	use sidechain_domain::NetworkType;
+
 	use super::*;
-	use crate::config::{CardanoNetwork, NetworkProtocol, CHAIN_CONFIG_FILE_PATH};
+	use crate::config::{NetworkProtocol, CHAIN_CONFIG_FILE_PATH};
 	use crate::ogmios::{EpochBoundary, EpochParameters, EraSummary};
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
 	use crate::tests::{MockIO, MockIOContext};
@@ -91,7 +93,7 @@ pub mod tests {
 		first_slot_number: 86400,
 		epoch_duration_millis: 432000000,
 		first_epoch_timestamp_millis: 1655769600000,
-		network: CardanoNetwork::Testnet,
+		network: NetworkType::Testnet,
 	};
 
 	pub(crate) const PREVIEW_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -101,7 +103,7 @@ pub mod tests {
 		first_slot_number: 0,
 		epoch_duration_millis: 86400000,
 		first_epoch_timestamp_millis: 1666656000000,
-		network: CardanoNetwork::Testnet,
+		network: NetworkType::Testnet,
 	};
 
 	#[test]
@@ -190,7 +192,7 @@ pub mod tests {
 
 	pub(crate) fn preprod_shelley_config() -> ShelleyGenesisConfiguration {
 		ShelleyGenesisConfiguration {
-			network: CardanoNetwork::Testnet,
+			network: NetworkType::Testnet,
 			security_parameter: 2160,
 			active_slots_coefficient: 0.05,
 			epoch_length: 432000,
@@ -234,7 +236,7 @@ pub mod tests {
 
 	pub(crate) fn preview_shelley_config() -> ShelleyGenesisConfiguration {
 		ShelleyGenesisConfiguration {
-			network: CardanoNetwork::Testnet,
+			network: NetworkType::Testnet,
 			security_parameter: 432,
 			active_slots_coefficient: 0.05,
 			epoch_length: 86400,

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -7,12 +7,13 @@ use crate::{config::config_fields, *};
 use anyhow::anyhow;
 use cli_commands::registration_signatures::RegisterValidatorMessage;
 use cli_commands::signing::sc_public_key_and_signature_for_datum;
-use config::{CardanoNetwork, ServiceConfig};
+use config::ServiceConfig;
 use ogmios::{OgmiosRequest, OgmiosResponse};
 use ogmios_client::types::OgmiosUtxo;
+use partner_chains_cardano_offchain::csl::NetworkTypeExt;
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
-use sidechain_domain::{McTxHash, SidechainPublicKey, UtxoId};
+use sidechain_domain::{McTxHash, NetworkType, SidechainPublicKey, UtxoId};
 use sp_core::bytes::from_hex;
 use sp_core::{ecdsa, Pair};
 use std::str::FromStr;
@@ -183,7 +184,7 @@ where
 
 fn derive_address<C: IOContext>(
 	context: &C,
-	cardano_network: CardanoNetwork,
+	cardano_network: NetworkType,
 ) -> Result<String, anyhow::Error> {
 	let cardano_payment_verification_key_file =
 		config_fields::CARDANO_PAYMENT_VERIFICATION_KEY_FILE
@@ -191,7 +192,7 @@ fn derive_address<C: IOContext>(
 	let key_bytes: [u8; 32] =
 		cardano_key::get_key_bytes_from_file(&cardano_payment_verification_key_file, context)?;
 	let address =
-		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.into());
+		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.to_csl());
 	address.to_bech32(None).map_err(|e| anyhow!(e.to_string()))
 }
 

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -65,7 +65,7 @@ impl CmdRun for Register3Cmd {
 
 		let command = format!(
 			"{PC_CONTRACTS_CLI_PATH} register --network {} {} --registration-utxo {} --sidechain-public-keys {}:{}:{} --sidechain-signature {} --spo-public-key {} --spo-signature {} --ada-based-staking {}",
-			cardano_network.to_network_param(),
+			cardano_network,
 			sidechain_param_arg,
 			self.registration_utxo,
 			self.sidechain_pub_key,

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -269,7 +269,7 @@ fn set_candidates_on_main_chain<C: IOContext>(
 			.run_command(&format!(
 				"{PC_CONTRACTS_CLI_PATH} {} --network {} {} {} {}",
 				command,
-				cardano_network.to_network_param(),
+				cardano_network.to_string(),
 				candidate_keys,
 				smart_contracts::sidechain_params_arguments(chain_params),
 				smart_contracts::runtime_config_arguments(
@@ -309,7 +309,7 @@ fn set_d_parameter_on_main_chain<C: IOContext>(
 		let cardano_network = get_cardano_network_from_file(context)?;
 		let command = format!(
 			"{PC_CONTRACTS_CLI_PATH} {pc_contracts_cli_command} --network {} --d-parameter-permissioned-candidates-count {p} --d-parameter-registered-candidates-count {r} {} {}",
-			cardano_network.to_network_param(),
+			cardano_network,
 			smart_contracts::sidechain_params_arguments(chain_params),
 			smart_contracts::runtime_config_arguments(&pc_contracts_cli_resources, &payment_signing_key_path)
 		);

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -476,6 +476,25 @@ impl UtxoInfo {
 	}
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "lowercase"))]
+pub enum NetworkType {
+	Mainnet,
+	Testnet,
+}
+
+#[cfg(feature = "std")]
+impl std::fmt::Display for NetworkType {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		let str = match self {
+			Self::Mainnet => "mainnet",
+			Self::Testnet => "testnet",
+		};
+		write!(f, "{}", str)
+	}
+}
+
 #[derive(Default, Clone, PartialEq, Eq, Encode, Decode)]
 #[byte_string(debug, hex_serialize, hex_deserialize)]
 pub struct CommitteeHash(pub Vec<u8>);

--- a/toolkit/utils/ogmios-client/Cargo.toml
+++ b/toolkit/utils/ogmios-client/Cargo.toml
@@ -14,6 +14,7 @@ serde = { workspace = true }
 serde_json = { workspace = true, features = ["raw_value", "arbitrary_precision"] }
 thiserror = { workspace = true }
 time = { workspace = true, features = ["std", "serde", "parsing"] }
+sidechain-domain = { workspace = true, features = ["std"] }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/toolkit/utils/ogmios-client/src/query_network.rs
+++ b/toolkit/utils/ogmios-client/src/query_network.rs
@@ -4,6 +4,7 @@ use crate::{types::SlotLength, OgmiosClient, OgmiosClientError, OgmiosParams};
 use fraction::Decimal;
 use serde::Deserialize;
 use serde_json::Value;
+use sidechain_domain::NetworkType;
 use std::collections::HashMap;
 
 pub trait QueryNetwork {
@@ -28,7 +29,7 @@ impl<T: OgmiosClient> QueryNetwork for T {
 #[serde(rename_all = "camelCase")]
 pub struct ShelleyGenesisConfigurationResponse {
 	pub network_magic: u32,
-	pub network: Network,
+	pub network: NetworkType,
 	pub security_parameter: u32,
 	#[serde(deserialize_with = "crate::types::parse_fraction_decimal")]
 	pub active_slots_coefficient: Decimal,
@@ -36,11 +37,4 @@ pub struct ShelleyGenesisConfigurationResponse {
 	pub slot_length: SlotLength,
 	#[serde(deserialize_with = "time::serde::iso8601::deserialize")]
 	pub start_time: time::OffsetDateTime,
-}
-
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
-#[serde(rename_all = "lowercase")]
-pub enum Network {
-	Mainnet,
-	Testnet,
 }

--- a/toolkit/utils/ogmios-client/tests/query_network.rs
+++ b/toolkit/utils/ogmios-client/tests/query_network.rs
@@ -6,10 +6,11 @@ use jsonrpsee::{
 	types::{ErrorCode, ErrorObject},
 };
 use ogmios_client::{
-	query_network::{Network, QueryNetwork, ShelleyGenesisConfigurationResponse},
+	query_network::{QueryNetwork, ShelleyGenesisConfigurationResponse},
 	types::SlotLength,
 };
 use serde_json::{json, Value};
+use sidechain_domain::NetworkType;
 use time::OffsetDateTime;
 
 mod server;
@@ -50,7 +51,7 @@ async fn shelley_genesis_configuration() {
 		genesis_configuration,
 		ShelleyGenesisConfigurationResponse {
 			network_magic: 2,
-			network: Network::Testnet,
+			network: NetworkType::Testnet,
 			start_time: OffsetDateTime::from_unix_timestamp(1666656000).unwrap(),
 			security_parameter: 432,
 			epoch_length: 86400,


### PR DESCRIPTION
# Description

Introduces a `NetworkType` enum in the domain crate and replaces local types representing Cardano network type from other crates.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

