### PR TITLE
fix: hide 't0' parameter of 'reserve create' command

### DIFF
--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -61,9 +61,6 @@ pub struct CreateReserveCmd {
 	/// Genesis UTXO of the partner-chain.
 	#[arg(long, short('c'))]
 	genesis_utxo: UtxoId,
-	/// t0, POSIX time used for calculating how many tokens could be released from the reserve at given moment.
-	#[arg(long)]
-	t0: u64,
 	/// Script hash of the 'total accrued function', also called V-function, that computes how many tokens could be released from the reserve at given moment.
 	#[arg(long)]
 	total_accrued_function_script_hash: ScriptHash,
@@ -86,7 +83,6 @@ impl CreateReserveCmd {
 			ReserveParameters {
 				initial_incentive: self.initial_incentive_amount,
 				total_accrued_function_script_hash: self.total_accrued_function_script_hash,
-				t0: self.t0,
 				token: self.token,
 				initial_deposit: self.initial_deposit_amount,
 			},

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -98,7 +98,6 @@ pub async fn create_reserve_utxo<
 pub struct ReserveParameters {
 	pub initial_incentive: u64,
 	pub total_accrued_function_script_hash: PolicyId,
-	pub t0: u64,
 	pub token: TokenId,
 	pub initial_deposit: u64,
 }
@@ -106,10 +105,7 @@ pub struct ReserveParameters {
 impl From<&ReserveParameters> for ReserveDatum {
 	fn from(value: &ReserveParameters) -> Self {
 		ReserveDatum {
-			immutable_settings: ReserveImmutableSettings {
-				t0: value.t0,
-				token: value.token.clone(),
-			},
+			immutable_settings: ReserveImmutableSettings { token: value.token.clone() },
 			mutable_settings: ReserveMutableSettings {
 				total_accrued_function_script_hash: value
 					.total_accrued_function_script_hash

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -294,7 +294,6 @@ async fn run_create_reserve_management<
 		reserve::create::ReserveParameters {
 			initial_incentive: 100,
 			total_accrued_function_script_hash: PolicyId([233u8; 28]),
-			t0: 1735689600,
 			token: TokenId::AssetId {
 				policy_id: REWARDS_TOKEN_POLICY_ID,
 				asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),


### PR DESCRIPTION
# Description

Removes 't0' from `reserve create` command, as it turned out to be not used by Reserve Validator.
It was misleading at least. If users release functions need "t0", then users are supposed to store it on their own.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate -> it wasn't released yet anyway
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

