### PR TITLE
add: ETCM-9061 reserve release command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Added
 
-* Command `smart-contracts reserve init`, `create`, `deposit`, `handover` and `update-settings`
+* Command `smart-contracts reserve init`, `create`, `deposit`, `release`, `handover` and `update-settings`
 * Command `smart-contracts governance update`
 * Ogmios client backed by jsonrpsee `WsClient`
 

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -208,7 +208,7 @@ pub struct ReleaseReserveCmd {
 	/// Reference UTXO containing the V-Function script
 	#[arg(long, short('r'))]
 	reference_utxo: UtxoId,
-	/// Use either "Ada" or encoded asset id in form <policy_id_hex>.<asset_name_hex>.
+	/// Encoded asset id in form <policy_id_hex>.<asset_name_hex>.
 	#[arg(long)]
 	token: AssetId,
 	/// Current value of the V-Function. This is the cumulative number of tokens to be released.

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -211,7 +211,7 @@ pub struct ReleaseReserveCmd {
 	/// Encoded asset id in form <policy_id_hex>.<asset_name_hex>.
 	#[arg(long)]
 	token: AssetId,
-	/// Current value of the V-Function. This is the cumulative number of tokens to be released.
+	/// Current value of the V-Function
 	#[arg(long)]
 	amount: u64,
 }

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -7,6 +7,7 @@ use partner_chains_cardano_offchain::{
 		deposit::deposit_to_reserve,
 		handover::handover_reserve,
 		init::init_reserve_management,
+		release::release_reserve_funds,
 		update_settings::update_reserve_settings,
 		TokenAmount,
 	},
@@ -23,6 +24,8 @@ pub enum ReserveCmd {
 	/// Update reserve management system settings for your chain
 	UpdateSettings(UpdateReserveSettingsCmd),
 	Handover(HandoverReserveCmd),
+	/// Releases funds from the reserve to the illiquid supply
+	Release(ReleaseReserveCmd),
 }
 
 impl ReserveCmd {
@@ -33,6 +36,7 @@ impl ReserveCmd {
 			Self::Deposit(cmd) => cmd.execute().await,
 			Self::UpdateSettings(cmd) => cmd.execute().await,
 			Self::Handover(cmd) => cmd.execute().await,
+			Self::Release(cmd) => cmd.execute().await,
 		}
 	}
 }
@@ -183,6 +187,43 @@ impl HandoverReserveCmd {
 		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
 		let _ = handover_reserve(
 			self.genesis_utxo,
+			payment_key.0,
+			&ogmios_client,
+			&FixedDelayRetries::two_minutes(),
+		)
+		.await?;
+		Ok(())
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct ReleaseReserveCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
+	/// Genesis UTXO of the partner-chain.
+	#[arg(long, short('c'))]
+	genesis_utxo: UtxoId,
+	/// Reference UTXO containing the V-Function script
+	#[arg(long, short('r'))]
+	reference_utxo: UtxoId,
+	/// Use either "Ada" or encoded asset id in form <policy_id_hex>.<asset_name_hex>.
+	#[arg(long)]
+	token: AssetId,
+	/// Current value of the V-Function. This is the cumulative number of tokens to be released.
+	#[arg(long)]
+	amount: u64,
+}
+
+impl ReleaseReserveCmd {
+	pub async fn execute(self) -> crate::CmdResult<()> {
+		let payment_key = self.payment_key_file.read_key()?;
+		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let _ = release_reserve_funds(
+			TokenAmount { token: self.token, amount: self.amount },
+			self.genesis_utxo,
+			self.reference_utxo,
 			payment_key.0,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),

--- a/toolkit/offchain/src/ogmios_mock.rs
+++ b/toolkit/offchain/src/ogmios_mock.rs
@@ -1,8 +1,11 @@
 use ogmios_client::{
-	query_ledger_state::{ProtocolParametersResponse, QueryLedgerState, QueryUtxoByUtxoId},
+	query_ledger_state::{
+		OgmiosTip, ProtocolParametersResponse, QueryLedgerState, QueryUtxoByUtxoId,
+	},
 	query_network::{QueryNetwork, ShelleyGenesisConfigurationResponse},
 	transactions::{OgmiosEvaluateTransactionResponse, SubmitTransactionResponse, Transactions},
 	types::OgmiosUtxo,
+	OgmiosClientError,
 };
 
 #[derive(Clone, Default, Debug)]
@@ -76,6 +79,10 @@ impl Transactions for MockOgmiosClient {
 }
 
 impl QueryLedgerState for MockOgmiosClient {
+	async fn get_tip(&self) -> Result<OgmiosTip, OgmiosClientError> {
+		unimplemented!()
+	}
+
 	async fn era_summaries(
 		&self,
 	) -> Result<Vec<ogmios_client::query_ledger_state::EraSummary>, ogmios_client::OgmiosClientError>

--- a/toolkit/offchain/src/reserve/mod.rs
+++ b/toolkit/offchain/src/reserve/mod.rs
@@ -18,6 +18,7 @@ pub mod create;
 pub mod deposit;
 pub mod handover;
 pub mod init;
+pub mod release;
 pub mod update_settings;
 
 #[derive(Clone, Debug)]

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -1,0 +1,497 @@
+//! This transaction releases some funds to the illiquid supply.
+//! Inputs:
+//!     - previous utxo at the *reserve validator*, containing the reserve tokens and the
+//!       [ReserveData] plutus data with reserve configuration and release stats
+//! Reference inputs:
+//!     - utxo with V-Function reference script matching the hash saved in the input [ReserveData].
+//!       IMPORTANT: The V-Function returns the total number of tokens that should have been
+//!                  released up to now. The number of tokens released in a single transaction
+//!                  equals <curent v-function value> - <number of previously released tokens>
+//!     - utxo with authentication policy reference script
+//!     - utxo with validator version policy reference script
+//!     - utxo with illiquid supply validator reference script
+//! Outputs:
+//!     - utxo at the *reserve validator* containing the rest of unreleased tokens and the
+//!       updated [ReserveData] plutus data
+//!     - utxo at the *illiquid supply validator* containing the newly released tokens
+//! Mints:
+//!     - V-Function tokens in the number equal to *the total number of reserve tokens released
+//!       including the ones released in this transaction*. Ie. if N tokens were already released
+//!       and M tokens are being released, the transaction should mint N+M V-Function tokens.
+//!       These tokens are worthless and don't serve any purpose after the transaction is done.
+use super::{deposit::input_with_script_reference, ReserveData, TokenAmount};
+use crate::{await_tx::AwaitTx, csl::*, plutus_script::PlutusScript, reserve::ReserveUtxo};
+use anyhow::anyhow;
+use cardano_serialization_lib::{
+	ExUnits, Int, MultiAsset, PlutusData, Transaction, TransactionBuilder, TransactionOutputBuilder,
+};
+use ogmios_client::{
+	query_ledger_state::*,
+	query_network::QueryNetwork,
+	transactions::Transactions,
+	types::{OgmiosScript, OgmiosUtxo},
+};
+use partner_chains_plutus_data::reserve::{ReserveDatum, ReserveRedeemer};
+use sidechain_domain::{McTxHash, UtxoId};
+
+pub async fn release_reserve_funds<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	// Asset ID of the reserve token and current value of the V-Function,
+	// ie. the *total* number of tokens that will have been released after this transction
+	token: TokenAmount,
+	genesis_utxo: UtxoId,
+	reference_utxo: UtxoId,
+	payment_key: [u8; 32],
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
+	let ctx = TransactionContext::for_payment_key(payment_key, client).await?;
+	let tip = client.get_tip().await?;
+	let reserve_data = ReserveData::get(genesis_utxo, &ctx, client).await?;
+	let Some(reference_utxo) = client.query_utxo_by_id(reference_utxo).await? else {
+		return Err(anyhow!("Reference utxo {reference_utxo:?} not found on chain"));
+	};
+
+	let ReserveUtxo { reserve_utxo, reserve_settings } =
+		reserve_data.get_reserve_utxo(&ctx, client).await?;
+
+	let tx = reserve_release_tx(
+		&ctx,
+		&reserve_data,
+		&reserve_utxo,
+		&reserve_settings,
+		&reference_utxo,
+		token.amount,
+		tip.slot,
+		ExUnits::new(&0u64.into(), &0u64.into()),
+		ExUnits::new(&0u64.into(), &0u64.into()),
+	)?;
+	let costs = client.evaluate_transaction(&tx.to_bytes()).await?;
+	let ScriptExUnits { mint_ex_units, spend_ex_units } = get_validator_budgets(costs);
+	let [mint_cost] = &mint_ex_units[..] else {
+		return Err(anyhow!("Error retrieving witness costs: mint cost data missing."));
+	};
+	let [spend_cost] = &spend_ex_units[..] else {
+		return Err(anyhow!("Error retrieving witness costs: spend cost data missing."));
+	};
+
+	let tx = reserve_release_tx(
+		&ctx,
+		&reserve_data,
+		&reserve_utxo,
+		&reserve_settings,
+		&reference_utxo,
+		token.amount,
+		tip.slot,
+		mint_cost.clone(),
+		spend_cost.clone(),
+	)?;
+	let signed_tx = ctx.sign(&tx).to_bytes();
+
+	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+		anyhow::anyhow!(
+			"Reserve release transaction request failed: {}, tx bytes: {}",
+			e,
+			hex::encode(signed_tx)
+		)
+	})?;
+	let tx_id = res.transaction.id;
+	log::info!("Reserve release transaction submitted: {}", hex::encode(tx_id));
+	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
+
+	Ok(McTxHash(tx_id))
+}
+
+fn reserve_release_tx(
+	ctx: &TransactionContext,
+	reserve_data: &ReserveData,
+	previous_reserve_utxo: &OgmiosUtxo,
+	previous_reserve_datum: &ReserveDatum,
+	reference_utxo: &OgmiosUtxo,
+	cumulative_total_transfer: u64,
+	latest_slot: u64,
+	mint_cost: ExUnits,
+	reserve_auth_script_cost: ExUnits,
+) -> anyhow::Result<Transaction> {
+	let token = previous_reserve_datum.immutable_settings.token.clone();
+	let stats = previous_reserve_datum.stats.clone();
+
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+
+	let reserve_balance = previous_reserve_utxo.get_asset_amount(&token);
+	let amount_to_transfer = cumulative_total_transfer - stats.token_total_amount_transferred;
+	if amount_to_transfer as i128 > reserve_balance {
+		return Err(anyhow!("Not enough funds in the reserve to transfer {amount_to_transfer} tokens (reserve balance: {reserve_balance})"));
+	}
+	let left_in_reserve: u64 = (reserve_balance - (amount_to_transfer as i128)) as u64;
+
+	// Additional reference scripts
+	tx_builder.add_script_reference_input(
+		&reserve_data.auth_policy_version_utxo.to_csl_tx_input(),
+		reserve_data.scripts.auth_policy.bytes.len(),
+	);
+	tx_builder.add_script_reference_input(
+		&reserve_data.validator_version_utxo.to_csl_tx_input(),
+		reserve_data.scripts.validator.bytes.len(),
+	);
+	tx_builder.add_script_reference_input(
+		&reserve_data
+			.illiquid_circulation_supply_validator_version_utxo
+			.to_csl_tx_input(),
+		reserve_data.scripts.illiquid_circulation_supply_validator.bytes.len(),
+	);
+
+	// Mint v-function tokens in the number equal to the *total* number of tokens transfered.
+	// This serves as a validation of the v-function value.
+	tx_builder.add_mint_script_token_using_reference_script(
+		&v_function_from_utxo(reference_utxo)?,
+		&reference_utxo.to_csl_tx_input(),
+		&Int::new(&cumulative_total_transfer.into()),
+		&mint_cost,
+	)?;
+
+	// Remove tokens from the reserve
+	tx_builder.set_inputs(&input_with_script_reference(
+		&previous_reserve_utxo,
+		&reserve_data,
+		ReserveRedeemer::FreeFromReserve,
+		reserve_auth_script_cost,
+	)?);
+
+	// Transfer released tokens to the illiquid supply
+	tx_builder.add_output(&{
+		TransactionOutputBuilder::new()
+			.with_address(
+				&reserve_data.scripts.illiquid_circulation_supply_validator.address(ctx.network),
+			)
+			.with_plutus_data(&PlutusData::new_empty_constr_plutus_data(&0u64.into()))
+			.next()?
+			.with_minimum_ada_and_asset(&token.to_multi_asset(amount_to_transfer)?, &ctx)?
+			.build()?
+	})?;
+
+	// Return the rest of the tokens back to the reserve
+	tx_builder.add_output(&{
+		TransactionOutputBuilder::new()
+			.with_address(&reserve_data.scripts.validator.address(ctx.network))
+			.with_plutus_data(&PlutusData::from(
+				previous_reserve_datum.clone().after_withdrawal(amount_to_transfer),
+			))
+			.next()?
+			.with_minimum_ada_and_asset(
+				&MultiAsset::from_ogmios_utxo(previous_reserve_utxo)?
+					.with_asset_amount(&token, left_in_reserve)?,
+				&ctx,
+			)?
+			.build()?
+	})?;
+
+	tx_builder.set_validity_start_interval_bignum(0u64.into());
+	Ok(tx_builder.balance_update_and_build(ctx)?)
+}
+
+fn v_function_from_utxo(utxo: &OgmiosUtxo) -> anyhow::Result<PlutusScript> {
+	let Some(v_function_script) = utxo.script.clone() else {
+		return Err(anyhow!("V-Function reference script missing from the reference UTXO",));
+	};
+	let OgmiosScript::Plutus(v_function_script) = v_function_script else {
+		return Err(anyhow!("V-Function reference script is not a Plutus script"));
+	};
+	PlutusScript::try_from(v_function_script)
+		.map_err(|val| anyhow!("{val:?} is not a valid Plutus Script"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{empty_asset_name, reserve_release_tx, AssetNameExt, TransactionContext};
+	use crate::{
+		plutus_script::PlutusScript,
+		reserve::{release::OgmiosUtxoExt, ReserveData},
+		scripts_data::ReserveScripts,
+		test_values::protocol_parameters,
+	};
+	use cardano_serialization_lib::{
+		ExUnits, Int, Language, NetworkIdKind, PolicyID, PrivateKey, Transaction,
+	};
+	use hex_literal::hex;
+	use ogmios_client::types::{Asset, OgmiosScript, OgmiosTx, OgmiosUtxo, OgmiosValue};
+	use partner_chains_plutus_data::reserve::{
+		ReserveDatum, ReserveImmutableSettings, ReserveMutableSettings, ReserveStats,
+	};
+	use pretty_assertions::assert_eq;
+	use sidechain_domain::{AssetName, MainchainPrivateKey, PolicyId};
+
+	fn payment_key_domain() -> MainchainPrivateKey {
+		MainchainPrivateKey(hex!(
+			"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
+		))
+	}
+
+	fn payment_key() -> PrivateKey {
+		PrivateKey::from_normal_bytes(&payment_key_domain().0).unwrap()
+	}
+
+	fn test_address_bech32() -> String {
+		"addr_test1vpmd59ajuvm34d723r8q2qzyz9ylq0x9pygqn7vun8qgpkgs7y5hw".into()
+	}
+
+	fn payment_utxo() -> OgmiosUtxo {
+		OgmiosUtxo {
+			transaction: OgmiosTx {
+				id: hex!("f5e751f474e909419c714bb5666a8f810e7ed61fadad236c29f67dafc1ff398b"),
+			},
+			index: 1,
+			value: OgmiosValue {
+				lovelace: 994916563,
+				native_tokens: [(
+					// random native token
+					hex!("08b95138e16a062fa8d623a2b1beebd59c06210f3d33690580733e73"),
+					vec![Asset { name: vec![], amount: 1 }],
+				)]
+				.into(),
+			},
+			address: test_address_bech32(),
+
+			..OgmiosUtxo::default()
+		}
+	}
+
+	fn tx_context() -> TransactionContext {
+		TransactionContext {
+			payment_key: payment_key(),
+			payment_key_utxos: vec![payment_utxo()],
+			network: NetworkIdKind::Testnet,
+			protocol_parameters: protocol_parameters(),
+		}
+	}
+
+	fn reserve_validator_script() -> PlutusScript {
+		PlutusScript::from_wrapped_cbor(raw_scripts::RESERVE_VALIDATOR, Language::new_plutus_v2())
+			.unwrap()
+	}
+
+	fn auth_policy_script() -> PlutusScript {
+		PlutusScript::from_wrapped_cbor(raw_scripts::RESERVE_AUTH_POLICY, Language::new_plutus_v2())
+			.unwrap()
+	}
+
+	fn illiquid_supply_validator_script() -> PlutusScript {
+		PlutusScript::from_wrapped_cbor(
+			raw_scripts::ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
+			Language::new_plutus_v2(),
+		)
+		.unwrap()
+	}
+
+	const UNIX_T0: u64 = 1736504093000u64;
+
+	fn applied_v_function() -> PlutusScript {
+		PlutusScript::from_wrapped_cbor(
+			raw_scripts::EXAMPLE_V_FUNCTION_POLICY,
+			Language::new_plutus_v2(),
+		)
+		.unwrap()
+		.apply_data(UNIX_T0)
+		.unwrap()
+	}
+
+	fn version_oracle_address() -> String {
+		"addr_test1wqskkgpmsyf0yr2renk0spgsvea75rkq4yvalrpwwudwr5ga3relp".to_string()
+	}
+
+	fn reserve_data() -> ReserveData {
+		ReserveData {
+			scripts: ReserveScripts {
+				validator: reserve_validator_script(),
+				auth_policy: auth_policy_script(),
+				illiquid_circulation_supply_validator: illiquid_supply_validator_script(),
+			},
+			auth_policy_version_utxo: OgmiosUtxo {
+				transaction: OgmiosTx {
+					id: hex!("d1030b0ce5cf33d97a6e8aafa1cfe150e7a8b3a5584bd7a345743938e78ec44b"),
+				},
+				index: 0,
+				address: version_oracle_address(),
+				script: Some(OgmiosScript::Plutus(auth_policy_script().into())),
+				..Default::default()
+			},
+			validator_version_utxo: OgmiosUtxo {
+				transaction: OgmiosTx {
+					id: hex!("fcb5d7877e6ce7cfaef579c4f4b5fdbbdb807e4fe613752671742f1a5191c850"),
+				},
+				index: 0,
+				address: version_oracle_address(),
+				script: Some(OgmiosScript::Plutus(reserve_validator_script().into())),
+				..Default::default()
+			},
+			illiquid_circulation_supply_validator_version_utxo: OgmiosUtxo {
+				transaction: OgmiosTx {
+					id: hex!("f5890475177fcc7cf40679974751f66331c7b25fcf2f1a148c53cf7e0e147114"),
+				},
+				index: 0,
+				address: version_oracle_address(),
+				script: Some(OgmiosScript::Plutus(illiquid_supply_validator_script().into())),
+				..Default::default()
+			},
+		}
+	}
+
+	fn reference_utxo() -> OgmiosUtxo {
+		OgmiosUtxo {
+			transaction: OgmiosTx {
+				id: hex!("45882cfd2de9381f34ae68ad073452e2a57a7ad11095dae49f365266637e9d04"),
+			},
+			index: 0,
+			script: Some(OgmiosScript::Plutus(applied_v_function().into())),
+			..Default::default()
+		}
+	}
+
+	fn previous_reserve_utxo() -> OgmiosUtxo {
+		OgmiosUtxo {
+			transaction: OgmiosTx {
+				id: hex!("23de508bbfeb6af651da305a2de022463f71e47d58365eba36d98fa6c4aed731"),
+			},
+			value: OgmiosValue {
+				lovelace: 1672280,
+				native_tokens: [
+					(
+						// reserve token
+						token_policy().0,
+						vec![Asset { name: token_name().0.to_vec(), amount: 990 }],
+					),
+					(
+						// leftover governance token - should be returned to the validator
+						hex!("75b8875ff8958c66fecbd93740ac5ffd7370d299e729a46bb5632066"),
+						vec![Asset { name: vec![], amount: 1 }],
+					),
+				]
+				.into(),
+			},
+
+			index: 1,
+			..Default::default()
+		}
+	}
+
+	fn token_policy() -> PolicyId {
+		PolicyId(hex!("1fab25f376bc49a181d03a869ee8eaa3157a3a3d242a619ca7995b2b"))
+	}
+
+	fn token_name() -> AssetName {
+		AssetName::from_hex_unsafe("52657761726420746f6b656e")
+	}
+
+	fn token_id() -> sidechain_domain::AssetId {
+		sidechain_domain::AssetId { policy_id: token_policy(), asset_name: token_name() }
+	}
+
+	fn previous_reserve_datum() -> ReserveDatum {
+		ReserveDatum {
+			immutable_settings: ReserveImmutableSettings { token: token_id() },
+			mutable_settings: ReserveMutableSettings {
+				total_accrued_function_script_hash: applied_v_function().policy_id(),
+				initial_incentive: 0,
+			},
+			stats: ReserveStats { token_total_amount_transferred: 10 },
+		}
+	}
+
+	fn reserve_release_test_tx() -> Transaction {
+		reserve_release_tx(
+			&tx_context(),
+			&reserve_data(),
+			&previous_reserve_utxo(),
+			&previous_reserve_datum(),
+			&reference_utxo(),
+			20,
+			0,
+			ExUnits::new(&0u64.into(), &0u64.into()),
+			ExUnits::new(&0u64.into(), &0u64.into()),
+		)
+		.unwrap()
+	}
+
+	#[test]
+	fn should_have_correct_reference_utxos() {
+		let ref_inputs: Vec<_> = reserve_release_test_tx()
+			.body()
+			.reference_inputs()
+			.expect("Should have reference inputs")
+			.into_iter()
+			.cloned()
+			.collect();
+
+		assert!(ref_inputs.contains(&reference_utxo().to_csl_tx_input()));
+		assert!(ref_inputs.contains(&reserve_data().auth_policy_version_utxo.to_csl_tx_input()));
+		assert!(ref_inputs.contains(&reserve_data().validator_version_utxo.to_csl_tx_input()));
+		assert!(ref_inputs.contains(
+			&reserve_data()
+				.illiquid_circulation_supply_validator_version_utxo
+				.to_csl_tx_input()
+		));
+		assert_eq!(ref_inputs.len(), 4)
+	}
+
+	#[test]
+	fn should_mint_v_function_scripts() {
+		let v_function_token_mint_amount = reserve_release_test_tx()
+			.body()
+			.mint()
+			.expect("Should mint a token")
+			.get(&applied_v_function().csl_script_hash())
+			.and_then(|policy| policy.get(0))
+			.expect("Should mint a v-function policy token")
+			.get(&empty_asset_name())
+			.expect("The minted token should have an empty asset name");
+
+		assert_eq!(v_function_token_mint_amount, Int::new_i32(20))
+	}
+
+	#[test]
+	fn should_burn_previoius_reserve_utxo() {
+		let inputs: Vec<_> =
+			reserve_release_test_tx().body().inputs().into_iter().cloned().collect();
+
+		assert!(inputs.contains(&previous_reserve_utxo().to_csl_tx_input()))
+	}
+
+	#[test]
+	fn should_add_correct_number_of_tokens_to_illiquid_supply() {
+		let illiquid_supply_output = (reserve_release_test_tx().body().outputs().into_iter())
+			.find(|output| {
+				output.address()
+					== illiquid_supply_validator_script().address(NetworkIdKind::Testnet)
+			})
+			.expect("Should output a UTXO to illiquid supply validator")
+			.amount()
+			.multiasset()
+			.expect("Should output native tokens to illiquid supply")
+			.get(&PolicyID::from(token_policy().0))
+			.expect("Should transfer reserve token policy token to illiquid supply")
+			.get(&token_name().to_csl().unwrap())
+			.expect("Should transfer reserve token to illiquid supply");
+
+		assert_eq!(illiquid_supply_output, 10u64.into())
+	}
+
+	#[test]
+	fn should_leave_unreleased_tokens_at_reserve_validator() {
+		let illiquid_supply_output = (reserve_release_test_tx().body().outputs().into_iter())
+			.find(|output| {
+				output.address() == reserve_validator_script().address(NetworkIdKind::Testnet)
+			})
+			.expect("Should output a UTXO to illiquid supply validator")
+			.amount()
+			.multiasset()
+			.expect("Should output native tokens to illiquid supply")
+			.get(&PolicyID::from(token_policy().0))
+			.expect("Should transfer reserve token policy token to illiquid supply")
+			.get(&token_name().to_csl().unwrap())
+			.expect("Should transfer reserve token to illiquid supply");
+
+		assert_eq!(illiquid_supply_output, 980u64.into())
+	}
+}

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -188,7 +188,7 @@ fn reserve_release_tx(
 			.build()?
 	})?;
 
-	tx_builder.set_validity_start_interval_bignum(0u64.into());
+	tx_builder.set_validity_start_interval_bignum(latest_slot.into());
 	Ok(tx_builder.balance_update_and_build(ctx)?)
 }
 

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -156,7 +156,7 @@ fn reserve_release_tx(
 	tx_builder.set_inputs(&input_with_script_reference(
 		&previous_reserve_utxo,
 		&reserve_data,
-		ReserveRedeemer::FreeFromReserve,
+		ReserveRedeemer::ReleaseFromReserve,
 		reserve_auth_script_cost,
 	)?);
 

--- a/toolkit/primitives/plutus-data/src/reserve.rs
+++ b/toolkit/primitives/plutus-data/src/reserve.rs
@@ -8,7 +8,7 @@ use sidechain_domain::{AssetId, AssetName, PolicyId};
 #[derive(Debug, Clone)]
 pub enum ReserveRedeemer {
 	DepositToReserve { governance_version: u64 },
-	TransferToIlliquidCirculationSupply,
+	FreeFromReserve,
 	UpdateReserve { governance_version: u64 },
 	Handover { governance_version: u64 },
 }
@@ -46,9 +46,7 @@ impl From<ReserveRedeemer> for PlutusData {
 					&PlutusData::new_integer(&BigInt::from(governance_version)),
 				)
 			},
-			TransferToIlliquidCirculationSupply => {
-				PlutusData::new_empty_constr_plutus_data(&BigNum::from(1_u64))
-			},
+			FreeFromReserve => PlutusData::new_empty_constr_plutus_data(&BigNum::from(1_u64)),
 			UpdateReserve { governance_version } => {
 				PlutusData::new_single_value_constr_plutus_data(
 					&BigNum::from(2_u64),
@@ -127,7 +125,18 @@ impl VersionedDatum for ReserveDatum {
 		match plutus_data_version_and_payload(datum) {
 			Some((0, datum, _)) => decode_v0_reserve_datum(&datum)
 				.ok_or_else(|| decoding_error_and_log(&datum, "ReserveDatum", "invalid data")),
-			_ => Err(decoding_error_and_log(datum, "ReserveDatum", "invalid data")),
+			_ => Err(decoding_error_and_log(datum, "ReserveDatum", "unversioned datum")),
+		}
+	}
+}
+
+impl ReserveDatum {
+	pub fn after_withdrawal(self, amount: u64) -> Self {
+		Self {
+			stats: ReserveStats {
+				token_total_amount_transferred: self.stats.token_total_amount_transferred + amount,
+			},
+			..self
 		}
 	}
 }

--- a/toolkit/primitives/plutus-data/src/reserve.rs
+++ b/toolkit/primitives/plutus-data/src/reserve.rs
@@ -8,7 +8,7 @@ use sidechain_domain::{AssetId, AssetName, PolicyId};
 #[derive(Debug, Clone)]
 pub enum ReserveRedeemer {
 	DepositToReserve { governance_version: u64 },
-	FreeFromReserve,
+	ReleaseFromReserve,
 	UpdateReserve { governance_version: u64 },
 	Handover { governance_version: u64 },
 }
@@ -46,7 +46,7 @@ impl From<ReserveRedeemer> for PlutusData {
 					&PlutusData::new_integer(&BigInt::from(governance_version)),
 				)
 			},
-			FreeFromReserve => PlutusData::new_empty_constr_plutus_data(&BigNum::from(1_u64)),
+			ReleaseFromReserve => PlutusData::new_empty_constr_plutus_data(&BigNum::from(1_u64)),
 			UpdateReserve { governance_version } => {
 				PlutusData::new_single_value_constr_plutus_data(
 					&BigNum::from(2_u64),

--- a/toolkit/utils/ogmios-client/src/query_ledger_state.rs
+++ b/toolkit/utils/ogmios-client/src/query_ledger_state.rs
@@ -8,6 +8,9 @@ use serde::Deserialize;
 
 pub trait QueryLedgerState {
 	#[allow(async_fn_in_trait)]
+	async fn get_tip(&self) -> Result<OgmiosTip, OgmiosClientError>;
+
+	#[allow(async_fn_in_trait)]
 	async fn era_summaries(&self) -> Result<Vec<EraSummary>, OgmiosClientError>;
 
 	#[allow(async_fn_in_trait)]
@@ -36,6 +39,10 @@ pub trait QueryUtxoByUtxoId {
 }
 
 impl<T: OgmiosClient> QueryLedgerState for T {
+	async fn get_tip(&self) -> Result<OgmiosTip, OgmiosClientError> {
+		self.request("queryLedgerState/tip", OgmiosParams::empty_positional()).await
+	}
+
 	async fn era_summaries(&self) -> Result<Vec<EraSummary>, OgmiosClientError> {
 		self.request("queryLedgerState/eraSummaries", OgmiosParams::empty_positional())
 			.await
@@ -136,4 +143,9 @@ pub struct PlutusCostModels {
 	pub plutus_v2: Vec<i128>,
 	#[serde(rename = "plutus:v3")]
 	pub plutus_v3: Vec<i128>,
+}
+
+#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Default)]
+pub struct OgmiosTip {
+	pub slot: u64,
 }


### PR DESCRIPTION
# Description

This PR uses helpers split out into https://github.com/input-output-hk/partner-chains/pull/405 .

Implements the reserve releasing transaction, offchain and command.

Also adds a transaction, offchain and command to create a reference utxo with the example v-function from `raw_scripts`. I'm not sure it should be exposed to the users. Let me know what you think.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

