### PR TITLE
change: Extrinsic enabling update from v1.3 to v1.4

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Added
 
+* Added `upgrade_and_set_addresses` extrinsic that atomically upgrades runtime and changes chain configuration.
+
 # v1.3.0
 
 ## Changed

--- a/pallets/sidechain/src/lib.rs
+++ b/pallets/sidechain/src/lib.rs
@@ -10,8 +10,9 @@ pub use pallet::*;
 #[frame_support::pallet]
 pub mod pallet {
 	use frame_support::pallet_prelude::*;
-	use frame_system::pallet_prelude::BlockNumberFor;
-	use sidechain_domain::{ScEpochNumber, ScSlotNumber};
+	use frame_system::ensure_root;
+	use frame_system::pallet_prelude::*;
+	use sidechain_domain::{ScEpochNumber, ScSlotNumber, UtxoId};
 	use sp_sidechain::OnNewEpoch;
 
 	#[pallet::pallet]
@@ -29,6 +30,10 @@ pub mod pallet {
 			+ MaxEncodedLen
 			+ Clone
 			+ Default;
+
+		type MainChainScripts: Member + Parameter + MaybeSerializeDeserialize + MaxEncodedLen;
+
+		fn set_main_chain_scripts(scripts: Self::MainChainScripts);
 	}
 
 	#[pallet::storage]
@@ -40,6 +45,9 @@ pub mod pallet {
 
 	#[pallet::storage]
 	pub(super) type SidechainParams<T: Config> = StorageValue<_, T::SidechainParams, ValueQuery>;
+
+	#[pallet::storage]
+	pub(super) type GenesisUtxo<T: Config> = StorageValue<_, UtxoId, ValueQuery>;
 
 	impl<T: Config> Pallet<T> {
 		pub fn sidechain_params() -> T::SidechainParams {
@@ -93,6 +101,28 @@ pub mod pallet {
 				},
 				_ => T::DbWeight::get().reads_writes(2, 0),
 			}
+		}
+	}
+
+	/// Priviledged extrinsic to atomically upgrade runtime code and vital sidechain parameters
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		#[pallet::call_index(1)]
+		#[pallet::weight((0, DispatchClass::Normal))]
+		pub fn upgrade_and_set_addresses(
+			origin: OriginFor<T>,
+			code: sp_std::vec::Vec<u8>,
+			genesis_utxo: UtxoId,
+			selection_main_chain_scripts: T::MainChainScripts,
+		) -> DispatchResultWithPostInfo {
+			ensure_root(origin.clone())?;
+
+			GenesisUtxo::<T>::set(genesis_utxo);
+
+			T::set_main_chain_scripts(selection_main_chain_scripts);
+
+			// Runtime upgrade must be last because it consumes the rest of the block time
+			frame_system::Pallet::<T>::set_code(origin, code)
 		}
 	}
 }

--- a/pallets/sidechain/src/lib.rs
+++ b/pallets/sidechain/src/lib.rs
@@ -104,7 +104,12 @@ pub mod pallet {
 		}
 	}
 
-	/// Priviledged extrinsic to atomically upgrade runtime code and vital sidechain parameters
+	/// Priviledged extrinsic to atomically upgrade runtime code and vital sidechain parameters.
+	///
+	/// Parameters:
+	/// - `code`: WASM of the new runtime
+	/// - `genesis_utxo`: genesis utxo burned by the `init-governance` transaction
+	/// - `main_chain_scripts`: policies and addresses obtained from the `addresses` for the `genesis_utxo`
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(1)]
@@ -113,13 +118,13 @@ pub mod pallet {
 			origin: OriginFor<T>,
 			code: sp_std::vec::Vec<u8>,
 			genesis_utxo: UtxoId,
-			selection_main_chain_scripts: T::MainChainScripts,
+			main_chain_scripts: T::MainChainScripts,
 		) -> DispatchResultWithPostInfo {
 			ensure_root(origin.clone())?;
 
 			GenesisUtxo::<T>::set(genesis_utxo);
 
-			T::set_main_chain_scripts(selection_main_chain_scripts);
+			T::set_main_chain_scripts(main_chain_scripts);
 
 			// Runtime upgrade must be last because it consumes the rest of the block time
 			frame_system::Pallet::<T>::set_code(origin, code)

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -200,7 +200,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 116,
+	spec_version: 117,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -472,6 +472,12 @@ impl pallet_sidechain::Config for Runtime {
 	type OnNewEpoch = LogBeneficiaries;
 
 	type SidechainParams = chain_params::SidechainParams;
+
+	type MainChainScripts = sp_session_validator_management::MainChainScripts;
+
+	fn set_main_chain_scripts(scripts: Self::MainChainScripts) {
+		pallet_session_validator_management::MainChainScriptsConfiguration::<Runtime>::set(scripts);
+	}
 }
 
 pub type BeneficiaryId = sidechain_domain::byte_string::SizedByteString<32>;


### PR DESCRIPTION
# Description

Adds an `upgrade_and_set_addresses` extrinsic to Sidechain pallet which allows to atomically upgrade the runtime and change chain configuration at the same time.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

