### PR TITLE
ETCM-9222 generic ExUnit calculation in reserve modules

### DIFF
--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -121,9 +121,9 @@ fn deposit_to_reserve_tx(
 	tx_builder.add_output(&validator_output(parameters, current_utxo, &reserve.scripts, ctx)?)?;
 
 	tx_builder.set_inputs(&reserve_utxo_input_with_validator_script_reference(
-		&current_utxo,
-		&reserve,
-		ReserveRedeemer::DepositToReserve { governance_version: 1 },
+		current_utxo,
+		reserve,
+		ReserveRedeemer::DepositToReserve,
 		&spend_reserve_auth_token_cost,
 	)?);
 

--- a/toolkit/offchain/src/reserve/handover.rs
+++ b/toolkit/offchain/src/reserve/handover.rs
@@ -91,7 +91,7 @@ fn build_tx(
 	governance: &GovernanceData,
 	costs: Costs,
 	ctx: &TransactionContext,
-) -> Result<Transaction, JsError> {
+) -> anyhow::Result<Transaction> {
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 
 	let reserve_auth_policy_spend_cost = costs.get_one_spend();
@@ -130,7 +130,7 @@ fn build_tx(
 		&reserve.illiquid_circulation_supply_validator_version_utxo.to_csl_tx_input(),
 		reserve.scripts.illiquid_circulation_supply_validator.bytes.len(),
 	);
-	tx_builder.balance_update_and_build(ctx)
+	Ok(tx_builder.balance_update_and_build(ctx)?)
 }
 
 // Creates output with reserve token and updated deposit

--- a/toolkit/offchain/src/reserve/handover.rs
+++ b/toolkit/offchain/src/reserve/handover.rs
@@ -109,7 +109,7 @@ fn build_tx(
 	tx_builder.set_inputs(&reserve_utxo_input_with_validator_script_reference(
 		reserve_utxo,
 		reserve,
-		ReserveRedeemer::Handover { governance_version: 1 },
+		ReserveRedeemer::Handover,
 		&reserve_auth_policy_spend_cost,
 	)?);
 

--- a/toolkit/offchain/src/reserve/update_settings.rs
+++ b/toolkit/offchain/src/reserve/update_settings.rs
@@ -129,10 +129,10 @@ fn update_reserve_settings_tx(
 
 	// spend old settings
 	tx_builder.set_inputs(&reserve_utxo_input_with_validator_script_reference(
-		&reserve_utxo,
-		&reserve,
-		ReserveRedeemer::UpdateReserve { governance_version: 1u64 },
-		&reserve_script_cost,
+		reserve_utxo,
+		reserve,
+		ReserveRedeemer::UpdateReserve,
+		reserve_script_cost,
 	)?);
 	{
 		let amount_builder = TransactionOutputBuilder::new()

--- a/toolkit/primitives/plutus-data/src/reserve.rs
+++ b/toolkit/primitives/plutus-data/src/reserve.rs
@@ -7,10 +7,10 @@ use sidechain_domain::{AssetId, AssetName, PolicyId};
 
 #[derive(Debug, Clone)]
 pub enum ReserveRedeemer {
-	DepositToReserve { governance_version: u64 },
-	ReleaseFromReserve,
-	UpdateReserve { governance_version: u64 },
-	Handover { governance_version: u64 },
+	DepositToReserve = 0,
+	ReleaseFromReserve = 1,
+	UpdateReserve = 2,
+	Handover = 3,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -38,26 +38,7 @@ pub struct ReserveStats {
 
 impl From<ReserveRedeemer> for PlutusData {
 	fn from(value: ReserveRedeemer) -> Self {
-		use ReserveRedeemer::*;
-		match value {
-			DepositToReserve { governance_version } => {
-				PlutusData::new_single_value_constr_plutus_data(
-					&BigNum::from(0_u64),
-					&PlutusData::new_integer(&BigInt::from(governance_version)),
-				)
-			},
-			ReleaseFromReserve => PlutusData::new_empty_constr_plutus_data(&BigNum::from(1_u64)),
-			UpdateReserve { governance_version } => {
-				PlutusData::new_single_value_constr_plutus_data(
-					&BigNum::from(2_u64),
-					&PlutusData::new_integer(&BigInt::from(governance_version)),
-				)
-			},
-			Handover { governance_version } => PlutusData::new_single_value_constr_plutus_data(
-				&BigNum::from(3_u64),
-				&PlutusData::new_integer(&BigInt::from(governance_version)),
-			),
-		}
+		PlutusData::new_empty_constr_plutus_data(&BigNum::from(value as u64))
 	}
 }
 


### PR DESCRIPTION
# Description

* Use Cost::calculate_costs in reserve module
* Remove unused parameters from ReserveRedeemer. These arguments were removed from the Plutus smart contracts a while ago, but the change was not reflected in the purescript code which was reimplemented in rust. The way PlutusData encoding works, superfluous fields can be ignored while decoding, so this didn't cause an issue and went unnoticed.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

