### PR TITLE
Reserve create CLI command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,7 +6,6 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
-* Added node command `smart-contracts reserve init`
 * `setup-main-chain-state` command now uses native Rust to upsert the D-Parameter and upsert permissioned candidates
 
 ## Removed
@@ -20,6 +19,9 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * Renamed of argument 'ogmios-host' to 'ogmios-url' in smart-contracts subcommands.
 
 ## Added
+
+* Command `smart-contracts reserve init`
+* Command `smart-contracts reserve create`
 
 # v1.4.0
 

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -1,20 +1,26 @@
 use jsonrpsee::http_client::HttpClient;
 use partner_chains_cardano_offchain::{
-	await_tx::FixedDelayRetries, reserve::init::init_reserve_management,
+	await_tx::FixedDelayRetries,
+	reserve::{
+		create::{create_reserve_utxo, ReserveParameters},
+		init::init_reserve_management,
+	},
 };
-use sidechain_domain::UtxoId;
+use sidechain_domain::{ScriptHash, TokenId, UtxoId};
 
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum ReserveCmd {
 	/// Initialize the reserve management system for your chain
 	Init(InitReserveCmd),
+	Create(CreateReserveCmd),
 }
 
 impl ReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		match self {
 			Self::Init(cmd) => cmd.execute().await,
+			Self::Create(cmd) => cmd.execute().await,
 		}
 	}
 }
@@ -23,8 +29,10 @@ impl ReserveCmd {
 pub struct InitReserveCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+	/// Path to the Cardano Payment Key file.
 	#[arg(long, short('k'))]
 	payment_key_file: String,
+	/// Genesis UTXO of the partner-chain.
 	#[arg(long, short('c'))]
 	genesis_utxo: UtxoId,
 }
@@ -34,6 +42,55 @@ impl InitReserveCmd {
 		let payment_key = crate::read_private_key_from_file(&self.payment_key_file)?;
 		let ogmios_client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 		let _ = init_reserve_management(
+			self.genesis_utxo,
+			payment_key.0,
+			&ogmios_client,
+			&FixedDelayRetries::two_minutes(),
+		)
+		.await?;
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct CreateReserveCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	/// Path to the Cardano Payment Key file.
+	#[arg(long, short('k'))]
+	payment_key_file: String,
+	/// Genesis UTXO of the partner-chain.
+	#[arg(long, short('c'))]
+	genesis_utxo: UtxoId,
+	/// t0, POSIX time used for calculating how many tokens could be released from the reserve at given moment.
+	#[arg(long)]
+	t0: u64,
+	/// Script hash of the 'total accrued function', also called V-function, that computes how many tokens could be released from the reserve at given moment.
+	#[arg(long)]
+	total_accrued_function_script_hash: ScriptHash,
+	/// Incentive amount of tokens.
+	#[arg(long, default_value = "0")]
+	initial_incentive_amount: u64,
+	/// Initial amount of tokens to deposit. They must be present in the payment wallet.
+	#[arg(long)]
+	initial_deposit_amount: u64,
+	/// Use either "Ada" or encoded asset id in form <policy_id_hex>.<asset_name_hex>.
+	#[arg(long)]
+	token: TokenId,
+}
+
+impl CreateReserveCmd {
+	pub async fn execute(self) -> crate::CmdResult<()> {
+		let payment_key = crate::read_private_key_from_file(&self.payment_key_file)?;
+		let ogmios_client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
+		let _ = create_reserve_utxo(
+			ReserveParameters {
+				initial_incentive: self.initial_incentive_amount,
+				total_accrued_function_script_hash: self.total_accrued_function_script_hash,
+				t0: self.t0,
+				token: self.token,
+				initial_deposit: self.initial_deposit_amount,
+			},
 			self.genesis_utxo,
 			payment_key.0,
 			&ogmios_client,

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -51,7 +51,7 @@ pub async fn create_reserve_utxo<
 	payment_key: [u8; 32],
 	client: &T,
 	await_tx: &A,
-) -> anyhow::Result<Option<McTxHash>> {
+) -> anyhow::Result<McTxHash> {
 	let ctx = TransactionContext::for_payment_key(payment_key, client).await?;
 	let governance = get_governance_data(genesis_utxo, client).await?;
 	let reserve = get_reserve_data(genesis_utxo, &ctx, client).await?;
@@ -92,7 +92,7 @@ pub async fn create_reserve_utxo<
 	let tx_id = res.transaction.id;
 	log::info!("Create Reserve transaction submitted: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
-	Ok(Some(McTxHash(tx_id)))
+	Ok(McTxHash(tx_id))
 }
 
 pub struct ReserveParameters {


### PR DESCRIPTION
# Description

Adds `reserve create` command to CLI.

Example:
```
./partner-chains-node smart-contracts reserve create \
  -c 61ca664e056ce49a9d4fd2fb3aa2b750ea753fe4ad5c9e6167482fd88394cf7d#0 \
  --token 1fab25f376bc49a181d03a869ee8eaa3157a3a3d242a619ca7995b2b.52657761726420746f6b656e \
  --t0 1735689600 \
  --total-accrued-function-script-hash c389187c6cabf1cd2ca64cf8c76bf57288eb9c02ced6781935b810a1 \
  --initial-deposit-amount 500000 \
  --initial-incentive-amount 1000 \
  -k funded_address.skey
2025-01-07T16:52:26.624180624+01:00 INFO partner_chains_cardano_offchain::reserve::create - Create Reserve transaction submitted: 04d2bdd2b9caeca2f80c4b7a459f518f14dc13ed01c265d47ab5c9f725368806
2025-01-07T16:52:26.624199549+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output '04d2bdd2b9caeca2f80c4b7a459f518f14dc13ed01c265d47ab5c9f725368806#0'
2025-01-07T16:52:31.629342490+01:00 INFO partner_chains_cardano_offchain::await_tx - Probing for transaction output '04d2bdd2b9caeca2f80c4b7a459f518f14dc13ed01c265d47ab5c9f725368806#0'
2025-01-07T16:52:31.635183731+01:00 INFO partner_chains_cardano_offchain::await_tx - Transaction output '04d2bdd2b9caeca2f80c4b7a459f518f14dc13ed01c265d47ab5c9f725368806'
```
, the token can also be:
```
--token ada
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

