### PR TITLE
feat: add static build config for MUSL

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,12 @@
 [net]
 git-fetch-with-cli = true
+
+[target.'cfg(target_os = "linux")']
+linker    = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+
+[target.x86_64-unknown-linux-musl]
+rustflags = [
+    "-C", "target-feature=+crt-static",
+    "-C", "relocation-model=static",
+]

--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -19,7 +19,7 @@
       };
   in {
     devShells = {
-      default = pkgs.mkShell {
+      default = pkgs.mkShell.override { stdenv = pkgs.clangStdenv; } {
         # envs needed for rust toochain
         RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
         LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
@@ -28,9 +28,9 @@
         # envs needed in order to construct some of the rust crates
         ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib/";
         OPENSSL_NO_VENDOR = 1;
-        OPENSSL_DIR = "${pkgs.openssl.dev}";
-        OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
-        OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+        OPENSSL_DIR = "${pkgs.pkgsStatic.openssl.dev}";
+        OPENSSL_INCLUDE_DIR = "${pkgs.pkgsStatic.openssl.dev}/include";
+        OPENSSL_LIB_DIR = "${pkgs.pkgsStatic.openssl.out}/lib";
         packages = with pkgs; [
           # core tooling to share across linux/macos
           coreutils
@@ -62,7 +62,7 @@
           if isDarwin
           then
             [ pkgs.darwin.apple_sdk.frameworks.SystemConfiguration ]
-          else [ pkgs.clang ]
+          else [ pkgs.clang pkgs.mold ]
         );
       };
       process-compose = pkgs.mkShell {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -10,5 +10,5 @@ components = [
     "rustc",
     "rustfmt",
 ]
-targets = [ "wasm32-unknown-unknown" ]
+targets = [ "wasm32-unknown-unknown", "x86_64-unknown-linux-musl" ]
 profile = "minimal"


### PR DESCRIPTION
# Description

Currently the node does not build totally statically due to the rocksdb crate. Newer versions of the crate do contain flags to statically compile, though, if we can find a way to update the transitive dependency cleanly.

Everything else is compiled in statically, including the MUSL C standard library

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.