### PR TITLE
feat: cleanup too specific helpers and make sense of redeemer data 

### DIFF
--- a/toolkit/offchain/src/d_param/mod.rs
+++ b/toolkit/offchain/src/d_param/mod.rs
@@ -6,15 +6,14 @@
 
 use crate::await_tx::{AwaitTx, FixedDelayRetries};
 use crate::csl::{
-	get_builder_config, get_validator_budgets, zero_ex_units, InputsBuilderExt, ScriptExUnits,
-	TransactionBuilderExt, TransactionContext,
+	get_builder_config, get_validator_budgets, unit_plutus_data, zero_ex_units, InputsBuilderExt,
+	ScriptExUnits, TransactionBuilderExt, TransactionContext,
 };
 use crate::init_governance::{self, GovernanceData};
 use crate::plutus_script::PlutusScript;
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	BigNum, ExUnits, JsError, PlutusData, ScriptHash, Transaction, TransactionBuilder,
-	TxInputsBuilder,
+	ExUnits, JsError, PlutusData, ScriptHash, Transaction, TransactionBuilder, TxInputsBuilder,
 };
 use ogmios_client::query_ledger_state::QueryUtxoByUtxoId;
 use ogmios_client::{
@@ -257,11 +256,7 @@ fn mint_d_param_token_tx(
 ) -> Result<Transaction, JsError> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 	// The essence of transaction: mint D-Param token and set output with it, mint a governance token.
-	tx_builder.add_mint_one_script_token(
-		policy,
-		&d_param_redeemer_data(),
-		d_param_policy_ex_units,
-	)?;
+	tx_builder.add_mint_one_script_token(policy, &unit_plutus_data(), d_param_policy_ex_units)?;
 	tx_builder.add_output_with_one_script_token(
 		validator,
 		policy,
@@ -294,7 +289,7 @@ fn update_d_param_tx(
 	inputs.add_script_utxo_input(
 		script_utxo,
 		validator,
-		&d_param_redeemer_data(),
+		&unit_plutus_data(),
 		ex_units
 			.spend_ex_units
 			.first()
@@ -320,9 +315,4 @@ fn update_d_param_tx(
 	)?;
 
 	tx_builder.balance_update_and_build(ctx)
-}
-
-/// D-param policy accepts any redeemer data.
-fn d_param_redeemer_data() -> PlutusData {
-	PlutusData::new_empty_constr_plutus_data(&BigNum::zero())
 }

--- a/toolkit/offchain/src/d_param/mod.rs
+++ b/toolkit/offchain/src/d_param/mod.rs
@@ -13,7 +13,8 @@ use crate::init_governance::{self, GovernanceData};
 use crate::plutus_script::PlutusScript;
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	ExUnits, JsError, PlutusData, ScriptHash, Transaction, TransactionBuilder, TxInputsBuilder,
+	BigNum, ExUnits, JsError, PlutusData, ScriptHash, Transaction, TransactionBuilder,
+	TxInputsBuilder,
 };
 use ogmios_client::query_ledger_state::QueryUtxoByUtxoId;
 use ogmios_client::{
@@ -256,7 +257,11 @@ fn mint_d_param_token_tx(
 ) -> Result<Transaction, JsError> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 	// The essence of transaction: mint D-Param token and set output with it, mint a governance token.
-	tx_builder.add_mint_one_script_token(policy, d_param_policy_ex_units)?;
+	tx_builder.add_mint_one_script_token(
+		policy,
+		&d_param_redeemer_data(),
+		d_param_policy_ex_units,
+	)?;
 	tx_builder.add_output_with_one_script_token(
 		validator,
 		policy,
@@ -271,8 +276,6 @@ fn mint_d_param_token_tx(
 		gov_policy_ex_units,
 	)?;
 
-	tx_builder.add_script_reference_input(&gov_tx_input, governance_data.policy_script.bytes.len());
-	//tx_builder.add_required_signer(&ctx.payment_key_hash());
 	tx_builder.balance_update_and_build(ctx)
 }
 
@@ -291,6 +294,7 @@ fn update_d_param_tx(
 	inputs.add_script_utxo_input(
 		script_utxo,
 		validator,
+		&d_param_redeemer_data(),
 		ex_units
 			.spend_ex_units
 			.first()
@@ -312,10 +316,13 @@ fn update_d_param_tx(
 		ex_units
 			.mint_ex_units
 			.first()
-			.ok_or_else(|| JsError::from_str("MInt ex units not found"))?,
+			.ok_or_else(|| JsError::from_str("Mint ex units not found"))?,
 	)?;
 
-	tx_builder.add_script_reference_input(&gov_tx_input, governance_data.policy_script.bytes.len());
-	tx_builder.add_required_signer(&ctx.payment_key_hash());
 	tx_builder.balance_update_and_build(ctx)
+}
+
+/// D-param policy accepts any redeemer data.
+fn d_param_redeemer_data() -> PlutusData {
+	PlutusData::new_empty_constr_plutus_data(&BigNum::zero())
 }

--- a/toolkit/offchain/src/register.rs
+++ b/toolkit/offchain/src/register.rs
@@ -1,6 +1,6 @@
 use crate::csl::{
-	get_first_validator_budget, InputsBuilderExt, OgmiosUtxoExt, TransactionBuilderExt,
-	TransactionContext,
+	get_first_validator_budget, unit_plutus_data, InputsBuilderExt, OgmiosUtxoExt,
+	TransactionBuilderExt, TransactionContext,
 };
 use crate::csl::{MainchainPrivateKeyExt, TransactionOutputAmountBuilderExt};
 use crate::{
@@ -314,7 +314,7 @@ fn deregister_tx(
 }
 
 fn register_redeemer_data() -> PlutusData {
-	PlutusData::new_empty_constr_plutus_data(&0u32.into())
+	unit_plutus_data()
 }
 
 #[cfg(test)]

--- a/toolkit/offchain/src/register.rs
+++ b/toolkit/offchain/src/register.rs
@@ -267,6 +267,7 @@ fn register_tx(
 			inputs.add_script_utxo_input(
 				own_registration_utxo,
 				validator,
+				&register_redeemer_data(),
 				&validator_redeemer_ex_units,
 			)?;
 		}
@@ -302,6 +303,7 @@ fn deregister_tx(
 			inputs.add_script_utxo_input(
 				own_registration_utxo,
 				validator,
+				&register_redeemer_data(),
 				&validator_redeemer_ex_units.clone(),
 			)?;
 		}
@@ -309,6 +311,10 @@ fn deregister_tx(
 	}
 
 	tx_builder.balance_update_and_build(ctx)
+}
+
+fn register_redeemer_data() -> PlutusData {
+	PlutusData::new_empty_constr_plutus_data(&0u32.into())
 }
 
 #[cfg(test)]

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -19,16 +19,15 @@ use super::ReserveData;
 use crate::{
 	await_tx::AwaitTx,
 	csl::{
-		empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units, AssetNameExt,
-		MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
-		TransactionOutputAmountBuilderExt,
+		get_builder_config, get_validator_budgets, zero_ex_units, MultiAssetExt, OgmiosUtxoExt,
+		TransactionBuilderExt, TransactionContext, TransactionOutputAmountBuilderExt,
 	},
 	init_governance::{get_governance_data, GovernanceData},
 	scripts_data::ReserveScripts,
 };
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	Assets, ExUnits, JsError, MultiAsset, Transaction, TransactionBuilder, TransactionOutput,
+	ExUnits, JsError, MultiAsset, Transaction, TransactionBuilder, TransactionOutput,
 	TransactionOutputBuilder,
 };
 use ogmios_client::{

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -145,7 +145,6 @@ fn create_reserve_tx(
 		&reserve.validator_version_utxo.to_csl_tx_input(),
 		reserve.scripts.validator.bytes.len(),
 	);
-	tx_builder.add_required_signer(&ctx.payment_key_hash());
 	tx_builder.balance_update_and_build(ctx)
 }
 

--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -19,8 +19,8 @@ use super::{ReserveData, TokenAmount};
 use crate::{
 	await_tx::AwaitTx,
 	csl::{
-		empty_asset_name, get_builder_config, get_validator_budgets, zero_ex_units, MultiAssetExt,
-		OgmiosUtxoExt, OgmiosValueExt, TransactionBuilderExt, TransactionContext,
+		get_builder_config, get_validator_budgets, zero_ex_units, MultiAssetExt, OgmiosUtxoExt,
+		OgmiosValueExt, TransactionBuilderExt, TransactionContext,
 		TransactionOutputAmountBuilderExt,
 	},
 	init_governance::{get_governance_data, GovernanceData},
@@ -28,8 +28,8 @@ use crate::{
 };
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	AssetName, Assets, ExUnits, JsError, Language, MultiAsset, PlutusData, PlutusScriptSource,
-	PlutusWitness, Redeemer, RedeemerTag, Transaction, TransactionBuilder, TransactionOutput,
+	ExUnits, JsError, Language, MultiAsset, PlutusData, PlutusScriptSource, PlutusWitness,
+	Redeemer, RedeemerTag, Transaction, TransactionBuilder, TransactionOutput,
 	TransactionOutputBuilder, TxInputsBuilder,
 };
 use ogmios_client::{

--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -173,7 +173,6 @@ fn deposit_to_reserve_tx(
 		&reserve.illiquid_circulation_supply_validator_version_utxo.to_csl_tx_input(),
 		reserve.scripts.illiquid_circulation_supply_validator.bytes.len(),
 	);
-	tx_builder.add_required_signer(&ctx.payment_key_hash());
 	tx_builder.balance_update_and_build(ctx)
 }
 

--- a/toolkit/offchain/src/reserve/init.rs
+++ b/toolkit/offchain/src/reserve/init.rs
@@ -322,7 +322,7 @@ fn decode_version_oracle_validator_datum(data: PlutusData) -> Option<VersionOrac
 mod tests {
 	use super::{init_script_tx, ScriptData};
 	use crate::{
-		csl::{OgmiosUtxoExt, TransactionContext},
+		csl::{unit_plutus_data, OgmiosUtxoExt, TransactionContext},
 		init_governance::GovernanceData,
 		plutus_script::PlutusScript,
 		scripts_data::{self, VersionOracleData},
@@ -466,7 +466,7 @@ mod tests {
 			.iter()
 			.find(|r| {
 				r.tag() == RedeemerTag::new_mint()
-					&& r.data() == PlutusData::new_empty_constr_plutus_data(&BigNum::zero())
+					&& r.data() == unit_plutus_data()
 					&& r.ex_units() == governance_script_cost()
 			})
 			.expect("Transaction should have a mint redeemer for Governance Policy");

--- a/toolkit/offchain/src/reserve/init.rs
+++ b/toolkit/offchain/src/reserve/init.rs
@@ -216,7 +216,6 @@ fn init_script_tx(
 	)?;
 
 	tx_builder.add_script_reference_input(&gov_tx_input, governance.policy_script.bytes.len());
-	tx_builder.add_required_signer(&ctx.payment_key_hash());
 	tx_builder.balance_update_and_build(ctx)
 }
 

--- a/toolkit/offchain/src/update_governance/mod.rs
+++ b/toolkit/offchain/src/update_governance/mod.rs
@@ -136,7 +136,7 @@ fn update_governance_tx(
 
 	tx_builder.set_inputs(&{
 		let mut inputs = TxInputsBuilder::new();
-		inputs.add_script_utxo_input_with_data(
+		inputs.add_script_utxo_input(
 			&governance_data.utxo,
 			&version_oracle_validator,
 			&PlutusData::new_integer(&(raw_scripts::ScriptId::GovernancePolicy as u32).into()),


### PR DESCRIPTION
# Description

* Merged `add_script_utxo_input` and `add_script_utxo_input_with_data` into one, because  the former assumed too much about redeemer data and is was re-usable only by chance
* `add_mint_one_script_token` - now requires redeemer data to make it really re-usable
* removed redundant `add_required_signer`, because our `balance_update_and_build` does it internally
* removed some redundant `add_script_reference_input`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff



