### PR TITLE
TEMPORARY: remove native token cofniguration for staging

### DIFF
--- a/node/src/staging.rs
+++ b/node/src/staging.rs
@@ -149,7 +149,7 @@ pub fn staging_genesis(
 			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()?,
+			main_chain_scripts: None,
 			..Default::default()
 		},
 	};

--- a/node/src/template_chain_spec.rs
+++ b/node/src/template_chain_spec.rs
@@ -39,7 +39,7 @@ pub fn chain_spec() -> Result<ChainSpec, envy::Error> {
 			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()?,
+			main_chain_scripts: Some(sp_native_token_management::MainChainScripts::read_from_env()?),
 			..Default::default()
 		},
 	};

--- a/node/src/testnet.rs
+++ b/node/src/testnet.rs
@@ -201,7 +201,7 @@ pub fn testnet_genesis(
 			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},
 		native_token_management: NativeTokenManagementConfig {
-			main_chain_scripts: sp_native_token_management::MainChainScripts::read_from_env()?,
+			main_chain_scripts: Some(sp_native_token_management::MainChainScripts::read_from_env()?),
 			..Default::default()
 		},
 	};

--- a/pallets/native-token-management/src/lib.rs
+++ b/pallets/native-token-management/src/lib.rs
@@ -66,14 +66,16 @@ pub mod pallet {
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]
 	pub struct GenesisConfig<T: Config> {
-		pub main_chain_scripts: sp_native_token_management::MainChainScripts,
+		pub main_chain_scripts: Option<sp_native_token_management::MainChainScripts>,
 		pub _marker: PhantomData<T>,
 	}
 
 	#[pallet::genesis_build]
 	impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
 		fn build(&self) {
-			MainChainScriptsConfiguration::<T>::put(self.main_chain_scripts.clone());
+			if let Some(main_chain_scripts) = self.main_chain_scripts.clone() {
+				MainChainScriptsConfiguration::<T>::put(main_chain_scripts);
+			}
 		}
 	}
 


### PR DESCRIPTION
# Description

This PR removes the native token configuration form the staging chain spec so the observability stays inert at the beginning. This is a temporary change for testing purposes.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

