### PR TITLE
remove usage of Balances::deposit from transfer handler

### DIFF
--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -323,17 +323,6 @@ pub struct TokenTransferHandler;
 
 impl pallet_native_token_management::TokenTransferHandler for TokenTransferHandler {
 	fn handle_token_transfer(token_amount: NativeTokenAmount) -> DispatchResult {
-		// Mint the "transfered" tokens into a dummy address.
-		// This is done for visibility in tests only.
-		// Despite using the `Balances` pallet to do the transfer here, the account balance
-		// is stored (and can be observed) in the `System` pallet's storage.
-		let _ = Balances::deposit(
-			&AccountId::from(hex!(
-				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-			)),
-			token_amount.0,
-			Precision::Exact,
-		)?;
 		log::info!("💸 Registered transfer of {} native tokens", token_amount.0);
 		Ok(())
 	}


### PR DESCRIPTION
# Description

Removes `Balances::deposit` from native token transfer handler, which caused problems when the total transfer was less than the existential token amount. This "feature" was only added for visibility and is not needed by anyone.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

