### PR TITLE
change: ETCM-8907 add logging of ogmios requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6715,7 +6715,6 @@ name = "partner-chains-smart-contracts-commands"
 version = "1.4.0"
 dependencies = [
  "clap",
- "env_logger 0.11.3",
  "hex",
  "jsonrpsee",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -193,6 +193,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "ark-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,6 +1993,12 @@ dependencies = [
  "rustc_version",
  "syn 2.0.71",
 ]
+
+[[package]]
+name = "destructure_traitobject"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c877555693c14d2f84191cfd3ad8582790fc52b5e2274b40b59cf5f5cea25c7"
 
 [[package]]
 name = "diff"
@@ -4844,6 +4856,43 @@ name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "log-mdc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94d21414c1f4a51209ad204c1776a3d0765002c76c6abcb602a6f09f1e881c7"
+
+[[package]]
+name = "log4rs"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0816135ae15bd0391cf284eab37e6e3ee0a6ee63d2ceeb659862bd8d0a984ca6"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "chrono",
+ "derivative",
+ "fnv",
+ "humantime",
+ "libc",
+ "log",
+ "log-mdc",
+ "once_cell",
+ "parking_lot 0.12.3",
+ "rand",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "serde_yaml",
+ "thiserror",
+ "thread-id",
+ "typemap-ors",
+ "winapi",
+]
 
 [[package]]
 name = "lru"
@@ -5768,6 +5817,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "jsonrpsee",
+ "log",
  "serde",
  "serde_json",
  "sidechain-domain",
@@ -5871,6 +5921,15 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "overload"
@@ -6656,8 +6715,11 @@ name = "partner-chains-smart-contracts-commands"
 version = "1.4.0"
 dependencies = [
  "clap",
+ "env_logger 0.11.3",
  "hex",
  "jsonrpsee",
+ "log",
+ "log4rs",
  "partner-chains-cardano-offchain",
  "serde",
  "serde_json",
@@ -9629,6 +9691,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
+]
+
+[[package]]
 name = "serde-wasm-bindgen"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9720,6 +9792,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.2.6",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -11644,6 +11729,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bf63baf9f5039dadc247375c29eb13706706cfde997d0330d05aa63a77d8820"
 
 [[package]]
+name = "thread-id"
+version = "4.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe8f25bbdd100db7e1d34acf7fd2dc59c4bf8f7483f505eaa7d4f12f76cc0ea"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12152,6 +12247,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
+name = "typemap-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a68c24b707f02dd18f1e4ccceb9d49f2058c2fb86384ef9972592904d7a28867"
+dependencies = [
+ "unsafe-any-ors",
+]
+
+[[package]]
 name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12250,6 +12354,21 @@ dependencies = [
  "crypto-common",
  "subtle 2.6.1",
 ]
+
+[[package]]
+name = "unsafe-any-ors"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
+dependencies = [
+ "destructure_traitobject",
+]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "unsigned-varint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6580,6 +6580,8 @@ dependencies = [
  "inquire",
  "jsonrpsee",
  "libp2p-identity",
+ "log",
+ "log4rs",
  "ogmios-client",
  "partner-chains-cardano-offchain",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,6 +109,7 @@ derive-new = { version = "0.7.0" }
 inquire = { version = "0.7.5" }
 parking_lot = { version = "0.12.3", default-features = false }
 envy = { version = "0.4.2" }
+log4rs = { version = "1.3.0" }
 
 # substrate dependencies
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2409" }

--- a/toolkit/cli/smart-contracts-commands/Cargo.toml
+++ b/toolkit/cli/smart-contracts-commands/Cargo.toml
@@ -13,3 +13,6 @@ jsonrpsee = { workspace = true, features = ["client-core", "http-client", "macro
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }
+log4rs = { workspace = true }

--- a/toolkit/cli/smart-contracts-commands/Cargo.toml
+++ b/toolkit/cli/smart-contracts-commands/Cargo.toml
@@ -14,5 +14,4 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 log = { workspace = true }
-env_logger = { workspace = true }
 log4rs = { workspace = true }

--- a/toolkit/cli/smart-contracts-commands/src/lib.rs
+++ b/toolkit/cli/smart-contracts-commands/src/lib.rs
@@ -1,3 +1,7 @@
+use log4rs::{
+	append::{console::ConsoleAppender, file::FileAppender},
+	config::Appender,
+};
 use sidechain_domain::MainchainPrivateKey;
 
 pub mod get_scripts;
@@ -30,6 +34,8 @@ impl SmartContractsCmd {
 	}
 
 	pub fn execute_blocking(self) -> CmdResult<()> {
+		setup_logging()?;
+
 		tokio::runtime::Runtime::new()?.block_on(self.execute())
 	}
 }
@@ -48,4 +54,24 @@ pub(crate) fn read_private_key_from_file(path: &str) -> CmdResult<MainchainPriva
 	let key_bytes = (hex::decode(key_hex)?.try_into())
 		.map_err(|_| format!("{} is not the valid lengh of 32", key_hex))?;
 	Ok(MainchainPrivateKey(key_bytes))
+}
+
+pub fn setup_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+	let stdout = ConsoleAppender::builder().build();
+	let ogmios_log = FileAppender::builder().build("ogmios_log.json")?;
+
+	let log_config = log4rs::config::Config::builder()
+		.appender(Appender::builder().build("stdout", Box::new(stdout)))
+		.appender(Appender::builder().build("ogmios-log", Box::new(ogmios_log)))
+		.logger(
+			log4rs::config::Logger::builder()
+				.appender("ogmios-log")
+				.additive(false)
+				.build("ogmios_client::jsonrpsee", log::LevelFilter::Debug),
+		)
+		.build(log4rs::config::Root::builder().appender("stdout").build(log::LevelFilter::Info))?;
+
+	log4rs::init_config(log_config)?;
+
+	Ok(())
 }

--- a/toolkit/cli/smart-contracts-commands/src/lib.rs
+++ b/toolkit/cli/smart-contracts-commands/src/lib.rs
@@ -58,7 +58,7 @@ pub(crate) fn read_private_key_from_file(path: &str) -> CmdResult<MainchainPriva
 
 pub fn setup_logging() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 	let stdout = ConsoleAppender::builder().build();
-	let ogmios_log = FileAppender::builder().build("ogmios_log.json")?;
+	let ogmios_log = FileAppender::builder().build("ogmios_client.log")?;
 
 	let log_config = log4rs::config::Config::builder()
 		.appender(Appender::builder().build("stdout", Box::new(stdout)))

--- a/toolkit/cli/smart-contracts-commands/src/main.rs
+++ b/toolkit/cli/smart-contracts-commands/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use partner_chains_smart_contracts_commands::SmartContractsCmd;
+use partner_chains_smart_contracts_commands::{setup_logging, SmartContractsCmd};
 
 #[derive(Clone, Debug, clap::Parser)]
 pub enum SmartContractsCmdStandalone {
@@ -11,6 +11,8 @@ type CmdResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;
 
 #[tokio::main]
 async fn main() -> CmdResult<()> {
+	setup_logging()?;
+
 	let SmartContractsCmdStandalone::Inner(cmd) = SmartContractsCmdStandalone::parse();
 	cmd.execute().await
 }

--- a/toolkit/offchain/src/init_governance/mod.rs
+++ b/toolkit/offchain/src/init_governance/mod.rs
@@ -53,17 +53,17 @@ pub async fn run_init_governance<T: QueryLedgerState + Transactions + QueryNetwo
 	let network = client.shelley_genesis_configuration().await?.network;
 
 	let own_address = key_hash_address(&payment_key.to_public().hash(), network.to_csl());
-	println!("✉️ Submitter address: {}", own_address.to_bech32(None).unwrap());
+	log::info!("✉️ Submitter address: {}", own_address.to_bech32(None).unwrap());
 
 	let own_utxos = client.query_utxos(&[own_address.to_bech32(None)?]).await?;
-	println!("💱 {} UTXOs available", own_utxos.len());
+	log::info!("💱 {} UTXOs available", own_utxos.len());
 	let protocol_parameters = client.query_protocol_parameters().await?;
 
 	let genesis_utxo = match genesis_utxo_id {
 		None => {
-			println!("⚙️ No genesis UTXO provided, will select one automatically...");
+			log::info!("⚙️ No genesis UTXO provided, will select one automatically...");
 			let utxo = own_utxos.first().ok_or(anyhow!("No UTXOs to choose from"))?.clone();
-			println!("☑️ UTXO selected: {}", utxo);
+			log::info!("☑️ UTXO selected: {}", utxo);
 			utxo
 		},
 		Some(utxo_id) => own_utxos
@@ -90,8 +90,7 @@ pub async fn run_init_governance<T: QueryLedgerState + Transactions + QueryNetwo
 		ExUnits::new(&0u64.into(), &0u64.into()),
 	)?;
 
-	println!("📨 Submitting transaction:");
-	println!("{}", unsigned_transaction.to_json()?);
+	log::info!("📨 Submitting transaction..");
 
 	let all_costs = client.evaluate_transaction(&unsigned_transaction.to_bytes()).await?;
 	let cost = get_first_validator_budget(all_costs)?;
@@ -109,7 +108,7 @@ pub async fn run_init_governance<T: QueryLedgerState + Transactions + QueryNetwo
 
 	let result = client.submit_transaction(&signed_transaction.to_bytes()).await?;
 
-	println!("✅ Transaction submited. ID: {}", hex::encode(result.transaction.id));
+	log::info!("✅ Transaction submited. ID: {}", hex::encode(result.transaction.id));
 
 	Ok(result.transaction)
 }

--- a/toolkit/partner-chains-cli/Cargo.toml
+++ b/toolkit/partner-chains-cli/Cargo.toml
@@ -37,6 +37,8 @@ ogmios-client = { workspace = true, features = ["jsonrpsee-client"] }
 tokio = { workspace = true }
 cardano-serialization-lib = { workspace = true }
 partner-chains-cardano-offchain = { workspace = true }
+log = { workspace = true }
+log4rs = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/toolkit/utils/ogmios-client/Cargo.toml
+++ b/toolkit/utils/ogmios-client/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { workspace = true, features = ["raw_value", "arbitrary_precision"]
 thiserror = { workspace = true }
 time = { workspace = true, features = ["std", "serde", "parsing"] }
 sidechain-domain = { workspace = true, features = ["std"] }
+log = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -24,4 +25,4 @@ tokio = { workspace = true }
 
 [features]
 default = ["jsonrpsee-client"]
-jsonrpsee-client = ["jsonrpsee"]
+jsonrpsee-client = ["jsonrpsee", "log"]

--- a/toolkit/utils/ogmios-client/src/jsonrpsee.rs
+++ b/toolkit/utils/ogmios-client/src/jsonrpsee.rs
@@ -1,26 +1,57 @@
 //! OgmiosClient implementation with jsonrpsee.
 //! Major drawback is that it swallows the error response from the server in case of 400 Bad Request.
 
+use std::io::Write;
+
 use crate::{OgmiosClient, OgmiosClientError, OgmiosParams};
-use jsonrpsee::core::params::ArrayParams;
 use jsonrpsee::{
-	core::{client::ClientT, params::ObjectParams},
+	core::client::ClientT,
+	core::params::{ArrayParams, ObjectParams},
 	http_client::HttpClient,
 };
 use serde::de::DeserializeOwned;
 
+const CONTRACTLOG_FILE: &str = "contractlog.json";
+
+macro_rules! contractlog {
+	($($arg:tt)*) => {
+		add_to_contractlog(&format!($($arg)*))
+	};
+}
+
+pub fn add_to_contractlog(msg: &str) {
+	let mut handle = match std::fs::OpenOptions::new()
+		.write(true)
+		.append(true)
+		.create(true)
+		.open(CONTRACTLOG_FILE)
+	{
+		Ok(handle) => handle,
+		Err(err) => {
+			eprintln!("Failed to open contractlog file {CONTRACTLOG_FILE}: {err}");
+			return;
+		},
+	};
+
+	let Ok(_) = handle.write_all(msg.as_bytes()) else {
+		eprintln!("Failed to write contractlog to file {CONTRACTLOG_FILE}");
+		return;
+	};
+}
+
 impl OgmiosClient for HttpClient {
-	async fn request<T: DeserializeOwned>(
+	async fn request<T: DeserializeOwned + std::fmt::Debug>(
 		&self,
 		method: &str,
 		params: OgmiosParams,
 	) -> Result<T, OgmiosClientError> {
-		match params {
+		let response = match params {
 			OgmiosParams::ByName(map) => {
 				let mut object_params = ObjectParams::new();
 				map.into_iter()
 					.try_for_each(|(k, v)| object_params.insert(k, v))
 					.map_err(serde_error_to_parameters_error)?;
+				contractlog!("request: {object_params:?}");
 				Ok(ClientT::request(self, method, object_params).await?)
 			},
 			OgmiosParams::Positional(v) => {
@@ -28,9 +59,14 @@ impl OgmiosClient for HttpClient {
 				v.into_iter()
 					.try_for_each(|v| array_params.insert(v))
 					.map_err(serde_error_to_parameters_error)?;
+				contractlog!("request: {array_params:?}");
 				Ok(ClientT::request(self, method, array_params).await?)
 			},
-		}
+		};
+
+		contractlog!("response: {response:?}");
+
+		response
 	}
 }
 

--- a/toolkit/utils/ogmios-client/src/jsonrpsee.rs
+++ b/toolkit/utils/ogmios-client/src/jsonrpsee.rs
@@ -1,42 +1,12 @@
 //! OgmiosClient implementation with jsonrpsee.
 //! Major drawback is that it swallows the error response from the server in case of 400 Bad Request.
 
-use std::io::Write;
-
 use crate::{OgmiosClient, OgmiosClientError, OgmiosParams};
 use jsonrpsee::{
 	core::{client::ClientT, traits::ToRpcParams, ClientError},
 	http_client::HttpClient,
 };
 use serde::de::DeserializeOwned;
-
-const CONTRACTLOG_FILE: &str = "contractlog.json";
-
-macro_rules! contractlog {
-	($($arg:tt)*) => {
-		add_to_contractlog(&format!("{}\n", format!($($arg)*)))
-	};
-}
-
-pub fn add_to_contractlog(msg: &str) {
-	let mut handle = match std::fs::OpenOptions::new()
-		.write(true)
-		.append(true)
-		.create(true)
-		.open(CONTRACTLOG_FILE)
-	{
-		Ok(handle) => handle,
-		Err(err) => {
-			eprintln!("Failed to open contractlog file {CONTRACTLOG_FILE}: {err}");
-			return;
-		},
-	};
-
-	let Ok(_) = handle.write_all(msg.as_bytes()) else {
-		eprintln!("Failed to write contractlog to file {CONTRACTLOG_FILE}");
-		return;
-	};
-}
 
 fn request_to_json(req: impl ToRpcParams) -> Result<String, OgmiosClientError> {
 	let json_str = match req.to_rpc_params().expect("Parameters are correct") {
@@ -60,10 +30,10 @@ impl OgmiosClient for HttpClient {
 		method: &str,
 		params: OgmiosParams,
 	) -> Result<T, OgmiosClientError> {
-		contractlog!("request: {}", request_to_json(params.clone())?);
+		log::debug!("request: {}", request_to_json(params.clone())?);
 		let response = ClientT::request::<serde_json::Value, _>(self, method, params).await;
 
-		contractlog!("response: {}", response_to_json(&response));
+		log::debug!("response: {}", response_to_json(&response));
 
 		serde_json::from_value(response?)
 			.map_err(|err| OgmiosClientError::ResponseError(err.to_string()))

--- a/toolkit/utils/ogmios-client/src/lib.rs
+++ b/toolkit/utils/ogmios-client/src/lib.rs
@@ -22,7 +22,7 @@ pub enum OgmiosClientError {
 
 pub trait OgmiosClient {
 	#[allow(async_fn_in_trait)]
-	async fn request<T: DeserializeOwned + std::fmt::Debug>(
+	async fn request<T: DeserializeOwned>(
 		&self,
 		method: &str,
 		params: OgmiosParams,

--- a/toolkit/utils/ogmios-client/src/lib.rs
+++ b/toolkit/utils/ogmios-client/src/lib.rs
@@ -22,7 +22,7 @@ pub enum OgmiosClientError {
 
 pub trait OgmiosClient {
 	#[allow(async_fn_in_trait)]
-	async fn request<T: DeserializeOwned>(
+	async fn request<T: DeserializeOwned + std::fmt::Debug>(
 		&self,
 		method: &str,
 		params: OgmiosParams,


### PR DESCRIPTION
# Description

Logs Ogmios requests and responses into `ogmios_client.log` file in HttpClient. There's some hoops to jump through to log json values because we're using jsonrpsee which hides them. I thought about introducing a wrapper type for HttpClient which would make it possible to configure the file to which we log but I'm not convinced it's really needed. 

I went with the simples 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

