### PR TITLE
fix: await upsert-d-parameter and upsert-permissioned-candidates transaction outputs being present

### DIFF
--- a/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
+++ b/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
@@ -1,5 +1,6 @@
 use crate::PaymentFilePath;
 use jsonrpsee::http_client::HttpClient;
+use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::d_param::upsert_d_param;
 use sidechain_domain::DParameter;
 use sidechain_domain::UtxoId;
@@ -27,7 +28,14 @@ impl UpsertDParameterCmd {
 		};
 		let client = HttpClient::builder().build(self.common_arguments.ogmios_url)?;
 
-		upsert_d_param(self.genesis_utxo, &d_param, payment_key.0, &client).await?;
+		upsert_d_param(
+			self.genesis_utxo,
+			&d_param,
+			payment_key.0,
+			&client,
+			&FixedDelayRetries::two_minutes(),
+		)
+		.await?;
 
 		Ok(())
 	}

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -223,6 +223,7 @@ async fn run_upsert_d_param<
 		&DParameter { num_permissioned_candidates, num_registered_candidates },
 		pkey.0,
 		client,
+		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
 	.await
 	.unwrap();
@@ -253,6 +254,7 @@ async fn run_upsert_permissioned_candidates<
 		&candidates,
 		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
 		client,
+		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
 	.await
 	.unwrap();


### PR DESCRIPTION
# Description

Not awaiting for the output being present made it possible that the following transactions fail, because they query wallet before previous transaction being observable but try to submit it after. Happened during testing wizards.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
