### PR TITLE
feat: improve handling of payment key argument and add documentation for some other fields

### DIFF
--- a/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
+++ b/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
@@ -1,9 +1,8 @@
+use crate::PaymentFilePath;
 use jsonrpsee::http_client::HttpClient;
 use partner_chains_cardano_offchain::d_param::upsert_d_param;
 use sidechain_domain::DParameter;
 use sidechain_domain::UtxoId;
-
-use crate::read_private_key_from_file;
 
 #[derive(Clone, Debug, clap::Parser)]
 pub struct UpsertDParameterCmd {
@@ -13,15 +12,15 @@ pub struct UpsertDParameterCmd {
 	permissioned_candidates_count: u16,
 	#[arg(long)]
 	registered_candidates_count: u16,
-	#[arg(long, short('k'))]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	#[arg(long, short('c'))]
 	genesis_utxo: UtxoId,
 }
 
 impl UpsertDParameterCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let d_param = DParameter {
 			num_permissioned_candidates: self.permissioned_candidates_count,
 			num_registered_candidates: self.registered_candidates_count,

--- a/toolkit/cli/smart-contracts-commands/src/governance.rs
+++ b/toolkit/cli/smart-contracts-commands/src/governance.rs
@@ -1,4 +1,4 @@
-use crate::read_private_key_from_file;
+use crate::PaymentFilePath;
 use jsonrpsee::http_client::HttpClient;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries, init_governance::run_init_governance,
@@ -31,9 +31,8 @@ pub struct InitGovernanceCmd {
 	/// Governance authority hash to be set.
 	#[arg(long, short = 'g')]
 	governance_authority: MainchainAddressHash,
-	/// Path to the Cardano Payment Key file.
-	#[arg(long, short = 'k')]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the new chain, it will be spent durning initialization. If not set, then one will be selected from UTXOs of the payment key.
 	#[arg(long, short = 'c')]
 	genesis_utxo: Option<UtxoId>,
@@ -41,7 +40,7 @@ pub struct InitGovernanceCmd {
 
 impl InitGovernanceCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 
 		run_init_governance(
@@ -63,9 +62,8 @@ pub struct UpdateGovernanceCmd {
 	/// Governance authority hash to be set.
 	#[arg(long, short = 'g')]
 	new_governance_authority: MainchainAddressHash,
-	/// Path to the Cardano Payment Key file.
-	#[arg(long, short = 'k')]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the chain
 	#[arg(long, short = 'c')]
 	genesis_utxo: UtxoId,
@@ -73,7 +71,7 @@ pub struct UpdateGovernanceCmd {
 
 impl UpdateGovernanceCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 
 		run_update_governance(

--- a/toolkit/cli/smart-contracts-commands/src/register.rs
+++ b/toolkit/cli/smart-contracts-commands/src/register.rs
@@ -1,4 +1,4 @@
-use crate::{parse_partnerchain_public_keys, read_private_key_from_file};
+use crate::{parse_partnerchain_public_keys, PaymentFilePath};
 use jsonrpsee::http_client::HttpClient;
 use partner_chains_cardano_offchain::csl::MainchainPrivateKeyExt;
 use partner_chains_cardano_offchain::{
@@ -14,30 +14,36 @@ use sidechain_domain::{
 pub struct RegisterCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+	/// Genesis UTXO of the partner-chain
 	#[arg(long)]
 	genesis_utxo: UtxoId,
+	/// UTXO that will be spend when executing registration transaction, part of the registration message
 	#[arg(long)]
 	registration_utxo: UtxoId,
-	#[arg(long)]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	#[arg(
 		long,
 		value_name = "PARTNERCHAIN_KEY:AURA_KEY:GRANDPA_KEY",
 		alias = "sidechain-public-keys",
 		value_parser = parse_partnerchain_public_keys
 	)]
+	/// Colon separated hex strings representing bytes of the Sidechain, Aura and Grandpa public keys
 	partner_chain_public_keys: PermissionedCandidateData,
+	/// Hex string of bytes of the registration message signature by partner-chain key, obtained by 'registration-signatures' command
 	#[arg(long, alias = "sidechain-signature")]
 	partner_chain_signature: SidechainSignature,
+	/// Hex string representing bytes of the Stake Pool Verification Key
 	#[arg(long)]
 	spo_public_key: MainchainPublicKey,
+	/// Hex string of bytes of the registration message signature by main chain key, obtained by 'registration-signatures' command
 	#[arg(long)]
 	spo_signature: MainchainSignature,
 }
 
 impl RegisterCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 		let candidate_registration = CandidateRegistration {
 			stake_ownership: AdaBasedStaking {
@@ -69,17 +75,19 @@ impl RegisterCmd {
 pub struct DeregisterCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+	/// Genesis UTXO of the partner-chain
 	#[arg(long)]
 	genesis_utxo: UtxoId,
-	#[arg(long)]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
+	/// Hex string representing bytes of the Stake Pool Verification Key
 	#[arg(long)]
 	spo_public_key: MainchainPublicKey,
 }
 
 impl DeregisterCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_signing_key = read_private_key_from_file(&self.payment_key_file)?;
+		let payment_signing_key = self.payment_key_file.read_key()?;
 		let client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 
 		run_deregister(

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -1,3 +1,4 @@
+use crate::PaymentFilePath;
 use jsonrpsee::http_client::HttpClient;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
@@ -29,9 +30,8 @@ impl ReserveCmd {
 pub struct InitReserveCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	/// Path to the Cardano Payment Key file.
-	#[arg(long, short('k'))]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the partner-chain.
 	#[arg(long, short('c'))]
 	genesis_utxo: UtxoId,
@@ -39,7 +39,7 @@ pub struct InitReserveCmd {
 
 impl InitReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = crate::read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let ogmios_client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 		let _ = init_reserve_management(
 			self.genesis_utxo,
@@ -56,9 +56,8 @@ impl InitReserveCmd {
 pub struct CreateReserveCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	/// Path to the Cardano Payment Key file.
-	#[arg(long, short('k'))]
-	payment_key_file: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the partner-chain.
 	#[arg(long, short('c'))]
 	genesis_utxo: UtxoId,
@@ -81,7 +80,7 @@ pub struct CreateReserveCmd {
 
 impl CreateReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let payment_key = crate::read_private_key_from_file(&self.payment_key_file)?;
+		let payment_key = self.payment_key_file.read_key()?;
 		let ogmios_client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 		let _ = create_reserve_utxo(
 			ReserveParameters {


### PR DESCRIPTION
# Description

1.
```
./partner-chains-node smart-contracts init-governance -c 61ca664e056ce49a9d4fd2fb3aa2b750ea753fe4ad5c9e6167482fd88394cf7d#0 -k payment.vkey -g e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b
Error: Application("Could not read private key file. Reason: Unsupported key type: PaymentVerificationKeyShelley_ed25519. Expected a signing key")
```
Instead of failing transaction because of missing funds when verification key is used in place of signing key.

2. Added help messages to params in `register` and `deregister`:
```
./target/debug/partner-chains-node smart-contracts register --help
Register candidate

Usage: partner-chains-node smart-contracts register [OPTIONS] --genesis-utxo <GENESIS_UTXO> --registration-utxo <REGISTRATION_UTXO> --payment-key-file <PAYMENT_KEY_FILE> --partner-chain-public-keys <PARTNERCHAIN_KEY:AURA_KEY:GRANDPA_KEY> --partner-chain-signature <PARTNER_CHAIN_SIGNATURE> --spo-public-key <SPO_PUBLIC_KEY> --spo-signature <SPO_SIGNATURE>

Options:
  -O, --ogmios-url <OGMIOS_URL>                                            [default: http://localhost:1337]
      --genesis-utxo <GENESIS_UTXO>                                        Genesis UTXO of the partner-chain
      --registration-utxo <REGISTRATION_UTXO>                              UTXO that will be spend when executing registration transaction, part of the registration message
  -k, --payment-key-file <PAYMENT_KEY_FILE>                                Path to the Cardano Signing Key file used sign transaction(s) and pay for them
      --partner-chain-public-keys <PARTNERCHAIN_KEY:AURA_KEY:GRANDPA_KEY>  Colon separated hex strings representing bytes of the Sidechain, Aura and Grandpa public keys
      --partner-chain-signature <PARTNER_CHAIN_SIGNATURE>                  Hex string of bytes of the registration message signature by partner-chain key, obtained by 'registration-signatures' command
      --spo-public-key <SPO_PUBLIC_KEY>                                    Hex string representing bytes of the Stake Pool Verification Key
      --spo-signature <SPO_SIGNATURE>                                      Hex string of bytes of the registration message signature by main chain key, obtained by 'registration-signatures' command
  -h, --help                                                               Print help
  -V, --version                                                            Print version
  ```


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

