### PR TITLE
fix: Change upgrade_and_set_addresses dispatch class to Operational

### DIFF
--- a/pallets/sidechain/src/lib.rs
+++ b/pallets/sidechain/src/lib.rs
@@ -113,7 +113,7 @@ pub mod pallet {
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		#[pallet::call_index(1)]
-		#[pallet::weight((0, DispatchClass::Normal))]
+		#[pallet::weight((0, DispatchClass::Operational))]
 		pub fn upgrade_and_set_addresses(
 			origin: OriginFor<T>,
 			code: sp_std::vec::Vec<u8>,


### PR DESCRIPTION
# Description

Normal dispatch class is affected by block weight limits. `upgrade_and_set_addresses` by necessity consumes all remaining weight of the block (this behaviour comes form `set_code`), which on my local chain caused it to never be included in a block. Changing the dispatch class to operational removes this issue. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

