### PR TITLE
chore: avoid using nix derivations defined in pc-contracts repo

### DIFF
--- a/dev/nix/packages/default.nix
+++ b/dev/nix/packages/default.nix
@@ -14,19 +14,19 @@
   }: let
     kupoVersion = "2.9.0";
     ogmiosVersion = "6.9.0";
+    pcContractsCliVersion = "7.0.1";
 
     flake-compat = import inputs.flake-compat;
     cardanoPackages = (flake-compat { src = inputs.cardano-node; }).defaultNix.packages.${system};
     dbSyncPackages = (flake-compat { src = inputs.cardano-dbsync; }).defaultNix.packages.${system};
-    smartContractsPkgs = (flake-compat { src = inputs.smart-contracts; }).defaultNix.packages.${system};
     #cardanoExtraPkgs = (flake-compat { src = inputs.cardano-nix; }).defaultNix.packages.${system};
   in {
     packages = {
-      inherit (smartContractsPkgs) pc-contracts-cli;
       inherit (cardanoPackages) cardano-node cardano-cli cardano-testnet;
       inherit (dbSyncPackages) "cardano-db-sync:exe:cardano-db-sync";
       kupo = pkgs.callPackage ./kupo.nix { version = kupoVersion; };
       ogmios = pkgs.callPackage ./ogmios.nix { version = ogmiosVersion; };
+      pc-contracts-cli = pkgs.callPackage ./pc-contracts-cli.nix { version = pcContractsCliVersion; };
       process-compose = pkgs.process-compose.overrideAttrs (oldAttrs: {
         patches = [ ./pc.patch ];
       });

--- a/dev/nix/packages/pc-contracts-cli.nix
+++ b/dev/nix/packages/pc-contracts-cli.nix
@@ -1,0 +1,14 @@
+{ fetchzip, stdenv, version, ... }:
+
+fetchzip {
+  url = "https://github.com/input-output-hk/partner-chains-smart-contracts/releases/download/v${version}/pc-contracts-cli-v${version}.zip";
+  hash = "sha256-Sp94vyyjI1lfRar6TJX1YRD/eOYkbK/t7dplLZx7+iA=";
+  stripRoot = false;
+  version = "${version}";
+  name = "pc-contracts-cli-${version}";
+  postFetch = ''
+      mkdir -p $out/bin
+      mv $out/pc-contracts-cli $out/bin
+      chmod +x $out/bin/pc-contracts-cli
+  '';
+}

--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -120,7 +120,7 @@
               name = "pc-contracts-cli";
               help = "CLI to interact with Partner Chains Smart Contracts";
               command = ''
-                ${self'.packages.pc-contracts-cli}/dist/pc-contracts-cli $@
+                ${self'.packages.pc-contracts-cli}/bin/pc-contracts-cli $@
               '';
             }
           ];
@@ -144,7 +144,7 @@
           name = "pc-contracts-cli";
           help = "CLI to interact with Partner Chains Smart Contracts";
           command = ''
-            ${self'.packages.pc-contracts-cli}/dist/pc-contracts-cli $@
+            ${self'.packages.pc-contracts-cli}/bin/pc-contracts-cli $@
           '';
         }
       ];

--- a/flake.lock
+++ b/flake.lock
@@ -232,8 +232,7 @@
         "nixpkgs": "nixpkgs",
         "ogmios": "ogmios",
         "process-compose": "process-compose",
-        "services-flake": "services-flake",
-        "smart-contracts": "smart-contracts"
+        "services-flake": "services-flake"
       }
     },
     "rust-analyzer-src": {
@@ -265,23 +264,6 @@
       "original": {
         "owner": "juspay",
         "repo": "services-flake",
-        "type": "github"
-      }
-    },
-    "smart-contracts": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1731596108,
-        "narHash": "sha256-MKmABReJpvrWvArccmHwsNtPhYvDkZMkQeVJjKG+3SU=",
-        "owner": "input-output-hk",
-        "repo": "partner-chains-smart-contracts",
-        "rev": "5f96807760b8e93eaf9661d72cef236700b3b616",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "v7.0.1",
-        "repo": "partner-chains-smart-contracts",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -23,10 +23,6 @@
     services-flake.url = "github:juspay/services-flake";
 
     # Partner Chains deps
-    smart-contracts = {
-      url = "github:input-output-hk/partner-chains-smart-contracts/v7.0.1";
-      flake = false;
-    };
     cardano-node = {
       url = "github:IntersectMBO/cardano-node/10.1.2";
       flake = false;


### PR DESCRIPTION
# Description

`partner-chains-smart-contracts` repo will stop providing nix derivations. This PR makes nix get `pc-contracts-cli` from the release archive instead.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

