### PR TITLE
chore: cleanup input with script reference for spending Reserve Auth Token, DRY

### DIFF
--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -15,22 +15,20 @@
 //! - Reserve Validator script
 //! - Illiquid Supply Validator script
 
-use super::{ReserveData, TokenAmount};
+use super::{reserve_utxo_input_with_validator_script_reference, ReserveData, TokenAmount};
 use crate::{
 	await_tx::AwaitTx,
 	csl::{
 		get_builder_config, get_validator_budgets, zero_ex_units, MultiAssetExt, OgmiosUtxoExt,
-		OgmiosValueExt, TransactionBuilderExt, TransactionContext,
-		TransactionOutputAmountBuilderExt,
+		TransactionBuilderExt, TransactionContext, TransactionOutputAmountBuilderExt,
 	},
 	init_governance::{get_governance_data, GovernanceData},
 	scripts_data::ReserveScripts,
 };
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	ExUnits, JsError, Language, MultiAsset, PlutusData, PlutusScriptSource, PlutusWitness,
-	Redeemer, RedeemerTag, Transaction, TransactionBuilder, TransactionOutput,
-	TransactionOutputBuilder, TxInputsBuilder,
+	ExUnits, JsError, MultiAsset, PlutusData, Transaction, TransactionBuilder, TransactionOutput,
+	TransactionOutputBuilder,
 };
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
@@ -38,7 +36,7 @@ use ogmios_client::{
 	transactions::{OgmiosEvaluateTransactionResponse, Transactions},
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::reserve::{ReserveDatum, ReserveRedeemer};
+use partner_chains_plutus_data::reserve::ReserveRedeemer;
 use sidechain_domain::{AssetId, McTxHash, UtxoId};
 
 /// Spends current UTXO at validator address and creates a new UTXO with increased token amount
@@ -55,9 +53,7 @@ pub async fn deposit_to_reserve<
 	let ctx = TransactionContext::for_payment_key(payment_key, client).await?;
 	let governance = get_governance_data(genesis_utxo, client).await?;
 	let reserve = ReserveData::get(genesis_utxo, &ctx, client).await?;
-
-	let utxo = get_utxo_with_tokens(&reserve.scripts, &parameters.token, &ctx, client).await?
-		.ok_or_else(||anyhow!("There are no UTXOs in the Reserve Validator address that contain token Reserve Auth Policy Token. Has Reserve been created already?"))?;
+	let utxo = reserve.get_reserve_utxo(&ctx, client).await?.reserve_utxo;
 	let current_amount = get_token_amount(&utxo, &parameters.token);
 	let token_amount =
 		TokenAmount { token: parameters.token, amount: current_amount + parameters.amount };
@@ -73,7 +69,7 @@ pub async fn deposit_to_reserve<
 	)?;
 	let evaluate_response = client.evaluate_transaction(&tx_to_evaluate.to_bytes()).await?;
 
-	let reserve_auth_ex_units = get_auth_policy_script_cost(evaluate_response.clone())?;
+	let spend_ex_units = get_spend_cost(evaluate_response.clone())?;
 	let governance_ex_units = get_governance_script_cost(evaluate_response)?;
 
 	let tx = deposit_to_reserve_tx(
@@ -82,7 +78,7 @@ pub async fn deposit_to_reserve<
 		&reserve,
 		&governance,
 		governance_ex_units,
-		reserve_auth_ex_units,
+		spend_ex_units,
 		&ctx,
 	)?;
 	let signed_tx = ctx.sign(&tx).to_bytes();
@@ -97,33 +93,6 @@ pub async fn deposit_to_reserve<
 	log::info!("Deposit to Reserve transaction submitted: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
 	Ok(McTxHash(tx_id))
-}
-
-async fn get_utxo_with_tokens<T: QueryLedgerState>(
-	scripts: &ReserveScripts,
-	token_id: &AssetId,
-	ctx: &TransactionContext,
-	client: &T,
-) -> Result<Option<OgmiosUtxo>, anyhow::Error> {
-	let validator_address = scripts.validator.address_bech32(ctx.network)?;
-	let utxos = client.query_utxos(&[validator_address.clone()]).await?;
-	Ok(utxos
-		.into_iter()
-		.find(|utxo| {
-			utxo.value.native_tokens.contains_key(&scripts.auth_policy.script_hash())
-				&& utxo.datum.clone().is_some_and(|datum| {
-					decode_reserve_datum(datum).is_some_and(|reserve_datum| {
-						reserve_datum.immutable_settings.token == *token_id
-					})
-				})
-		})
-		.clone())
-}
-
-fn decode_reserve_datum(datum: ogmios_client::types::Datum) -> Option<ReserveDatum> {
-	PlutusData::from_bytes(datum.bytes)
-		.ok()
-		.and_then(|plutus_data| ReserveDatum::try_from(plutus_data).ok())
 }
 
 fn get_token_amount(utxo: &OgmiosUtxo, token: &AssetId) -> u64 {
@@ -144,25 +113,23 @@ fn deposit_to_reserve_tx(
 	reserve: &ReserveData,
 	governance: &GovernanceData,
 	governance_script_cost: ExUnits,
-	reserve_auth_script_cost: ExUnits,
+	spend_reserve_auth_token_cost: ExUnits,
 	ctx: &TransactionContext,
 ) -> Result<Transaction, JsError> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 
 	tx_builder.add_output(&validator_output(parameters, current_utxo, &reserve.scripts, ctx)?)?;
 
-	let inputs = input_with_script_reference(
-		current_utxo,
-		reserve,
+	tx_builder.set_inputs(&reserve_utxo_input_with_validator_script_reference(
+		&current_utxo,
+		&reserve,
 		ReserveRedeemer::DepositToReserve { governance_version: 1 },
-		reserve_auth_script_cost,
-	)?;
-	tx_builder.set_inputs(&inputs);
+		&spend_reserve_auth_token_cost,
+	)?);
 
-	let gov_tx_input = governance.utxo_id_as_tx_input();
 	tx_builder.add_mint_one_script_token_using_reference_script(
 		&governance.policy_script,
-		&gov_tx_input,
+		&governance.utxo_id_as_tx_input(),
 		&governance_script_cost,
 	)?;
 
@@ -171,37 +138,10 @@ fn deposit_to_reserve_tx(
 		reserve.scripts.auth_policy.bytes.len(),
 	);
 	tx_builder.add_script_reference_input(
-		&reserve.validator_version_utxo.to_csl_tx_input(),
-		reserve.scripts.validator.bytes.len(),
-	);
-	tx_builder.add_script_reference_input(
 		&reserve.illiquid_circulation_supply_validator_version_utxo.to_csl_tx_input(),
 		reserve.scripts.illiquid_circulation_supply_validator.bytes.len(),
 	);
 	tx_builder.balance_update_and_build(ctx)
-}
-
-pub(crate) fn input_with_script_reference(
-	consumed_utxo: &OgmiosUtxo,
-	reserve: &ReserveData,
-	redeemer: ReserveRedeemer,
-	cost: ExUnits,
-) -> Result<TxInputsBuilder, JsError> {
-	let mut inputs = TxInputsBuilder::new();
-	let input = consumed_utxo.to_csl_tx_input();
-	let amount = consumed_utxo.value.to_csl()?;
-	let script = &reserve.scripts.auth_policy;
-	let witness = PlutusWitness::new_with_ref_without_datum(
-		&PlutusScriptSource::new_ref_input(
-			&script.csl_script_hash(),
-			&input,
-			&Language::new_plutus_v2(),
-			script.bytes.len(),
-		),
-		&Redeemer::new(&RedeemerTag::new_spend(), &0u32.into(), &redeemer.into(), &cost),
-	);
-	inputs.add_plutus_script_input(&witness, &input, &amount);
-	Ok(inputs)
 }
 
 // governance token is the only minted token
@@ -216,7 +156,7 @@ fn get_governance_script_cost(
 }
 
 // Auth policy token is the only spent token is the transaction
-fn get_auth_policy_script_cost(
+fn get_spend_cost(
 	response: Vec<OgmiosEvaluateTransactionResponse>,
 ) -> Result<ExUnits, anyhow::Error> {
 	Ok(get_validator_budgets(response)

--- a/toolkit/offchain/src/reserve/mod.rs
+++ b/toolkit/offchain/src/reserve/mod.rs
@@ -1,9 +1,14 @@
 //! All smart-contracts related to Rewards Token Reserve Management
 
-use crate::csl::OgmiosUtxoExt;
-use crate::{csl::TransactionContext, scripts_data};
+use crate::{
+	csl::{OgmiosUtxoExt, OgmiosValueExt, TransactionContext},
+	scripts_data,
+};
 use anyhow::anyhow;
-use cardano_serialization_lib::PlutusData;
+use cardano_serialization_lib::{
+	ExUnits, JsError, PlutusData, PlutusScriptSource, PlutusWitness, Redeemer, RedeemerTag,
+	TxInputsBuilder,
+};
 use init::find_script_utxo;
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
@@ -11,7 +16,7 @@ use ogmios_client::{
 	transactions::Transactions,
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::reserve::ReserveDatum;
+use partner_chains_plutus_data::reserve::{ReserveDatum, ReserveRedeemer};
 use sidechain_domain::{AssetId, AssetName, UtxoId};
 
 pub mod create;
@@ -96,7 +101,7 @@ impl ReserveData {
 
 		let auth_token_asset_id = AssetId {
 			policy_id: self.scripts.auth_policy.policy_id(),
-			asset_name: AssetName::from_hex_unsafe(""),
+			asset_name: AssetName::empty(),
 		};
 
 		let (reserve_utxo, reserve_settings) = validator_utxos
@@ -122,4 +127,27 @@ impl ReserveData {
 pub struct TokenAmount {
 	pub token: AssetId,
 	pub amount: u64,
+}
+
+pub(crate) fn reserve_utxo_input_with_validator_script_reference(
+	reserve_utxo: &OgmiosUtxo,
+	reserve: &ReserveData,
+	redeemer: ReserveRedeemer,
+	cost: &ExUnits,
+) -> Result<TxInputsBuilder, JsError> {
+	let mut inputs = TxInputsBuilder::new();
+	let input = reserve_utxo.to_csl_tx_input();
+	let amount = reserve_utxo.value.to_csl()?;
+	let script = &reserve.scripts.validator;
+	let witness = PlutusWitness::new_with_ref_without_datum(
+		&PlutusScriptSource::new_ref_input(
+			&script.csl_script_hash(),
+			&reserve.validator_version_utxo.to_csl_tx_input(),
+			&script.language,
+			script.bytes.len(),
+		),
+		&Redeemer::new(&RedeemerTag::new_spend(), &0u32.into(), &redeemer.into(), cost),
+	);
+	inputs.add_plutus_script_input(&witness, &input, &amount);
+	Ok(inputs)
 }

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -19,7 +19,7 @@
 //!       including the ones released in this transaction*. Ie. if N tokens were already released
 //!       and M tokens are being released, the transaction should mint N+M V-Function tokens.
 //!       These tokens are worthless and don't serve any purpose after the transaction is done.
-use super::{deposit::input_with_script_reference, ReserveData, TokenAmount};
+use super::{reserve_utxo_input_with_validator_script_reference, ReserveData, TokenAmount};
 use crate::{await_tx::AwaitTx, csl::*, plutus_script::PlutusScript, reserve::ReserveUtxo};
 use anyhow::anyhow;
 use cardano_serialization_lib::{
@@ -133,10 +133,6 @@ fn reserve_release_tx(
 		reserve_data.scripts.auth_policy.bytes.len(),
 	);
 	tx_builder.add_script_reference_input(
-		&reserve_data.validator_version_utxo.to_csl_tx_input(),
-		reserve_data.scripts.validator.bytes.len(),
-	);
-	tx_builder.add_script_reference_input(
 		&reserve_data
 			.illiquid_circulation_supply_validator_version_utxo
 			.to_csl_tx_input(),
@@ -153,11 +149,11 @@ fn reserve_release_tx(
 	)?;
 
 	// Remove tokens from the reserve
-	tx_builder.set_inputs(&input_with_script_reference(
+	tx_builder.set_inputs(&reserve_utxo_input_with_validator_script_reference(
 		&previous_reserve_utxo,
 		&reserve_data,
 		ReserveRedeemer::ReleaseFromReserve,
-		reserve_auth_script_cost,
+		&reserve_auth_script_cost,
 	)?);
 
 	// Transfer released tokens to the illiquid supply


### PR DESCRIPTION
# Description

* Four transactions that spend a Reserve Auth Token now use the same function from crate mod.rs
* DRY in deposit, regarding getting current data

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

