### PR TITLE
feat: implement 'reserve init' command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* Added node command `smart-contracts reserve init`
 * `setup-main-chain-state` command now uses native Rust to upsert the D-Parameter and upsert permissioned candidates
 
 ## Removed

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -1,0 +1,45 @@
+use jsonrpsee::http_client::HttpClient;
+use partner_chains_cardano_offchain::{
+	await_tx::FixedDelayRetries, reserve::init::init_reserve_management,
+};
+use sidechain_domain::UtxoId;
+
+#[derive(Clone, Debug, clap::Subcommand)]
+#[allow(clippy::large_enum_variant)]
+pub enum ReserveCmd {
+	/// Initialize the reserve management system for your chain
+	Init(InitReserveCmd),
+}
+
+impl ReserveCmd {
+	pub async fn execute(self) -> crate::CmdResult<()> {
+		match self {
+			Self::Init(cmd) => cmd.execute().await,
+		}
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct InitReserveCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long, short('k'))]
+	payment_key_file: String,
+	#[arg(long, short('c'))]
+	genesis_utxo: UtxoId,
+}
+
+impl InitReserveCmd {
+	pub async fn execute(self) -> crate::CmdResult<()> {
+		let payment_key = crate::read_private_key_from_file(&self.payment_key_file)?;
+		let ogmios_client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
+		let _ = init_reserve_management(
+			self.genesis_utxo,
+			payment_key.0,
+			&ogmios_client,
+			&FixedDelayRetries::two_minutes(),
+		)
+		.await?;
+		Ok(())
+	}
+}


### PR DESCRIPTION
# Description

* Added subcommand `reserve` and its command `init`.
```
./partner-chains-node smart-contracts reserve init --help
Initialize the reserve management system for your chain

Usage: partner-chains-node smart-contracts reserve init [OPTIONS] --payment-key-file <PAYMENT_KEY_FILE> --genesis-utxo <GENESIS_UTXO>
```

Logs from invocation:
```
./partner-chains-node smart-contracts reserve init -k payment.skey -c c389187c6cabf1cd2ca64cf8c76bf57288eb9c02ced6781935b810a1d0e7fbb4#1
2024-12-31T08:03:13.116031291+01:00 INFO partner_chains_cardano_offchain::reserve::init - Initialized Versioned 'Reserve Management Validator' transaction submitted: cec190d8187ade25c749819b8b330cbad79866d0cdb2759c7ca3eb009e4852bd
2024-12-31T08:03:13.116057881+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output 'cec190d8187ade25c749819b8b330cbad79866d0cdb2759c7ca3eb009e4852bd#0'
2024-12-31T08:03:18.122911078+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output 'cec190d8187ade25c749819b8b330cbad79866d0cdb2759c7ca3eb009e4852bd#0'
2024-12-31T08:03:18.133285480+01:00 INFO partner_chains_cardano_offchain::await_tx - Transaction output 'cec190d8187ade25c749819b8b330cbad79866d0cdb2759c7ca3eb009e4852bd'
2024-12-31T08:03:18.431779493+01:00 INFO partner_chains_cardano_offchain::reserve::init - Initialized Versioned 'Reserve Management Policy' transaction submitted: 720c8c2e2bc23dbb163b1a42b89310ace61b8a58f49ad5e2f3e29ff59c411afc
2024-12-31T08:03:18.431807015+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output '720c8c2e2bc23dbb163b1a42b89310ace61b8a58f49ad5e2f3e29ff59c411afc#0'
2024-12-31T08:03:23.438609907+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output '720c8c2e2bc23dbb163b1a42b89310ace61b8a58f49ad5e2f3e29ff59c411afc#0'
2024-12-31T08:03:23.447134655+01:00 INFO partner_chains_cardano_offchain::await_tx - Transaction output '720c8c2e2bc23dbb163b1a42b89310ace61b8a58f49ad5e2f3e29ff59c411afc'
2024-12-31T08:03:23.715017926+01:00 INFO partner_chains_cardano_offchain::reserve::init - Initialized Versioned 'Illiquid Circulation Validator' transaction submitted: f6152f689ecbe724b7b4b224a859953af7ff6e972940e1c4164aacd385ac9ccc
2024-12-31T08:03:23.715056829+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output 'f6152f689ecbe724b7b4b224a859953af7ff6e972940e1c4164aacd385ac9ccc#0'
2024-12-31T08:03:28.722210520+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output 'f6152f689ecbe724b7b4b224a859953af7ff6e972940e1c4164aacd385ac9ccc#0'
2024-12-31T08:03:28.730769884+01:00 INFO partner_chains_cardano_offchain::await_tx - Transaction output 'f6152f689ecbe724b7b4b224a859953af7ff6e972940e1c4164aacd385ac9ccc'
```

* Improved an error message for payment key reading errors, example:
before:
```
Error: Application(Os { code: 2, kind: NotFound, message: "No such file or directory" })
```
after:
```
Error: Application("Could not read private key file. Reason: No such file or directory (os error 2)")
```
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

