### PR TITLE
feat: script validate license compatibility for all workspace crates

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -31,6 +31,7 @@
         gnumake
         gawk
         cargo-edit
+        cargo-license
         perl
       ]
       ++ (

--- a/scripts/validate_workspace_licenses.py
+++ b/scripts/validate_workspace_licenses.py
@@ -1,0 +1,123 @@
+import subprocess
+import json
+import toml
+
+ALLOWED_GPL_LICENSE = "GPL-3.0-or-later WITH Classpath-exception-2.0"
+CLASSPATH_EXCEPTION_CRATES = {"partner-chains-node"}  # Crates explicitly allowed to have dependencies licensed with ALLOWED_GPL_LICENSE
+
+# Clarifications for crates with unknown licenses
+CLARIFICATIONS = {
+    "ring": "OpenSSL AND ISC AND MIT",
+    "webpki": "ISC",
+    "fuchsia-cprng": "BSD-3-Clause",
+    "raw-scripts": "Apache-2.0",
+}
+
+def get_workspace_crates():
+    try:
+        result = subprocess.run(
+            ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        metadata = json.loads(result.stdout)
+        return [pkg["manifest_path"] for pkg in metadata["packages"]]
+    except subprocess.CalledProcessError as e:
+        print("Error retrieving workspace metadata:", e.stderr)
+        exit(1)
+
+def get_crate_name(crate_manifest_path):
+    try:
+        with open(crate_manifest_path, "r") as f:
+            data = toml.load(f)
+            return data["package"]["name"]
+    except (FileNotFoundError, KeyError) as e:
+        print(f"Error retrieving crate name from {crate_manifest_path}: {e}")
+        return "UNKNOWN"
+
+def get_crate_license(crate_manifest_path):
+    try:
+        with open(crate_manifest_path, "r") as f:
+            data = toml.load(f)
+            return data["package"]["license"]
+    except FileNotFoundError:
+        print(f"Manifest file not found: {crate_manifest_path}")
+        return "UNKNOWN"
+    except KeyError:
+        print(f"License not specified: {crate_manifest_path}")
+        return "UNKNOWN"
+
+def list_licenses_for_crate_deps(crate_manifest_path):
+    try:
+        result = subprocess.run(
+            ["cargo", "license", "--manifest-path", crate_manifest_path, "--json", "--avoid-build-deps"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as e:
+        print(f"Error checking licenses for {crate_manifest_path}: {e.stderr}")
+        return None
+
+# Naive (but probably good enough) way of checking if a license is non-GPL
+def is_non_gpl_license(license_str):
+    return "GPL" not in license_str
+
+def is_allowed_gpl_license(license_str):
+    return license_str == ALLOWED_GPL_LICENSE
+
+def is_valid_license_combination(license_str, crate_license, crate_name):
+    licenses = [l.strip() for l in license_str.split("OR")]
+    # Check if at least one license is valid
+    return any(
+        is_non_gpl_license(lic) or
+        (is_allowed_gpl_license(lic) and
+         (crate_license == ALLOWED_GPL_LICENSE or crate_name in CLASSPATH_EXCEPTION_CRATES))
+        for lic in licenses
+    )
+
+def main():
+    print("Fetching workspace crates...")
+    workspace_crates = get_workspace_crates()
+    violations = []
+
+    for crate_manifest_path in workspace_crates:
+        crate_name = get_crate_name(crate_manifest_path)
+        print(f"Checking licenses for {crate_name}...")
+
+        crate_license = get_crate_license(crate_manifest_path)
+        dependencies = list_licenses_for_crate_deps(crate_manifest_path)
+
+        if dependencies is None:
+            violations.append(f"{crate_name} -> Failed to retrieve license information for dependencies.")
+            continue
+
+        for dep in dependencies:
+            dep_name = dep["name"]
+            dep_license = dep.get("license")
+
+            if dep_license is None or dep_license == "UNKNOWN":
+                if dep_name in CLARIFICATIONS:
+                    dep_license = CLARIFICATIONS[dep_name]
+                else:
+                    violations.append(f"{crate_name} -> {dep_name} has no license specified and no clarification provided")
+                    continue
+
+            if not is_valid_license_combination(dep_license, crate_license, crate_name):
+                violations.append(
+                    f"{crate_name} -> {dep_name} ({dep_license}) is not allowed. "
+                    f"Only 'non-GPL' or '{ALLOWED_GPL_LICENSE}' licenses are permitted, "
+                    f"with additional restrictions for GPL licenses."
+                )
+
+    if violations:
+        print("\nLicense violations detected:")
+        print("\n".join(violations))
+        exit(1)
+    else:
+        print("All licenses comply with policies.")
+
+if __name__ == "__main__":
+    main()

--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cli-commands"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/cli/node-commands/Cargo.toml
+++ b/toolkit/cli/node-commands/Cargo.toml
@@ -2,7 +2,7 @@
 name = "partner-chains-node-commands"
 version = "1.3.0"
 edition = "2021"
-license = "GPLv3 with a classpath exception"
+license = "GPL-3.0-or-later WITH Classpath-exception-2.0"
 
 [dependencies]
 authority-selection-inherents = { workspace = true }

--- a/toolkit/cli/smart-contracts-commands/Cargo.toml
+++ b/toolkit/cli/smart-contracts-commands/Cargo.toml
@@ -2,6 +2,7 @@
 name = "partner-chains-smart-contracts-commands"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 clap = { workspace = true }

--- a/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
@@ -2,6 +2,7 @@
 name = "db-sync-follower"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/toolkit/mainchain-follower/main-chain-follower-cli/Cargo.toml
+++ b/toolkit/mainchain-follower/main-chain-follower-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "main-chain-follower-cli"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/mainchain-follower/mock/Cargo.toml
+++ b/toolkit/mainchain-follower/mock/Cargo.toml
@@ -3,6 +3,7 @@ name = "main-chain-follower-mock"
 version = "1.3.0"
 edition = "2021"
 publish = false
+license = "Apache-2.0"
 
 [dependencies]
 async-trait = { workspace = true }

--- a/toolkit/pallets/block-rewards/Cargo.toml
+++ b/toolkit/pallets/block-rewards/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-block-rewards"
 version = "1.3.0"
 edition = "2021"
 description = "Pallet to track due block rewards"
+license = "Apache-2.0"
 
 [dependencies]
 frame-support = { workspace = true }

--- a/toolkit/pallets/native-token-management/Cargo.toml
+++ b/toolkit/pallets/native-token-management/Cargo.toml
@@ -3,6 +3,7 @@ name = "pallet-native-token-management"
 version = "1.3.0"
 edition = "2021"
 description = "Pallet responsible for handling changes to the illiquid supply of the native token on main chain."
+license = "Apache-2.0"
 
 [dependencies]
 frame-support = { workspace = true }

--- a/toolkit/pallets/session-validator-management/benchmarking/Cargo.toml
+++ b/toolkit/pallets/session-validator-management/benchmarking/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-session-validator-management-benchmarking"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/toolkit/pallets/session-validator-management/rpc/Cargo.toml
+++ b/toolkit/pallets/session-validator-management/rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-session-validator-management-rpc"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 derive-new = { workspace = true }

--- a/toolkit/pallets/sidechain/Cargo.toml
+++ b/toolkit/pallets/sidechain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-sidechain"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/pallets/sidechain/rpc/Cargo.toml
+++ b/toolkit/pallets/sidechain/rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "pallet-sidechain-rpc"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/authority-selection-inherents/Cargo.toml
+++ b/toolkit/primitives/authority-selection-inherents/Cargo.toml
@@ -2,6 +2,7 @@
 name = "authority-selection-inherents"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/block-rewards/Cargo.toml
+++ b/toolkit/primitives/block-rewards/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp-block-rewards"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 async-trait = { workspace = true }

--- a/toolkit/primitives/domain/Cargo.toml
+++ b/toolkit/primitives/domain/Cargo.toml
@@ -3,6 +3,7 @@ name = "sidechain-domain"
 version = "1.3.0"
 authors = [ "Nikolaos Dymitriadis <nikolaos.dymitriadis@iohk.io>" ]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 sp-core = { workspace = true, features = ["serde"] }

--- a/toolkit/primitives/mock-types/Cargo.toml
+++ b/toolkit/primitives/mock-types/Cargo.toml
@@ -3,6 +3,7 @@ name = "mock-types"
 version = "1.3.0"
 edition = "2021"
 description = "Shared mock type definitions for reuse in multiple crates"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/native-token-management/Cargo.toml
+++ b/toolkit/primitives/native-token-management/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp-native-token-management"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/toolkit/primitives/plutus-data/Cargo.toml
+++ b/toolkit/primitives/plutus-data/Cargo.toml
@@ -3,6 +3,7 @@ name = "partner-chains-plutus-data"
 version = "1.3.0"
 edition = "2021"
 description = "Parsing and serialization of Plutus data schemas used by Partner Chains smart contracts."
+license = "Apache-2.0"
 
 [dependencies]
 log = { workspace = true }

--- a/toolkit/primitives/selection/Cargo.toml
+++ b/toolkit/primitives/selection/Cargo.toml
@@ -4,6 +4,7 @@ version = "1.3.0"
 description = "Selection logic for sidechain validators"
 edition = "2021"
 publish = false
+license = "Apache-2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/toolkit/primitives/session-manager/Cargo.toml
+++ b/toolkit/primitives/session-manager/Cargo.toml
@@ -2,6 +2,7 @@
 name = "session-manager"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/session-validator-management/Cargo.toml
+++ b/toolkit/primitives/session-validator-management/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp-session-validator-management"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/session-validator-management/query/Cargo.toml
+++ b/toolkit/primitives/session-validator-management/query/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp-session-validator-management-query"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 parity-scale-codec = { workspace = true }

--- a/toolkit/primitives/sidechain-block-search/Cargo.toml
+++ b/toolkit/primitives/sidechain-block-search/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sidechain-block-search"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/primitives/sidechain-mc-hash/Cargo.toml
+++ b/toolkit/primitives/sidechain-mc-hash/Cargo.toml
@@ -3,6 +3,7 @@ name = "sidechain-mc-hash"
 version = "1.3.0"
 edition = "2021"
 description = "Logic for putting a main chain block reference in digest and inherent data"
+license = "Apache-2.0"
 
 [dependencies]
 async-trait = { workspace = true }

--- a/toolkit/primitives/sidechain/Cargo.toml
+++ b/toolkit/primitives/sidechain/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sp-sidechain"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/toolkit/utils/byte-string-derivation/Cargo.toml
+++ b/toolkit/utils/byte-string-derivation/Cargo.toml
@@ -2,6 +2,7 @@
 name = "byte-string-derive"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true

--- a/toolkit/utils/ogmios-client/Cargo.toml
+++ b/toolkit/utils/ogmios-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ogmios-client"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [package.metadata.docs.rs]
 targets = ["x86_64-unknown-linux-gnu"]

--- a/toolkit/utils/plutus/Cargo.toml
+++ b/toolkit/utils/plutus/Cargo.toml
@@ -3,6 +3,7 @@ name = "plutus"
 version = "1.3.0"
 edition = "2021"
 publish = false
+license = "Apache-2.0"
 
 [dependencies]
 hex = { workspace = true }

--- a/toolkit/utils/plutus/plutus-datum-derive/Cargo.toml
+++ b/toolkit/utils/plutus/plutus-datum-derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plutus-datum-derive"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [lib]
 proc-macro = true

--- a/toolkit/utils/time-source/Cargo.toml
+++ b/toolkit/utils/time-source/Cargo.toml
@@ -2,6 +2,7 @@
 name = "time-source"
 version = "1.3.0"
 edition = "2021"
+license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Description

This pull request introduces a Python script to verify license compliance for dependencies in this dual-licensed repository. The script will reduce the risk of inadverent license violations.
I've tried to enforce it using cargo-deny. However, it doesn't seem to provide useful functionality. If you think it might be beneficial, I can add a deny.toml configuration which specifies all possible licenses and crate exceptions, but it won't ensure the same checks as the script provided.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
~- [ ] New tests are added if needed and existing tests are updated.~ Scripts don't require tests, do they?
~- [ ] Relevant logging and metrics added~
- [x] CI passes. See note on CI.
~- [ ] Any changes are noted in the `changelog.md` for affected crate~ Doesn't seem like this requires a note in changelog file, does it?
- [x] Self-reviewed the diff
