### PR TITLE
ETCM-9064 reserve redeemer and misc changes

### DIFF
--- a/toolkit/offchain/src/d_param/tests.rs
+++ b/toolkit/offchain/src/d_param/tests.rs
@@ -6,7 +6,7 @@ use crate::{
 	test_values::*,
 };
 use cardano_serialization_lib::{
-	Address, ExUnits, Int, LanguageKind, NetworkIdKind, PlutusData, RedeemerTag, ScriptHash,
+	Address, ExUnits, Int, Language, NetworkIdKind, PlutusData, RedeemerTag, ScriptHash,
 };
 use hex_literal::hex;
 use ogmios_client::types::{Asset as OgmiosAsset, OgmiosTx, OgmiosUtxo, OgmiosValue};
@@ -323,7 +323,7 @@ fn test_tx_context() -> TransactionContext {
 }
 
 fn governance_script() -> crate::plutus_script::PlutusScript {
-	crate::plutus_script::PlutusScript { language: LanguageKind::PlutusV2, bytes: vec![] }
+	crate::plutus_script::PlutusScript { language: Language::new_plutus_v2(), bytes: vec![] }
 }
 
 fn governance_script_hash() -> ScriptHash {

--- a/toolkit/offchain/src/init_governance/transaction.rs
+++ b/toolkit/offchain/src/init_governance/transaction.rs
@@ -19,7 +19,7 @@ pub(crate) fn init_governance_transaction(
 	ex_units: ExUnits,
 ) -> anyhow::Result<Transaction> {
 	let multi_sig_policy =
-		PlutusScript::from_wrapped_cbor(raw_scripts::MULTI_SIG_POLICY, LanguageKind::PlutusV2)?
+		PlutusScript::from_wrapped_cbor(raw_scripts::MULTI_SIG_POLICY, Language::new_plutus_v2())?
 			.apply_uplc_data(multisig_governance_policy_configuration(governance_authority))?;
 	let version_oracle = version_oracle(genesis_utxo.to_domain(), tx_context.network)?;
 	let config = crate::csl::get_builder_config(tx_context)?;

--- a/toolkit/offchain/src/permissioned_candidates.rs
+++ b/toolkit/offchain/src/permissioned_candidates.rs
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 
 use crate::await_tx::{AwaitTx, FixedDelayRetries};
 use crate::csl::{
-	convert_value, empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units,
-	OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
+	empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units, OgmiosUtxoExt,
+	OgmiosValueExt, TransactionBuilderExt, TransactionContext,
 };
 use crate::init_governance::{self, GovernanceData};
 use crate::plutus_script::PlutusScript;
@@ -338,7 +338,7 @@ fn update_permissioned_candidates_tx(
 	{
 		let mut inputs = TxInputsBuilder::new();
 		let input = script_utxo.to_csl_tx_input();
-		let amount = convert_value(&script_utxo.value)?;
+		let amount = &script_utxo.value.to_csl()?;
 		let witness = PlutusWitness::new_without_datum(
 			&validator.to_csl(),
 			&Redeemer::new(
@@ -381,7 +381,7 @@ mod tests {
 		plutus_script::PlutusScript,
 		test_values::*,
 	};
-	use cardano_serialization_lib::{Address, ExUnits, Int, NetworkIdKind, PlutusData};
+	use cardano_serialization_lib::{Address, ExUnits, Int, Language, NetworkIdKind, PlutusData};
 	use hex_literal::hex;
 	use ogmios_client::types::{Asset as OgmiosAsset, OgmiosTx, OgmiosUtxo, OgmiosValue};
 	use partner_chains_plutus_data::permissioned_candidates::permissioned_candidates_to_plutus_data;
@@ -556,10 +556,7 @@ mod tests {
 	}
 
 	fn test_goveranance_policy() -> PlutusScript {
-		PlutusScript {
-			bytes: hex!("88991122").into(),
-			language: cardano_serialization_lib::LanguageKind::PlutusV2,
-		}
+		PlutusScript { bytes: hex!("88991122").into(), language: Language::new_plutus_v2() }
 	}
 
 	fn test_goveranance_utxo() -> OgmiosUtxo {

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -19,7 +19,7 @@ use super::ReserveData;
 use crate::{
 	await_tx::AwaitTx,
 	csl::{
-		empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units,
+		empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units, OgmiosUtxoExt,
 		TransactionBuilderExt, TransactionContext, UtxoIdExt,
 	},
 	init_governance::{get_governance_data, GovernanceData},
@@ -133,7 +133,7 @@ fn create_reserve_tx(
 
 	tx_builder.add_mint_one_script_token_using_reference_script(
 		&reserve.scripts.auth_policy,
-		&reserve.auth_policy_version_utxo.to_csl(),
+		&reserve.auth_policy_version_utxo.to_csl_tx_input(),
 		&reserve_auth_script_cost,
 	)?;
 	tx_builder.add_output(&reserve_validator_output(parameters, &reserve.scripts, ctx)?)?;
@@ -145,7 +145,7 @@ fn create_reserve_tx(
 		&governance_script_cost,
 	)?;
 	tx_builder.add_script_reference_input(
-		&reserve.validator_version_utxo.to_csl(),
+		&reserve.validator_version_utxo.to_csl_tx_input(),
 		reserve.scripts.validator.bytes.len(),
 	);
 	tx_builder.add_required_signer(&ctx.payment_key_hash());

--- a/toolkit/offchain/src/reserve/mod.rs
+++ b/toolkit/offchain/src/reserve/mod.rs
@@ -7,6 +7,7 @@ use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
 	query_network::QueryNetwork,
 	transactions::Transactions,
+	types::OgmiosUtxo,
 };
 use sidechain_domain::UtxoId;
 
@@ -16,9 +17,9 @@ pub mod init;
 
 pub(crate) struct ReserveData {
 	pub(crate) scripts: scripts_data::ReserveScripts,
-	pub(crate) auth_policy_version_utxo: UtxoId,
-	pub(crate) validator_version_utxo: UtxoId,
-	pub(crate) illiquid_circulation_supply_validator_version_utxo: UtxoId,
+	pub(crate) auth_policy_version_utxo: OgmiosUtxo,
+	pub(crate) validator_version_utxo: OgmiosUtxo,
+	pub(crate) illiquid_circulation_supply_validator_version_utxo: OgmiosUtxo,
 }
 
 pub(crate) async fn get_reserve_data<
@@ -57,7 +58,7 @@ pub(crate) async fn get_reserve_data<
 	)
 	.await?
 	.ok_or_else(|| {
-		anyhow!("Reserve Validator Version Utxo not found, is the Reserve Token Management initialized?")
+		anyhow!("Illiquid Circulation Supply Validator Version Utxo not found, is the Reserve Token Management initialized?")
 	})?;
 	let scripts = scripts_data::reserve_scripts(genesis_utxo, ctx.network)?;
 	Ok(ReserveData {

--- a/toolkit/offchain/src/scripts_data.rs
+++ b/toolkit/offchain/src/scripts_data.rs
@@ -1,5 +1,5 @@
 use crate::{csl::NetworkTypeExt, plutus_script::PlutusScript, OffchainError};
-use cardano_serialization_lib::{LanguageKind::PlutusV2, NetworkIdKind};
+use cardano_serialization_lib::{Language, NetworkIdKind};
 use ogmios_client::query_network::QueryNetwork;
 use serde::Serialize;
 use sidechain_domain::{MainchainAddressHash, PolicyId, UtxoId};
@@ -62,13 +62,15 @@ pub fn get_scripts_data(
 ) -> anyhow::Result<ScriptsData> {
 	let version_oracle_data = version_oracle(genesis_utxo, network)?;
 
-	let committee_candidate_validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::COMMITTEE_CANDIDATE_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?;
+	let committee_candidate_validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::COMMITTEE_CANDIDATE_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?;
 	let (d_parameter_validator, d_parameter_policy) = d_parameter_scripts(genesis_utxo, network)?;
 	let illiquid_circulation_supply_validator = PlutusScript::from_wrapped_cbor(
 		raw_scripts::ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
-		PlutusV2,
+		Language::new_plutus_v2(),
 	)?
 	.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
 	let (permissioned_candidates_validator, permissioned_candidates_policy) =
@@ -123,13 +125,17 @@ pub(crate) fn version_oracle(
 	genesis_utxo: UtxoId,
 	network: NetworkIdKind,
 ) -> Result<VersionOracleData, anyhow::Error> {
-	let validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::VERSION_ORACLE_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?;
-	let policy_script =
-		PlutusScript::from_wrapped_cbor(raw_scripts::VERSION_ORACLE_POLICY, PlutusV2)?
-			.apply_data(genesis_utxo)?
-			.apply_uplc_data(validator.address_data(network)?)?;
+	let validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::VERSION_ORACLE_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?;
+	let policy_script = PlutusScript::from_wrapped_cbor(
+		raw_scripts::VERSION_ORACLE_POLICY,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_uplc_data(validator.address_data(network)?)?;
 	Ok(VersionOracleData { validator, policy: policy_script })
 }
 
@@ -137,12 +143,17 @@ pub(crate) fn version_scripts_and_address(
 	genesis_utxo: UtxoId,
 	network: NetworkIdKind,
 ) -> Result<(PlutusScript, PlutusScript, String), anyhow::Error> {
-	let validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::VERSION_ORACLE_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?;
-	let policy = PlutusScript::from_wrapped_cbor(raw_scripts::VERSION_ORACLE_POLICY, PlutusV2)?
-		.apply_data(genesis_utxo)?
-		.apply_uplc_data(validator.address_data(network)?)?;
+	let validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::VERSION_ORACLE_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?;
+	let policy = PlutusScript::from_wrapped_cbor(
+		raw_scripts::VERSION_ORACLE_POLICY,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_uplc_data(validator.address_data(network)?)?;
 	let address = validator.address_bech32(network)?;
 	Ok((validator, policy, address))
 }
@@ -152,15 +163,19 @@ pub(crate) fn d_parameter_scripts(
 	network: NetworkIdKind,
 ) -> Result<(PlutusScript, PlutusScript), anyhow::Error> {
 	let version_oracle_data = version_oracle(genesis_utxo, network)?;
-	let d_parameter_validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::D_PARAMETER_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?
-			.apply_data(version_oracle_data.policy_id())?;
-	let d_parameter_policy =
-		PlutusScript::from_wrapped_cbor(raw_scripts::D_PARAMETER_POLICY, PlutusV2)?
-			.apply_data(genesis_utxo)?
-			.apply_data(version_oracle_data.policy_id())?
-			.apply_uplc_data(d_parameter_validator.address_data(network)?)?;
+	let d_parameter_validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::D_PARAMETER_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_data(version_oracle_data.policy_id())?;
+	let d_parameter_policy = PlutusScript::from_wrapped_cbor(
+		raw_scripts::D_PARAMETER_POLICY,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_data(version_oracle_data.policy_id())?
+	.apply_uplc_data(d_parameter_validator.address_data(network)?)?;
 	Ok((d_parameter_validator, d_parameter_policy))
 }
 
@@ -169,24 +184,30 @@ pub(crate) fn permissioned_candidates_scripts(
 	network: NetworkIdKind,
 ) -> Result<(PlutusScript, PlutusScript), anyhow::Error> {
 	let version_oracle_data = version_oracle(genesis_utxo, network)?;
-	let validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::PERMISSIONED_CANDIDATES_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?
-			.apply_data(version_oracle_data.policy_id())?;
-	let policy =
-		PlutusScript::from_wrapped_cbor(raw_scripts::PERMISSIONED_CANDIDATES_POLICY, PlutusV2)?
-			.apply_data(genesis_utxo)?
-			.apply_data(version_oracle_data.policy_id())?
-			.apply_uplc_data(validator.address_data(network)?)?;
+	let validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::PERMISSIONED_CANDIDATES_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_data(version_oracle_data.policy_id())?;
+	let policy = PlutusScript::from_wrapped_cbor(
+		raw_scripts::PERMISSIONED_CANDIDATES_POLICY,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?
+	.apply_data(version_oracle_data.policy_id())?
+	.apply_uplc_data(validator.address_data(network)?)?;
 	Ok((validator, policy))
 }
 
 pub(crate) fn registered_candidates_scripts(
 	genesis_utxo: UtxoId,
 ) -> Result<PlutusScript, anyhow::Error> {
-	let validator =
-		PlutusScript::from_wrapped_cbor(raw_scripts::COMMITTEE_CANDIDATE_VALIDATOR, PlutusV2)?
-			.apply_data(genesis_utxo)?;
+	let validator = PlutusScript::from_wrapped_cbor(
+		raw_scripts::COMMITTEE_CANDIDATE_VALIDATOR,
+		Language::new_plutus_v2(),
+	)?
+	.apply_data(genesis_utxo)?;
 	Ok(validator)
 }
 
@@ -201,13 +222,17 @@ pub(crate) fn reserve_scripts(
 	network: NetworkIdKind,
 ) -> Result<ReserveScripts, anyhow::Error> {
 	let version_oracle_data = version_oracle(genesis_utxo, network)?;
-	let validator = PlutusScript::from_wrapped_cbor(raw_scripts::RESERVE_VALIDATOR, PlutusV2)?
-		.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
-	let auth_policy = PlutusScript::from_wrapped_cbor(raw_scripts::RESERVE_AUTH_POLICY, PlutusV2)?
-		.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
+	let validator =
+		PlutusScript::from_wrapped_cbor(raw_scripts::RESERVE_VALIDATOR, Language::new_plutus_v2())?
+			.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
+	let auth_policy = PlutusScript::from_wrapped_cbor(
+		raw_scripts::RESERVE_AUTH_POLICY,
+		Language::new_plutus_v2(),
+	)?
+	.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
 	let illiquid_circulation_supply_validator = PlutusScript::from_wrapped_cbor(
 		raw_scripts::ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
-		PlutusV2,
+		Language::new_plutus_v2(),
 	)?
 	.apply_uplc_data(version_oracle_data.policy_id_as_plutus_data())?;
 	Ok(ReserveScripts { validator, auth_policy, illiquid_circulation_supply_validator })

--- a/toolkit/offchain/src/test_values.rs
+++ b/toolkit/offchain/src/test_values.rs
@@ -1,5 +1,5 @@
 use crate::plutus_script::PlutusScript;
-use cardano_serialization_lib::{Address, LanguageKind, PlutusData, PrivateKey};
+use cardano_serialization_lib::{Address, Language, PlutusData, PrivateKey};
 use hex_literal::hex;
 use ogmios_client::{
 	query_ledger_state::{
@@ -30,12 +30,15 @@ pub(crate) fn mainchain_pub_key() -> MainchainPublicKey {
 pub(crate) fn test_validator() -> PlutusScript {
 	PlutusScript {
 		bytes: hex!("4d4c01000022223212001375a009").to_vec(),
-		language: LanguageKind::PlutusV2,
+		language: Language::new_plutus_v2(),
 	}
 }
 
 pub(crate) fn test_policy() -> PlutusScript {
-	PlutusScript { bytes: hex!("49480100002221200101").to_vec(), language: LanguageKind::PlutusV2 }
+	PlutusScript {
+		bytes: hex!("49480100002221200101").to_vec(),
+		language: Language::new_plutus_v2(),
+	}
 }
 
 pub(crate) fn test_plutus_data() -> PlutusData {

--- a/toolkit/offchain/src/update_governance/mod.rs
+++ b/toolkit/offchain/src/update_governance/mod.rs
@@ -17,7 +17,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	ExUnits, LanguageKind, PlutusData, Transaction, TransactionBuilder, TxInputsBuilder,
+	ExUnits, Language, PlutusData, Transaction, TransactionBuilder, TxInputsBuilder,
 };
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
@@ -109,13 +109,13 @@ fn update_governance_tx(
 	spend_ex_units: ExUnits,
 ) -> anyhow::Result<Transaction> {
 	let multi_sig_policy =
-		PlutusScript::from_wrapped_cbor(multi_sig_policy, LanguageKind::PlutusV2)?
+		PlutusScript::from_wrapped_cbor(multi_sig_policy, Language::new_plutus_v2())?
 			.apply_uplc_data(multisig_governance_policy_configuration(new_governance_authority))?;
 	let version_oracle_validator =
-		PlutusScript::from_wrapped_cbor(version_oracle_validator, LanguageKind::PlutusV2)?
+		PlutusScript::from_wrapped_cbor(version_oracle_validator, Language::new_plutus_v2())?
 			.apply_data(genesis_utxo)?;
 	let version_oracle_policy =
-		PlutusScript::from_wrapped_cbor(version_oracle_policy, LanguageKind::PlutusV2)?
+		PlutusScript::from_wrapped_cbor(version_oracle_policy, Language::new_plutus_v2())?
 			.apply_data(genesis_utxo)?
 			.apply_uplc_data(version_oracle_validator.address_data(tx_context.network)?)?;
 

--- a/toolkit/offchain/src/update_governance/test.rs
+++ b/toolkit/offchain/src/update_governance/test.rs
@@ -88,7 +88,7 @@ fn genesis_utxo() -> OgmiosUtxo {
 }
 
 fn governance_script() -> crate::plutus_script::PlutusScript {
-	crate::plutus_script::PlutusScript { language: LanguageKind::PlutusV2, bytes: vec![] }
+	crate::plutus_script::PlutusScript { language: Language::new_plutus_v2(), bytes: vec![] }
 }
 
 fn governance_data() -> GovernanceData {


### PR DESCRIPTION
# Description

* adds reserve redeemer type + plutus data conversion
* changes uses of LanguageKind to Language (can't easily get Language from LanguageKind, but can get do the other way with `.kind()`, and CSL API seems to expect Language usually)
* reserve::find_script_utxo returns OgmiosUtxo because I need it
* turned convert_value into an extension trait to make it easier to find and more consistent with other conversions

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

