### PR TITLE
ETCM-8754: fix register command

### DIFF
--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -76,7 +76,6 @@ async fn upsert_d_param() {
 	assert!(run_upsert_d_param(genesis_utxo, 1, 1, &client).await.is_some())
 }
 
-#[ignore = "Internal error: cannot use evaluateTransaction response"]
 #[tokio::test]
 async fn register() {
 	let _ = env_logger::builder().is_test(true).try_init();

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -635,6 +635,16 @@ pub struct CandidateRegistration {
 	pub grandpa_pub_key: GrandpaPublicKey,
 }
 
+impl CandidateRegistration {
+	pub fn matches_keys(&self, other: &Self) -> bool {
+		self.stake_ownership == other.stake_ownership
+			&& self.partnerchain_pub_key == other.partnerchain_pub_key
+			&& self.partnerchain_signature == other.partnerchain_signature
+			&& self.aura_pub_key == other.aura_pub_key
+			&& self.grandpa_pub_key == other.grandpa_pub_key
+	}
+}
+
 /// AdaBasedStaking is a variant of Plutus type StakeOwnership.
 /// The other variant, TokenBasedStaking, is not supported
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
# Description

Register had two issues:
* it always tried to calculate exunits, even when there was no need (thanks Lech)
* it was comparing the entire registration datum when checking for existing registrations, even though the registration utxo can differ for registering the same keys

This PR fixes these issues and enables the integration test for the register command.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

