### PR TITLE
change: ETCM-8949 use native upsert_d_param in wizard

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* `setup-main-chain-state` command now uses native Rust to insert the D-Parameter
+
 ## Removed
 
 ## Fixed

--- a/toolkit/offchain/src/d_param/mod.rs
+++ b/toolkit/offchain/src/d_param/mod.rs
@@ -24,6 +24,27 @@ use sidechain_domain::{DParameter, McTxHash, UtxoId};
 #[cfg(test)]
 mod tests;
 
+pub trait UpsertDParam {
+	#[allow(async_fn_in_trait)]
+	async fn upsert_d_param(
+		&self,
+		genesis_utxo: UtxoId,
+		d_parameter: &DParameter,
+		payment_signing_key: [u8; 32],
+	) -> anyhow::Result<Option<McTxHash>>;
+}
+
+impl<C: QueryLedgerState + QueryNetwork + Transactions> UpsertDParam for C {
+	async fn upsert_d_param(
+		&self,
+		genesis_utxo: UtxoId,
+		d_parameter: &DParameter,
+		payment_signing_key: [u8; 32],
+	) -> anyhow::Result<Option<McTxHash>> {
+		upsert_d_param(genesis_utxo, d_parameter, payment_signing_key, self).await
+	}
+}
+
 pub async fn upsert_d_param<C: QueryLedgerState + QueryNetwork + Transactions>(
 	genesis_utxo: UtxoId,
 	d_parameter: &DParameter,

--- a/toolkit/partner-chains-cli/src/cardano_key.rs
+++ b/toolkit/partner-chains-cli/src/cardano_key.rs
@@ -1,5 +1,6 @@
 use crate::IOContext;
 use anyhow::anyhow;
+use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -36,4 +37,23 @@ pub(crate) fn get_key_bytes_from_file<const N: usize>(
 			anyhow!("Invalid cbor value of Cardano key - incorrect length: {}", json.cbor_hex)
 		})?;
 	Ok(bytes)
+}
+
+pub(crate) fn get_mc_pkey_from_file(
+	path: &str,
+	context: &impl IOContext,
+) -> anyhow::Result<MainchainPrivateKey> {
+	Ok(MainchainPrivateKey(get_key_bytes_from_file(path, context)?))
+}
+
+pub(crate) fn get_mc_address_hash_from_pkey(pkey: &MainchainPrivateKey) -> MainchainAddressHash {
+	let csl_private_key = cardano_serialization_lib::PrivateKey::from_normal_bytes(&pkey.0)
+		.expect("Conversion is infallible");
+	let csl_public_key_hash = csl_private_key
+		.to_public()
+		.hash()
+		.to_bytes()
+		.try_into()
+		.expect("Bytes represent correct public key hash");
+	MainchainAddressHash(csl_public_key_hash)
 }

--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -2,6 +2,7 @@ use crate::config::ServiceConfig;
 use crate::ogmios::{ogmios_request, OgmiosRequest, OgmiosResponse};
 use anyhow::{anyhow, Context};
 use jsonrpsee::http_client::HttpClient;
+use partner_chains_cardano_offchain::d_param::UpsertDParam;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
 use partner_chains_cardano_offchain::scripts_data::GetScriptsData;
 use sp_core::offchain::Timestamp;
@@ -15,7 +16,7 @@ use tempfile::{TempDir, TempPath};
 
 pub trait IOContext {
 	/// It should implement all the required traits for offchain operations
-	type Offchain: GetScriptsData + InitGovernance;
+	type Offchain: GetScriptsData + InitGovernance + UpsertDParam;
 
 	fn run_command(&self, cmd: &str) -> anyhow::Result<String>;
 	fn print(&self, msg: &str);

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -285,6 +285,16 @@ impl OffchainMock {
 			..self
 		}
 	}
+
+	pub(crate) fn with_upsert_d_param(
+		self,
+		genesis_utxo: UtxoId,
+		d_param: DParameter,
+		payment_key: MainchainPrivateKey,
+		result: Result<Option<McTxHash>, String>,
+	) -> Self {
+		Self { upsert_d_param: [((genesis_utxo, d_param, payment_key.0), result)].into(), ..self }
+	}
 }
 
 impl GetScriptsData for OffchainMock {
@@ -321,7 +331,9 @@ impl UpsertDParam for OffchainMock {
 		self.upsert_d_param
 			.get(&(genesis_utxo, d_parameter.clone(), payment_signing_key))
 			.cloned()
-			.unwrap_or_else(|| Err("No mock for upsert_d_param".into()))
+			.unwrap_or_else(|| {
+				Err(format!("No mock for upsert_d_param({genesis_utxo}, {d_parameter:?}, {payment_signing_key:?})"))
+			})
 			.map_err(|err| anyhow!("{err}"))
 	}
 }

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -1,11 +1,13 @@
 use crate::io::IOContext;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse};
+use anyhow::anyhow;
 use ogmios_client::types::OgmiosTx;
+use partner_chains_cardano_offchain::d_param::UpsertDParam;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
 use partner_chains_cardano_offchain::scripts_data::{GetScriptsData, ScriptsData};
 use partner_chains_cardano_offchain::OffchainError;
 use pretty_assertions::assert_eq;
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey, UtxoId};
+use sidechain_domain::{DParameter, MainchainAddressHash, MainchainPrivateKey, McTxHash, UtxoId};
 use sp_core::offchain::Timestamp;
 use std::collections::HashMap;
 use std::panic::{catch_unwind, resume_unwind, UnwindSafe};
@@ -253,6 +255,7 @@ pub struct OffchainMock {
 		(UtxoId, MainchainAddressHash, MainchainPrivateKey),
 		Result<OgmiosTx, OffchainError>,
 	>,
+	pub upsert_d_param: HashMap<(UtxoId, DParameter, [u8; 32]), Result<Option<McTxHash>, String>>,
 }
 
 impl OffchainMock {
@@ -305,6 +308,21 @@ impl InitGovernance for OffchainMock {
 			.unwrap_or_else(|| {
 				Err(OffchainError::InternalError("No mock for init_governance".into()))
 			})
+	}
+}
+
+impl UpsertDParam for OffchainMock {
+	async fn upsert_d_param(
+		&self,
+		genesis_utxo: UtxoId,
+		d_parameter: &DParameter,
+		payment_signing_key: [u8; 32],
+	) -> anyhow::Result<Option<McTxHash>> {
+		self.upsert_d_param
+			.get(&(genesis_utxo, d_parameter.clone(), payment_signing_key))
+			.cloned()
+			.unwrap_or_else(|| Err("No mock for upsert_d_param".into()))
+			.map_err(|err| anyhow!("{err}"))
 	}
 }
 

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -616,7 +616,7 @@ impl GrandpaPublicKey {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Decode, Encode, MaxEncodedLen, TypeInfo, Eq)]
+#[derive(Debug, Clone, PartialEq, Decode, Encode, MaxEncodedLen, TypeInfo, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct DParameter {
 	pub num_permissioned_candidates: u16,

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -623,6 +623,12 @@ pub struct DParameter {
 	pub num_registered_candidates: u16,
 }
 
+impl DParameter {
+	pub fn new(num_permissioned_candidates: u16, num_registered_candidates: u16) -> Self {
+		Self { num_permissioned_candidates, num_registered_candidates }
+	}
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Decode, Encode, TypeInfo, PartialOrd, Ord)]
 pub struct PermissionedCandidateData {
 	pub sidechain_public_key: SidechainPublicKey,


### PR DESCRIPTION
# Description

Uses the native Rust offchain implementation to update D-Param in the `setup-main-chain-state` command in wizard.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

