### PR TITLE
fix: parse keys with 0x prefix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6725,6 +6725,7 @@ dependencies = [
  "clap",
  "env_logger 0.11.3",
  "hex",
+ "hex-literal",
  "jsonrpsee",
  "partner-chains-cardano-offchain",
  "serde",

--- a/toolkit/cli/smart-contracts-commands/Cargo.toml
+++ b/toolkit/cli/smart-contracts-commands/Cargo.toml
@@ -15,3 +15,6 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 cardano-serialization-lib = { workspace = true }
+
+[dev-dependencies]
+hex-literal = { workspace = true }

--- a/toolkit/cli/smart-contracts-commands/src/lib.rs
+++ b/toolkit/cli/smart-contracts-commands/src/lib.rs
@@ -62,6 +62,7 @@ pub(crate) fn read_private_key_from_file(path: &str) -> CmdResult<MainchainPriva
 pub(crate) fn parse_partnerchain_public_keys(
 	partner_chain_public_keys: &str,
 ) -> CmdResult<PermissionedCandidateData> {
+	let partner_chain_public_keys = partner_chain_public_keys.replace("0x", "");
 	if let [sidechain_pub_key, aura_pub_key, grandpa_pub_key] =
 		partner_chain_public_keys.split(":").collect::<Vec<_>>()[..]
 	{
@@ -85,4 +86,39 @@ fn payment_signing_key_to_mainchain_address_hash(
 		.as_slice()
 		.try_into()
 		.map(MainchainAddressHash)?)
+}
+
+#[cfg(test)]
+mod test {
+	use crate::parse_partnerchain_public_keys;
+	use hex_literal::hex;
+	use sidechain_domain::{
+		AuraPublicKey, GrandpaPublicKey, PermissionedCandidateData, SidechainPublicKey,
+	};
+
+	#[test]
+	fn parse_partnerchain_public_keys_with_0x_prefix() {
+		let input = "039799ff93d184146deacaa455dade51b13ed16f23cdad11d1ad6af20103391180:e85534c93315d60f808568d1dce5cb9e8ba6ed0b204209c5cc8f3bec56c10b73:cdf3e5b33f53c8b541bbaea383225c45654f24de38c585725f3cff25b2802f55";
+		assert_eq!(parse_partnerchain_public_keys(input).unwrap(), expected_public_keys())
+	}
+
+	#[test]
+	fn parse_partnerchain_public_keys_without_0x_prefix() {
+		let input = "0x039799ff93d184146deacaa455dade51b13ed16f23cdad11d1ad6af20103391180:0xe85534c93315d60f808568d1dce5cb9e8ba6ed0b204209c5cc8f3bec56c10b73:0xcdf3e5b33f53c8b541bbaea383225c45654f24de38c585725f3cff25b2802f55";
+		assert_eq!(parse_partnerchain_public_keys(input).unwrap(), expected_public_keys())
+	}
+
+	fn expected_public_keys() -> PermissionedCandidateData {
+		PermissionedCandidateData {
+			sidechain_public_key: SidechainPublicKey(
+				hex!("039799ff93d184146deacaa455dade51b13ed16f23cdad11d1ad6af20103391180").to_vec(),
+			),
+			aura_public_key: AuraPublicKey(
+				hex!("e85534c93315d60f808568d1dce5cb9e8ba6ed0b204209c5cc8f3bec56c10b73").to_vec(),
+			),
+			grandpa_public_key: GrandpaPublicKey(
+				hex!("cdf3e5b33f53c8b541bbaea383225c45654f24de38c585725f3cff25b2802f55").to_vec(),
+			),
+		}
+	}
 }


### PR DESCRIPTION
# Description

Our registration-signatures command outputs:
```
{"spo_public_key":"0x08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e","spo_signature":"0x040a8b9f336986fe5cea10a3bfcd6fb4f84dceda8e00ca23eee6e28af0605fb86fd96b41746df159b318b5075e067ce30e67d2bf5fef3e21f01a48325e375a06","sidechain_public_key":"0x039799ff93d184146deacaa455dade51b13ed16f23cdad11d1ad6af20103391180","sidechain_signature":"0xf0905c8d5a4db6075f76f6628282b3e257ffa1184ba2e35cd34415968d360d7452c981d171b4f22489690994a46026c1c1801df3e83f1038d4f20bb8affdfbcd"}
```
, so it is not nice to not accept 0x prefix at input.
With this modification such command is accepted:
```
target/debug/partner-chains-node smart-contracts register --genesis-utxo c389187c6cabf1cd2ca64cf8c76bf57288eb9c02ced6781935b810a1d0e7fbb4#0 --registration-utxo c389187c6cabf1cd2ca64cf8c76bf57288eb9c02ced6781935b810a1d0e7fbb4#2 \
--spo-public-key 0x08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e \
--spo-signature 0x08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e \
--partnerchain-signature 0x08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e08accadc8b60a5f519ee74ab144ada6993709f5479152f9217688889d8a2db2e \
--partnerchain-public-keys 0x039799ff93d184146deacaa455dade51b13ed16f23cdad11d1ad6af20103391180:0xe85534c93315d60f808568d1dce5cb9e8ba6ed0b204209c5cc8f3bec56c10b73:0xcdf3e5b33f53c8b541bbaea383225c45654f24de38c585725f3cff25b2802f55 --payment-key-file dev/local-environment/configurations/partner-chains-nodes/partner-chains-node-4/keys/payment.skey
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

