### PR TITLE
add: ETCM-8948 get-scripts command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,7 +33,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Added
 
-* Added `smart-contracts` command to the node with first command `init-governance`.
+* Added `smart-contracts` command to the node with sub-commands `init-governance` and `get-scripts`.
 
 # v1.3.0
 

--- a/toolkit/cli/smart-contracts-commands/src/get_scripts.rs
+++ b/toolkit/cli/smart-contracts-commands/src/get_scripts.rs
@@ -1,0 +1,24 @@
+use jsonrpsee::http_client::HttpClient;
+use partner_chains_cardano_offchain::scripts_data::get_scripts_data_with_ogmios;
+use sidechain_domain::UtxoId;
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct GetScripts {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long, short = 'c')]
+	genesis_utxo: UtxoId,
+}
+
+impl GetScripts {
+	pub async fn execute(self) -> crate::CmdResult<()> {
+		let client = HttpClient::builder().build(self.common_arguments.ogmios_host)?;
+		let scripts_data = get_scripts_data_with_ogmios(self.genesis_utxo, client).await?;
+
+		let json = serde_json::to_string_pretty(&scripts_data)?;
+
+		print!("{json}");
+
+		Ok(())
+	}
+}

--- a/toolkit/cli/smart-contracts-commands/src/init_governance.rs
+++ b/toolkit/cli/smart-contracts-commands/src/init_governance.rs
@@ -8,11 +8,11 @@ use crate::read_private_key_from_file;
 pub struct InitGovernanceCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	#[arg(long)]
+	#[arg(long, short = 'g')]
 	governance_authority: MainchainAddressHash,
-	#[arg(long)]
+	#[arg(long, short = 'k')]
 	payment_key_file: String,
-	#[arg(long)]
+	#[arg(long, short = 'c')]
 	genesis_utxo: Option<UtxoId>,
 }
 

--- a/toolkit/cli/smart-contracts-commands/src/lib.rs
+++ b/toolkit/cli/smart-contracts-commands/src/lib.rs
@@ -1,10 +1,13 @@
 use sidechain_domain::MainchainPrivateKey;
 
+pub mod get_scripts;
 pub mod init_governance;
 
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum SmartContractsCmd {
+	/// Print validator addresses and policy IDs of Partner Chain smart contracts
+	GetScripts(get_scripts::GetScripts),
 	/// Initialize Partner Chain governance
 	InitGovernance(init_governance::InitGovernanceCmd),
 }
@@ -12,7 +15,7 @@ pub enum SmartContractsCmd {
 #[derive(Clone, Debug, clap::Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct CommonArguments {
-	#[arg(default_value = "http://localhost:1337")]
+	#[arg(default_value = "http://localhost:1337", long, short = 'O')]
 	ogmios_host: String,
 }
 
@@ -22,6 +25,7 @@ impl SmartContractsCmd {
 	pub async fn execute(self) -> CmdResult<()> {
 		match self {
 			Self::InitGovernance(cmd) => cmd.execute().await,
+			Self::GetScripts(cmd) => cmd.execute().await,
 		}
 	}
 

--- a/toolkit/offchain/src/scripts_data.rs
+++ b/toolkit/offchain/src/scripts_data.rs
@@ -129,6 +129,14 @@ pub fn get_scripts_data(
 	})
 }
 
+pub async fn get_scripts_data_with_ogmios(
+	genesis_utxo: UtxoId,
+	client: impl QueryNetwork,
+) -> anyhow::Result<ScriptsData> {
+	let network = client.shelley_genesis_configuration().await?.network.to_csl();
+	get_scripts_data(genesis_utxo, network)
+}
+
 // Returns version oracle script, policy and PlutusData required by other scripts.
 pub(crate) fn version_oracle(
 	genesis_utxo: UtxoId,


### PR DESCRIPTION
# Description

Adds `get-scripts` command that prints all validator addresses and policy IDs for a given genesis utxo.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

