### PR TITLE
feat: make 'wizards' subcommand of node

### DIFF
--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -17,18 +17,15 @@ runs:
     - name: Checkout
       uses: actions/checkout@v4
       with:
-        ref: ${{ inputs.sha }} 
+        ref: ${{ inputs.sha }}
     - name: Set filename variables
       shell: bash
       run: |
         if [[ "${{ inputs.os }}" == "linux" ]]; then
-          echo "PARTNER_CHAINS_CLI=partner-chains-cli-${{ inputs.tag }}-x86_64-linux" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-x86_64-linux" >> $GITHUB_ENV
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
-          echo "PARTNER_CHAINS_CLI=partner-chains-cli-${{ inputs.tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
-          echo "PARTNER_CHAINS_CLI=partner-chains-cli-${{ inputs.tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
         fi
 
@@ -68,33 +65,6 @@ runs:
           cp target/aarch64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         fi
-
-    - name: Build partner-chains-cli
-      shell: bash
-      run: |
-        cd $GITHUB_WORKSPACE
-        if [[ "${{ inputs.os }}" == "linux" ]]; then
-          rustup target add x86_64-unknown-linux-gnu
-          cargo build -p partner-chains-cli --locked --release --target x86_64-unknown-linux-gnu
-          cp target/x86_64-unknown-linux-gnu/release/partner-chains-cli $PARTNER_CHAINS_CLI
-          chmod +x $PARTNER_CHAINS_CLI
-        elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
-          rustup target add x86_64-apple-darwin
-          cargo build -p partner-chains-cli --locked --release --target x86_64-apple-darwin
-          cp target/x86_64-apple-darwin/release/partner-chains-cli $PARTNER_CHAINS_CLI
-          chmod +x $PARTNER_CHAINS_CLI
-        elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
-          rustup target add aarch64-apple-darwin
-          cargo build -p partner-chains-cli --locked --release --target aarch64-apple-darwin
-          cp target/aarch64-apple-darwin/release/partner-chains-cli $PARTNER_CHAINS_CLI
-          chmod +x $PARTNER_CHAINS_CLI
-        fi
-
-    - name: Upload partner-chains-cli artifact
-      uses: actions/upload-artifact@v4
-      with:
-        name: partner-chains-cli-${{ inputs.os }}-artifact
-        path: ${{ env.PARTNER_CHAINS_CLI }}
 
     - name: Upload partner-chains-node artifact
       uses: actions/upload-artifact@v4

--- a/.github/actions/release/create-draft-release/action.yml
+++ b/.github/actions/release/create-draft-release/action.yml
@@ -13,19 +13,10 @@ runs:
     - name: Set filename variables
       id: set-filenames
       run: |
-        echo "PARTNER_CHAINS_CLI_X86_64_LINUX=partner-chains-cli-${{ inputs.tag }}-x86_64-linux" >> $GITHUB_ENV
         echo "PARTNER_CHAINS_NODE_X86_64_LINUX=partner-chains-node-${{ inputs.tag }}-x86_64-linux" >> $GITHUB_ENV
-        echo "PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN=partner-chains-cli-${{ inputs.tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
         echo "PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN=partner-chains-node-${{ inputs.tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
-        echo "PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN=partner-chains-cli-${{ inputs.tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
         echo "PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN=partner-chains-node-${{ inputs.tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
       shell: bash
-
-    - name: Download partner-chains-cli-linux-artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: partner-chains-cli-linux-artifact
-        path: artifact-linux/
 
     - name: Download partner-chains-node-linux-artifact
       uses: actions/download-artifact@v4
@@ -33,23 +24,11 @@ runs:
         name: partner-chains-node-linux-artifact
         path: artifact-linux/
 
-    - name: Download partner-chains-cli-macos-x86_64-artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: partner-chains-cli-macos-x86_64-artifact
-        path: artifact-macos-x86_64/
-
     - name: Download partner-chains-node-macos-x86_64-artifact
       uses: actions/download-artifact@v4
       with:
         name: partner-chains-node-macos-x86_64-artifact
         path: artifact-macos-x86_64/
-
-    - name: Download partner-chains-cli-macos-arm64-artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: partner-chains-cli-macos-arm64-artifact
-        path: artifact-macos-arm64/
 
     - name: Download partner-chains-node-macos-arm64-artifact
       uses: actions/download-artifact@v4
@@ -81,39 +60,39 @@ runs:
         tag="${{ inputs.tag }}"
         changelog_file="changelog.md"
         section_names="Changed|Added"
-    
+
         # Extract the "Changed" and "Added" sections from changelog.md for the given tag
         release_notes=$(awk -v tag="$tag" -v sections="$section_names" 'BEGIN{in_tag=0;in_section=0;section_regex="^## ("sections")$";}/^# /{if($0=="# "tag){in_tag=1;next;}else if(in_tag){exit;}}/^## /{if(in_tag&&match($0,section_regex)){in_section=1;print $0;next;}else if(in_tag){in_section=0;}}{if(in_section&&in_tag)print $0;}' "$changelog_file")
-    
+
         # Escape special characters for GitHub Actions output
         release_notes="${release_notes//'%'/'%25'}"
         release_notes="${release_notes//$'\n'/'%0A'}"
         release_notes="${release_notes//$'\r'/'%0D'}"
-    
+
         echo "::set-output name=release_notes::$release_notes"
       shell: bash
-    
+
     - name: Create draft release
       id: create_release
       if: ${{ steps.check_release.outputs.release_exists == 'false' }}
       run: |
         tag="${{ inputs.tag }}"
-    
+
         release_body="### Pre-release candidate for version $tag\n\n"
         release_body+="This is a draft pre-release candidate for release $tag that is undergoing testing. The current testing status is:\n\n"
         release_body+="- [x] Local environment\n"
         release_body+="- [ ] Staging preview environment\n"
         release_body+="- [ ] Staging preprod environment\n\n"
         release_body+="Please note: this release is not yet fully verified and is pending further testing.\n"
-    
+
         release_response=$(curl -s -X POST -H "Authorization: token ${{ env.GITHUB_TOKEN }}" \
                           -d '{"tag_name": "'$tag'", "name": "'$tag'", "body": "'"$release_body"'", "draft": true, "generate_release_notes": true, "prerelease": true}' \
                           "https://api.github.com/repos/${{ github.repository }}/releases")
-        
+
         echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
         echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
       shell: bash
-    
+
     - name: Upload artifacts to release
       if: ${{ steps.check_release.outputs.release_exists == 'true' || steps.create_release.outputs.release_id != '' }}
       run: |
@@ -139,4 +118,3 @@ runs:
             "https://uploads.github.com/repos/${{ github.repository }}/releases/$release_id/assets?name=$(basename $artifact)"
         done
       shell: bash
-

--- a/.github/actions/tests/local-environment-tests/action.yml
+++ b/.github/actions/tests/local-environment-tests/action.yml
@@ -32,11 +32,6 @@ runs:
       uses: docker/login-action@v3
       with:
         registry: ${{ env.ECR_REGISTRY_SECRET }}
-    - name: Download partner-chains-cli artifact
-      uses: actions/download-artifact@v4
-      with:
-        name: partner-chains-cli-artifact
-        path: dev/local-environment/configurations/pc-contracts-cli/overrides/
     - name: Download partner-chains-node artifact
       uses: actions/download-artifact@v4
       with:
@@ -44,7 +39,6 @@ runs:
         path: dev/local-environment/configurations/pc-contracts-cli/overrides/
     - name: Deploy local environment with overrides
       run: |
-        mv dev/local-environment/configurations/pc-contracts-cli/overrides/partner-chains-cli-artifact dev/local-environment/configurations/pc-contracts-cli/overrides/partner-chains-cli
         mv dev/local-environment/configurations/pc-contracts-cli/overrides/partner-chains-node-artifact dev/local-environment/configurations/pc-contracts-cli/overrides/partner-chains-node
         mkdir -p dev/local-environment/configurations/tests/e2e-tests
         cp -r E2E-tests/* dev/local-environment/configurations/tests/e2e-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,11 +51,6 @@ jobs:
           EARTHLY_PUSH: true
         run: |
           earthly -P +ci --image=${{ secrets.ECR_REGISTRY_SECRET }}/substrate-node
-      - name: Upload partner-chains-cli artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: partner-chains-cli-artifact
-          path: partner-chains-cli-artifact
       - name: Upload partner-chains-node artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - name: Set filename variables
         id: set-filenames
         run: |
-          echo "PARTNER_CHAINS_CLI_X86_64_LINUX=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-x86_64-linux" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_X86_64_LINUX=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-x86_64-linux" >> $GITHUB_ENV
 
       - name: Checkout code
@@ -38,19 +37,6 @@ jobs:
           cp target/x86_64-unknown-linux-gnu/release/partner-chains-node $PARTNER_CHAINS_NODE_X86_64_LINUX
           chmod +x $PARTNER_CHAINS_NODE_X86_64_LINUX
 
-      - name: Build partner-chains-cli
-        run: |
-          rustup target add x86_64-unknown-linux-gnu
-          cargo build -p partner-chains-cli --locked --release --target x86_64-unknown-linux-gnu
-          cp target/x86_64-unknown-linux-gnu/release/partner-chains-cli $PARTNER_CHAINS_CLI_X86_64_LINUX
-          chmod +x $PARTNER_CHAINS_CLI_X86_64_LINUX
-
-      - name: Upload partner-chains-cli-x86_64-linux
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.PARTNER_CHAINS_CLI_X86_64_LINUX }}
-          path: ${{ env.PARTNER_CHAINS_CLI_X86_64_LINUX }}
-
       - name: Upload partner-chains-node-x86_64-linux
         uses: actions/upload-artifact@v4
         with:
@@ -63,7 +49,6 @@ jobs:
       - name: Set filename variables
         id: set-filenames
         run: |
-          echo "PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
 
       - name: Checkout code
@@ -84,19 +69,6 @@ jobs:
           cp target/x86_64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN
           chmod +x $PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN
 
-      - name: Build partner-chains-cli
-        run: |
-          rustup target add x86_64-apple-darwin
-          cargo build -p partner-chains-cli --locked --release --target x86_64-apple-darwin
-          cp target/x86_64-apple-darwin/release/partner-chains-cli $PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN
-          chmod +x $PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN
-
-      - name: Upload partner-chains-cli-x86_64-apple-darwin
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN }}
-          path: ${{ env.PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN }}
-
       - name: Upload partner-chains-node-x86_64-apple-darwin
         uses: actions/upload-artifact@v4
         with:
@@ -109,7 +81,6 @@ jobs:
       - name: Set filename variables
         id: set-filenames
         run: |
-          echo "PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
 
       - name: Checkout code
@@ -130,25 +101,12 @@ jobs:
           cp target/aarch64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN
           chmod +x $PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN
 
-      - name: Build partner-chains-cli
-        run: |
-          rustup target add aarch64-apple-darwin
-          cargo build -p partner-chains-cli --locked --release --target aarch64-apple-darwin
-          cp target/aarch64-apple-darwin/release/partner-chains-cli $PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN
-          chmod +x $PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN
-
-      - name: Upload partner-chains-cli-aarch64-apple-darwin
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ env.PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN }}
-          path: ${{ env.PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN }}
-
       - name: Upload partner-chains-node-aarch64-apple-darwin
         uses: actions/upload-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN }}
           path: ${{ env.PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN }}
-  
+
   release:
     runs-on: ubuntu-latest
     needs: [partner-chains-linux, partner-chains-macos-x86_64, partner-chains-macos-arm64]
@@ -157,49 +115,46 @@ jobs:
       - name: Set filename variables
         id: set-filenames
         run: |
-          echo "PARTNER_CHAINS_CLI_X86_64_LINUX=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-x86_64-linux" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_X86_64_LINUX=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-x86_64-linux" >> $GITHUB_ENV
-          echo "PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
-          echo "PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN=partner-chains-cli-${{ github.event.inputs.partner-chains-tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
           echo "PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN=partner-chains-node-${{ github.event.inputs.partner-chains-tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
-  
+
       - name: Download Linux CLI artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_CLI_X86_64_LINUX }}
           path: artifact-linux/
-  
+
       - name: Download Linux NODE artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_NODE_X86_64_LINUX }}
           path: artifact-linux/
-  
+
       - name: Download macOS x86_64 CLI artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN }}
           path: artifact-macos-x86_64/
-  
+
       - name: Download macOS x86_64 NODE artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_NODE_X86_64_APPLE_DARWIN }}
           path: artifact-macos-x86_64/
-  
+
       - name: Download macOS ARM64 CLI artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_CLI_AARCH64_APPLE_DARWIN }}
           path: artifact-macos-arm64/
-  
+
       - name: Download macOS ARM64 NODE artifact
         uses: actions/download-artifact@v4
         with:
           name: ${{ env.PARTNER_CHAINS_NODE_AARCH64_APPLE_DARWIN }}
           path: artifact-macos-arm64/
-  
+
       - name: Check if release already exists
         id: check_release
         run: |
@@ -215,7 +170,7 @@ jobs:
             echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
             echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
           fi
-  
+
       - name: Create draft release
         id: create_release
         if: ${{ steps.check_release.outputs.release_exists == 'false' }}
@@ -226,7 +181,7 @@ jobs:
                             "https://api.github.com/repos/${{ github.repository }}/releases")
           echo "release_id=$(echo $release_response | jq -r .id)" >> $GITHUB_ENV
           echo "::set-output name=release_id::$(echo $release_response | jq -r .id)"
-  
+
       - name: Upload artifacts to release
         if: ${{ steps.check_release.outputs.release_exists == 'true' || steps.create_release.outputs.release_id != '' }}
         run: |
@@ -234,7 +189,7 @@ jobs:
           if [ -z "$release_id" ]; then
             release_id="${{ steps.check_release.outputs.release_id }}"
           fi
-  
+
           for artifact in "artifact-linux/${{ env.PARTNER_CHAINS_CLI_X86_64_LINUX }}" \
                           "artifact-linux/${{ env.PARTNER_CHAINS_NODE_X86_64_LINUX }}" \
                           "artifact-macos-x86_64/${{ env.PARTNER_CHAINS_CLI_X86_64_APPLE_DARWIN }}" \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6728,6 +6728,7 @@ dependencies = [
  "log",
  "log4rs",
  "parity-scale-codec",
+ "partner-chains-cli",
  "partner-chains-smart-contracts-commands",
  "plutus",
  "sc-cli",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6621,7 +6621,6 @@ dependencies = [
  "inquire",
  "libp2p-identity",
  "log",
- "log4rs",
  "ogmios-client",
  "partner-chains-cardano-offchain",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,5 +222,6 @@ sp-partner-chains-consensus-aura = { path = "toolkit/primitives/consensus/aura",
 pallet-partner-chains-session = { path = "toolkit/pallets/partner-chains-session", default-features = false }
 pallet-session-runtime-stub = { path = "toolkit/pallets/pallet-session-runtime-stub", default-features = false }
 partner-chains-cardano-offchain = { path = "toolkit/offchain", default-features = false }
+partner-chains-cli = { path = "toolkit/partner-chains-cli", default-features = false }
 partner-chains-plutus-data = { path = "toolkit/primitives/plutus-data", default-features = false }
 partner-chains-smart-contracts-commands = { path = "toolkit/cli/smart-contracts-commands", default-features = false }

--- a/Earthfile
+++ b/Earthfile
@@ -48,7 +48,6 @@ build:
   RUN cargo build --locked --profile=$PROFILE --features=$FEATURES
   SAVE ARTIFACT target/*/partner-chains-node AS LOCAL partner-chains-node
   SAVE ARTIFACT target/*/partner-chains-node AS LOCAL partner-chains-node-artifact
-  SAVE ARTIFACT target/*/partner-chains-cli AS LOCAL partner-chains-cli-artifact
 
 test:
   FROM +build

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ cargo build --profile=production
 
 ### Downloads
 
-Please see the [releases page](https://github.com/input-output-hk/partner-chains/releases) for the latest downloadable binaries and Docker images of the `partner-chains-node` and `partner-chains-cli`.
+Please see the [releases page](https://github.com/input-output-hk/partner-chains/releases) for the latest downloadable binaries and Docker images of the `partner-chains-node`.
 
 ### Docker Image
 
@@ -45,8 +45,8 @@ Refer to the [documentation](docs/user-guides) for detailed instructions on how 
 
 ### Block Production Rewards for Validators
 
-The Partner Chains node provides a simple mechanism for exposing the mapping of block beneficiaries with produced blocks. 
-The chain builder is responsible for using this input to accurately calculate and distribute block rewards on their partner chain, following the tokenomics they will design and implement. 
+The Partner Chains node provides a simple mechanism for exposing the mapping of block beneficiaries with produced blocks.
+The chain builder is responsible for using this input to accurately calculate and distribute block rewards on their partner chain, following the tokenomics they will design and implement.
 For managing payouts, they will leverage the provided artifacts to distribute payments to validators on the partner chain ledger, applying their specific business logic.
 
 | Component | Description |
@@ -58,7 +58,7 @@ For managing payouts, they will leverage the provided artifacts to distribute pa
 
 #### For Partner Chains Node Operators
 
-1. Implement a reward distribution system using the block production data provided by the Partner Chains node. 
+1. Implement a reward distribution system using the block production data provided by the Partner Chains node.
 2. Set up and manage the required smart contracts on Cardano.
 3. Automate the reward calculation and distribution process within the consensus layer.
 4. Establish a registration process for validators.
@@ -71,7 +71,7 @@ For managing payouts, they will leverage the provided artifacts to distribute pa
 #### More Details
 
 1. Block Production Tracking: The Partner Chain node logs block production data. Each block has a beneficiary, identified by Partner Chain receiving addresses (such as `SizedByteStrings(0x1)`, `SizedByteStrings(0x2)`, etc.). At the end of each Partner Chain epoch, the node summarizes who produced how many blocks.
-2. Smart Contract Implementation: Two main smart contracts are involved: 
+2. Smart Contract Implementation: Two main smart contracts are involved:
 
 	a. Permissioned candidates contract: Lists approved validators with their public keys.
 

--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,11 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * smart-contracts commands and offchain tests now use WebSockets implementation of Ogmios client
 * Updated to polkadot-stable2409-3 (aka v1.16.3).
 * `local-environment` now uses the `partner-chains-node` based container for the smart-contracts setup.
+* `partner-chains-cli` separate binary is transformed to a library crated and integreted in `partner-chains-node-commands` library crate.
+Every invocation of `partner-chains-cli` should be replaced with `<node> wizards` subcommand of the node built with Partner Chains SDK.
+The only other change is that "node executable path" configuration is not present in `partner-chains-cli-resources.json` anymore, because it is not needed anymore.
+Code will always invoke "self" executable instead.
+Since this change, all functionality of Partner Chains is available in the one executable of the node.
 
 ## Removed
 

--- a/dev/local-environment/README.md
+++ b/dev/local-environment/README.md
@@ -64,7 +64,6 @@ Alternatively artifact URLs can be overriden from local files with the `--overri
 
 ```
 cd dev/local-environment
-cp /path/to/artifact ./configurations/pc-contracts-cli/overrides/partner-chains-cli
 cp /path/to/artifact ./configurations/pc-contracts-cli/overrides/partner-chains-node
 bash setup.sh --non-interactive --overrides --node-image ${{ inputs.image }}
 ```

--- a/dev/local-environment/configurations/pc-contracts-cli/entrypoint.sh
+++ b/dev/local-environment/configurations/pc-contracts-cli/entrypoint.sh
@@ -2,7 +2,6 @@
 
 # Initialize flags
 PC_NODE_READY=0
-PC_CLI_READY=0
 PC_CONTRACTS_CLI_READY=0
 
 if [ "$ARTIFACT_OVERRIDE" == "yes" ]; then
@@ -24,13 +23,6 @@ if [ "$ARTIFACT_OVERRIDE" == "yes" ]; then
     PC_NODE_READY=1
   fi
 
-  if [ -f "/overrides/partner-chains-cli" ]; then
-    echo "partner-chains-cli found in /overrides/. Using local artifact."
-    cp /overrides/partner-chains-cli ./partner-chains-cli
-    echo "partner-chains-cli copied."
-    PC_CLI_READY=1
-  fi
-
 else
   echo "Artifact override is not enabled. Defaulting to downloading all artifacts..."
 fi
@@ -47,14 +39,9 @@ if [ "$PC_NODE_READY" -eq 0 ]; then
   wget -q -O ./partner-chains-node "$PARTNER_CHAINS_NODE_URL"
 fi
 
-if [ "$PC_CLI_READY" -eq 0 ]; then
-  echo "Downloading partner-chains-cli..."
-  wget -q -O ./partner-chains-cli "$PARTNER_CHAINS_CLI_URL"
-fi
 
 # Set executable permissions
 chmod +x ./partner-chains-node
-chmod +x ./partner-chains-cli
 chmod +x ./pc-contracts-cli
 
 # Install jq

--- a/dev/local-environment/setup.sh
+++ b/dev/local-environment/setup.sh
@@ -10,7 +10,6 @@ SIDECHAIN_MAIN_CLI_IMAGE="node:22-bookworm"
 TESTS_IMAGE="python:3.10-slim"
 PC_CONTRACTS_CLI_ZIP_URL="https://github.com/input-output-hk/partner-chains-smart-contracts/releases/download/v7.0.2/pc-contracts-cli-v7.0.2.zip"
 PARTNER_CHAINS_NODE_URL="https://github.com/input-output-hk/partner-chains/releases/download/v1.3.0/partner-chains-node-v1.3.0-x86_64-linux"
-PARTNER_CHAINS_CLI_URL="https://github.com/input-output-hk/partner-chains/releases/download/v1.3.0/partner-chains-cli-v1.3.0-x86_64-linux"
 
 display_banner() {
   cat <<'EOF'
@@ -166,8 +165,6 @@ configure_artifact_overrides() {
                 echo -e "./configurations/pc-contracts-cli/overrides/pc-contracts-cli and ./configurations/pc-contracts-cli/overrides/node_modules \n"
                 echo "To override the partner-chains-node artifact, copy artifact to path:"
                 echo -e "./configurations/pc-contracts-cli/overrides/partner-chains-node \n"
-                echo "To override the partner-chains-cli artifact, copy artifact to path:"
-                echo -e "./configurations/pc-contracts-cli/overrides/partner-chains-cli \n"
             else
                 echo -e "Artifact overrides disabled. Stable versions will be automatically downloaded within the container from Github Releases. \n"
             fi
@@ -199,13 +196,6 @@ configure_artifact_overrides() {
             echo -e "partner-chains-node found. Override enabled. \n"
         else
             echo -e "partner-chains-node not found. Override disabled for partner-chains-node. \n"
-        fi
-
-        # Check for partner-chains-cli artifact
-        if [ -f "./configurations/pc-contracts-cli/overrides/partner-chains-cli" ]; then
-            echo -e "partner-chains-cli found. Override enabled. \n"
-        else
-            echo -e "partner-chains-cli not found. Override disabled for partner-chains-cli. \n"
         fi
     fi
 }

--- a/docs/user-guides/chain-builder.md
+++ b/docs/user-guides/chain-builder.md
@@ -250,7 +250,7 @@ The generate-keys wizard will generate necessary keys and save them to your node
 
 If these keys already exist in the node’s keystore, you will be asked to overwrite existing keys. The wizard will also generate a network key for your node if needed.
 
-1. Start the wizard: `./partner-chains-cli generate-keys`
+1. Start the wizard: `./partner-chains-node wizards generate-keys`
 2. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`.
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys:
@@ -267,7 +267,7 @@ Now the wizard will output `partner-chains-public-keys.json` containing three ke
 
 Before running this wizard, be sure that `ogmios` is available by host and port.
 
-1. Start the wizard:`./partner-chains-cli prepare-configuration`
+1. Start the wizard:`./partner-chains-node wizards prepare-configuration`
 2. Update the bootnodes array and provide public ip or hostname
 3. Provide required payment keys and select genesis utxo to initialize the chain
 4. Configure initial native token supply address (optional)
@@ -354,7 +354,7 @@ A sample file:
 
 The wizard reads the file `partner-chains-cli-chain-config.json`. This file should be present and identical for every node participating in the chain.
 
-1. Start the wizard: `./partner-chains-cli create-chain-spec`
+1. Start the wizard: `./partner-chains-node wizards create-chain-spec`
 
 The wizard displays the contents of `chain_parameters` and `initial_permissioned_candidates` from the `partner-chains-cli-chain-config.json` file. You can manually modify these values before running this wizard.
 
@@ -364,7 +364,7 @@ The wizard informs you of the full path to the `chain-spec.json` file. You can n
 
 ### 5. Run the setup-main-chain-state wizard
 
-1. Start the wizard: `./partner-chains-cli setup-main-chain-state`
+1. Start the wizard: `./partner-chains-node wizards setup-main-chain-state`
 
 The wizard reads the permissioned candidates list from the chain config file and Cardano. If it finds any discrepancy, it allows you to update the list. To update the list, add to the `initial_permissioned_candidates` array in `partner-chains-cli-chain-config.json` and re-run the setup-main-chain-state wizard.
 
@@ -387,7 +387,7 @@ The start-node wizard is used to start a partner chain node. Make sure that `car
 
 Be sure two main chain (Cardano) epochs have passed since the registration of a new partner chain before running the start-node wizard. On the preview network, this is between 1-2 days.
 
-1. Start the wizard: `./partner-chains-cli start-node`
+1. Start the wizard: `./partner-chains-node wizards start-node`
 2. The wizard checks if all required keys are present. If not, it reminds you to run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, it should be generated with the create-chain-spec wizard.
 4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, it should be generated with the prepare-configuration wizard.

--- a/docs/user-guides/permissioned.md
+++ b/docs/user-guides/permissioned.md
@@ -150,7 +150,7 @@ The generate-keys wizard will generate necessary keys and save them to your node
 
 If these keys already exist in the node’s keystore, you will be asked to overwrite existing keys. The wizard will also generate a network key for your node if needed.
 
-1. Start the wizard: `./partner-chains-cli generate-keys`
+1. Start the wizard: `./partner-chains-node wizards generate-keys`
 2. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`.
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys.
@@ -178,7 +178,7 @@ Contact the chain builder and request the `chain-spec.json` and `partner-chains-
 
 The start-node wizard is used to start a partner chain node. Make sure that `cardano-node` is running with DB Sync running and fully synced. You will need to provide a link to postgreSQL server running with DB Sync as part of starting the node.
 
-1. Start the wizard: `./partner-chains-cli start-node`
+1. Start the wizard: `./partner-chains-node start-node`
 2. The wizard checks if all required keys are present. If not, it reminds you to run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, you should obtain it from the chain builder.
 4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, you should obtain it from the chain builder.

--- a/docs/user-guides/registered.md
+++ b/docs/user-guides/registered.md
@@ -255,7 +255,7 @@ The generate-keys wizard will generate necessary keys and save them to your node
 If these keys already exist in the node’s keystore, you will be asked to overwrite existing keys. The wizard will also generate a network key for your node if needed.
 
 1. To start the wizard, run the following command in the node repository:
-`./partner-chains-cli generate-keys`
+`./partner-chains-node wizards generate-keys`
 3. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys:
@@ -282,7 +282,7 @@ Registration is a three-step process, with the second step executed on the 'cold
 
 The register-1 wizard obtains the registration UTXO.
 
-1. Start the wizard: `./partner-chains-cli register1`
+1. Start the wizard: `./partner-chains-node wizards register1`
 2. Follow the steps when prompted by the wizard
 
 The wizard derives a payment address from the payment verification key and queries Ogmios for the UTXOs of the derived address.
@@ -317,7 +317,7 @@ The wizard will give you the option of displaying the registration status. If yo
 
 The start-node wizard is used to start a partner chain node. Make sure that `cardano-node` is running with DB Sync running and fully synced. You will need to provide a link to postgreSQL server running with DB Sync as part of starting the node.
 
-1. Start the wizard: `./partner-chains-cli start-node`.
+1. Start the wizard: `./partner-chains-node wizards start-node`.
 2. The wizard checks if all required keys are present. If not, it reminds you to the run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, you should obtain it from the governance authority.
 4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, you should obtain it from the governance authority.
@@ -332,7 +332,7 @@ Registration is effective after 1-2 Cardano epochs. After the waiting period, th
 
 To deregister from the list of block producer candidates, you need to run the deregister wizard.
 
-1. Start the wizard: `./partner-chains-cli deregister`.
+1. Start the wizard: `./partner-chains-node wizards deregister`.
 2. The wizard checks the `partner-chains-cli-chain-config.json` file.
 3. The wizard prompts for the payment verification key file used during registration.
 4. The wizard prompts for the cold verification key matching the cold signing key used during registration.

--- a/node/node/src/template_chain_spec.rs
+++ b/node/node/src/template_chain_spec.rs
@@ -6,8 +6,8 @@ use sidechain_runtime::{
 };
 
 /// Produces template chain spec for Partner Chains.
-/// This code should be run by `partner-chains-cli chain-spec`, to produce JSON chain spec file.
-/// `initial_validators` fields should be updated by the `partner-chains-cli chain-spec`.
+/// This code should be run by `partner-chains-node wizards chain-spec`, to produce JSON chain spec file.
+/// `initial_validators` fields should be updated by the `partner-chains-node wizards chain-spec`.
 /// Add and modify other fields of `ChainSpec` accordingly to the needs of your chain.
 pub fn chain_spec() -> Result<ChainSpec, envy::Error> {
 	let runtime_genesis_config = RuntimeGenesisConfig {

--- a/toolkit/cli/node-commands/Cargo.toml
+++ b/toolkit/cli/node-commands/Cargo.toml
@@ -13,6 +13,7 @@ frame-support = { workspace = true }
 log = { workspace = true }
 log4rs = { workspace = true }
 parity-scale-codec = { workspace = true }
+partner-chains-cli = { workspace = true }
 partner-chains-smart-contracts-commands = { workspace = true }
 plutus = { workspace = true }
 sidechain-domain = { workspace = true, default-features = true }

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -7,6 +7,7 @@ use frame_support::sp_runtime::traits::NumberFor;
 use parity_scale_codec::{Decode, Encode};
 use partner_chains_smart_contracts_commands::SmartContractsCmd;
 use sc_cli::{CliConfiguration, SharedParams, SubstrateCli};
+use sc_service::Configuration;
 use sc_service::TaskManager;
 use sidechain_domain::{MainchainPublicKey, McEpochNumber, ScEpochNumber};
 use sp_api::ProvideRuntimeApi;
@@ -89,6 +90,10 @@ pub enum PartnerChainsSubcommand {
 	/// Commands for interacting with Partner Chain smart contracts on Cardano
 	#[command(subcommand)]
 	SmartContracts(SmartContractsCmd),
+
+	/// Partner Chains text "wizards" for setting up chain
+	#[command(subcommand)]
+	Wizards(partner_chains_cli::Command),
 }
 
 pub fn run<Cli, Block, CrossChainPublic, SessionKeys, Client>(
@@ -156,6 +161,9 @@ where
 		PartnerChainsSubcommand::SmartContracts(cmd) => {
 			crate::setup_log4rs()?;
 			Ok(cmd.execute_blocking()?)
+		},
+		PartnerChainsSubcommand::Wizards(cmd) => {
+			Ok(partner_chains_cli::run(cmd).map_err(|e| sc_cli::Error::Application(e.into()))?)
 		},
 	}
 }

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -5,9 +5,9 @@ use clap::Parser;
 use cli_commands::registration_signatures::RegistrationSignaturesCmd;
 use frame_support::sp_runtime::traits::NumberFor;
 use parity_scale_codec::{Decode, Encode};
+use partner_chains_cli::io::DefaultCmdRunContext;
 use partner_chains_smart_contracts_commands::SmartContractsCmd;
 use sc_cli::{CliConfiguration, SharedParams, SubstrateCli};
-use sc_service::Configuration;
 use sc_service::TaskManager;
 use sidechain_domain::{MainchainPublicKey, McEpochNumber, ScEpochNumber};
 use sp_api::ProvideRuntimeApi;
@@ -163,7 +163,8 @@ where
 			Ok(cmd.execute_blocking()?)
 		},
 		PartnerChainsSubcommand::Wizards(cmd) => {
-			Ok(partner_chains_cli::run(cmd).map_err(|e| sc_cli::Error::Application(e.into()))?)
+			setup_log4rs()?;
+			Ok(cmd.run(&DefaultCmdRunContext).map_err(|e| sc_cli::Error::Application(e.into()))?)
 		},
 	}
 }

--- a/toolkit/partner-chains-cli/Cargo.toml
+++ b/toolkit/partner-chains-cli/Cargo.toml
@@ -33,7 +33,6 @@ tokio = { workspace = true }
 cardano-serialization-lib = { workspace = true }
 partner-chains-cardano-offchain = { workspace = true }
 log = { workspace = true }
-log4rs = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/toolkit/partner-chains-cli/readme.md
+++ b/toolkit/partner-chains-cli/readme.md
@@ -2,4 +2,4 @@
 
 A set of CLI style wizards to help getting started with Partner Chains.
 
-Should be packaged together with **partner-chains-node** executable, and **partner-chain-smart-contracts CLI**.
+These should be integrated to the node executable as subcommands.

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -395,16 +395,6 @@ pub mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub const NODE_EXECUTABLE_DEFAULT: &str = "./partner-chains-node";
-
-	pub const NODE_EXECUTABLE: ConfigFieldDefinition<'static, String> = ConfigFieldDefinition {
-		config_file: RESOURCES_CONFIG_FILE_PATH,
-		path: &["substrate_node_executable_path"],
-		name: "Partner Chains node executable",
-		default: Some(NODE_EXECUTABLE_DEFAULT),
-		_marker: PhantomData,
-	};
-
 	pub const CARDANO_PAYMENT_VERIFICATION_KEY_FILE: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
 			config_file: RESOURCES_CONFIG_FILE_PATH,

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -1,4 +1,3 @@
-use crate::config::config_fields::{NODE_EXECUTABLE, NODE_EXECUTABLE_DEFAULT};
 use crate::config::ConfigFieldDefinition;
 use crate::io::IOContext;
 use crate::permissioned_candidates::{ParsedPermissionedCandidatesKeys, PermissionedCandidateKeys};
@@ -11,7 +10,7 @@ use sidechain_domain::UtxoId;
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct CreateChainSpecCmd;
 
 const SESSION_INITIAL_VALIDATORS_PATH: &str =
@@ -80,8 +79,7 @@ impl CreateChainSpecCmd {
 		context: &C,
 		config: &CreateChainSpecConfig,
 	) -> anyhow::Result<String> {
-		let node_executable =
-			NODE_EXECUTABLE.save_if_empty(NODE_EXECUTABLE_DEFAULT.to_string(), context);
+		let node_executable = context.current_executable()?;
 		context.set_env_var("GENESIS_UTXO", &config.genesis_utxo.to_string());
 		context.set_env_var(
 			"COMMITTEE_CANDIDATE_ADDRESS",

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,10 +1,9 @@
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
 use crate::tests::{MockIO, MockIOContext};
-use crate::{config, CmdRun};
+use crate::CmdRun;
 use anyhow::anyhow;
 use colored::Colorize;
-use serde_json::json;
 
 #[test]
 fn happy_path() {
@@ -258,14 +257,10 @@ fn set_env_vars_io() -> MockIO {
 
 fn run_build_spec_io(output: Result<String, anyhow::Error>) -> MockIO {
 	MockIO::Group(vec![
-		MockIO::file_write_json(
-			config::config_fields::NODE_EXECUTABLE.config_file,
-			json!({"substrate_node_executable_path": "./partner-chains-node"}),
-		),
 		set_env_vars_io(),
 		MockIO::RunCommand {
 			expected_cmd:
-				"./partner-chains-node build-spec --disable-default-bootnode > chain-spec.json"
+				"<mock executable> build-spec --disable-default-bootnode > chain-spec.json"
 					.to_string(),
 			output,
 		},

--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -12,7 +12,7 @@ use crate::CmdRun;
 use anyhow::anyhow;
 use partner_chains_cardano_offchain::register::Deregister;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct DeregisterCmd;
 
 impl CmdRun for DeregisterCmd {

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -217,9 +217,7 @@ fn chain_parameters_json() -> serde_json::Value {
 }
 
 fn test_resources_config_content() -> serde_json::Value {
-	json!({
-		"substrate_node_executable_path": "./partner-chains-node"
-	})
+	json!({})
 }
 
 fn valid_payment_signing_key_content() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -26,6 +26,7 @@ pub trait IOContext {
 		+ UpsertPermissionedCandidates;
 
 	fn run_command(&self, cmd: &str) -> anyhow::Result<String>;
+	fn current_executable(&self) -> anyhow::Result<String>;
 	fn print(&self, msg: &str);
 	fn eprint(&self, msg: &str);
 	fn enewline(&self);
@@ -92,6 +93,12 @@ impl IOContext for DefaultCmdRunContext {
 			return Err(anyhow!("Failed to run command"));
 		}
 		Ok(String::from_utf8(output)?)
+	}
+
+	fn current_executable(&self) -> anyhow::Result<String> {
+		let exe = std::env::current_exe()?;
+		let node_executable = exe.to_str().ok_or(anyhow!("Cannot get current executable name"))?;
+		Ok(node_executable.to_string())
 	}
 
 	fn print(&self, msg: &str) {

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -22,10 +22,6 @@ mod tests;
 
 use clap::Parser;
 use io::*;
-use log4rs::{
-	append::{console::ConsoleAppender, file::FileAppender},
-	config::Appender,
-};
 
 #[derive(Clone, Debug, Parser)]
 #[command(
@@ -54,37 +50,24 @@ pub enum Command {
 	Deregister(deregister::DeregisterCmd),
 }
 
-pub trait CmdRun {
-	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()>;
+impl Command {
+	pub fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
+		match self {
+			Command::GenerateKeys(cmd) => cmd.run(context),
+			Command::PrepareConfiguration(cmd) => cmd.run(context),
+			Command::CreateChainSpec(cmd) => cmd.run(context),
+			Command::SetupMainChainState(cmd) => cmd.run(context),
+			Command::StartNode(cmd) => cmd.run(context),
+			Command::Register1(cmd) => cmd.run(context),
+			Command::Register2(cmd) => cmd.run(context),
+			Command::Register3(cmd) => cmd.run(context),
+			Command::Deregister(cmd) => cmd.run(context),
+		}
+	}
 }
 
-pub fn run(command: Command) -> anyhow::Result<()> {
-	let log_config = log4rs::config::Config::builder()
-		.appender(Appender::builder().build("stdout", Box::new(ConsoleAppender::builder().build())))
-		.appender(
-			Appender::builder()
-				.build("ogmios-log", Box::new(FileAppender::builder().build("ogmios_client.log")?)),
-		)
-		.logger(
-			log4rs::config::Logger::builder()
-				.appender("ogmios-log")
-				.additive(false)
-				.build("ogmios_client::jsonrpsee", log::LevelFilter::Debug),
-		)
-		.build(log4rs::config::Root::builder().appender("stdout").build(log::LevelFilter::Info))?;
-	log4rs::init_config(log_config)?;
-	match command {
-		Command::GenerateKeys(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::PrepareConfiguration(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::CreateChainSpec(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::SetupMainChainState(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::StartNode(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::Register1(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::Register2(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::Register3(cmd) => cmd.run(&DefaultCmdRunContext)?,
-		Command::Deregister(cmd) => cmd.run(&DefaultCmdRunContext)?,
-	}
-	Ok(())
+pub trait CmdRun {
+	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()>;
 }
 
 const HELP_EXAMPLES: &str = r#"

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -27,11 +27,10 @@ use log4rs::{
 	config::Appender,
 };
 
-#[derive(Debug, Parser)]
+#[derive(Clone, Debug, Parser)]
 #[command(
     after_long_help = HELP_EXAMPLES,
 )]
-
 pub enum Command {
 	/// This wizard generates the keys required for operating a partner-chains node, stores them in the keystore directory, and prints the public keys and keystore location.
 	GenerateKeys(generate_keys::GenerateKeysCmd),
@@ -59,7 +58,7 @@ pub trait CmdRun {
 	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()>;
 }
 
-fn main() -> anyhow::Result<()> {
+pub fn run(command: Command) -> anyhow::Result<()> {
 	let log_config = log4rs::config::Config::builder()
 		.appender(Appender::builder().build("stdout", Box::new(ConsoleAppender::builder().build())))
 		.appender(
@@ -73,10 +72,8 @@ fn main() -> anyhow::Result<()> {
 				.build("ogmios_client::jsonrpsee", log::LevelFilter::Debug),
 		)
 		.build(log4rs::config::Root::builder().appender("stdout").build(log::LevelFilter::Info))?;
-
 	log4rs::init_config(log_config)?;
-	let args = Command::parse();
-	match args {
+	match command {
 		Command::GenerateKeys(cmd) => cmd.run(&DefaultCmdRunContext)?,
 		Command::PrepareConfiguration(cmd) => cmd.run(&DefaultCmdRunContext)?,
 		Command::CreateChainSpec(cmd) => cmd.run(&DefaultCmdRunContext)?,

--- a/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use std::vec;
 use thiserror::Error;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct PrepareConfigurationCmd {}
 
 impl CmdRun for PrepareConfigurationCmd {

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -82,10 +82,10 @@ impl CmdRun for Register1Cmd {
 
 		let sidechain_signature =
 			sign_registration_message_with_sidechain_key(registration_message, ecdsa_pair)?;
-
+		let executable = context.current_executable()?;
 		context.print("Run the following command to generate signatures on the next step. It has to be executed on the machine with your SPO cold signing key.");
 		context.print("");
-		context.print(&format!("./partner-chains-cli register2 \\\n --genesis-utxo {genesis_utxo} \\\n --registration-utxo {registration_utxo} \\\n --aura-pub-key {aura_pub_key} \\\n --grandpa-pub-key {grandpa_pub_key} \\\n --sidechain-pub-key {sidechain_pub_key} \\\n --sidechain-signature {sidechain_signature}"));
+		context.print(&format!("{executable} wizards register2 \\\n --genesis-utxo {genesis_utxo} \\\n --registration-utxo {registration_utxo} \\\n --aura-pub-key {aura_pub_key} \\\n --grandpa-pub-key {grandpa_pub_key} \\\n --sidechain-pub-key {sidechain_pub_key} \\\n --sidechain-signature {sidechain_signature}"));
 
 		Ok(())
 	}
@@ -539,7 +539,7 @@ mod tests {
 		vec![
 		MockIO::print("Run the following command to generate signatures on the next step. It has to be executed on the machine with your SPO cold signing key."),
 		MockIO::print(""),
-		MockIO::print("./partner-chains-cli register2 \\\n --genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n --registration-utxo 4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93 \\\n --aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n --grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n --sidechain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n --sidechain-signature 6e295e36a6b11d8b1c5ec01ac8a639b466fbfbdda94b39ea82b0992e303d58543341345fc705e09c7838786ba0bc746d9038036f66a36d1127d924c4a0228bec")
+		MockIO::print("<mock executable> wizards register2 \\\n --genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n --registration-utxo 4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93 \\\n --aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n --grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n --sidechain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n --sidechain-signature 6e295e36a6b11d8b1c5ec01ac8a639b466fbfbdda94b39ea82b0992e303d58543341345fc705e09c7838786ba0bc746d9038036f66a36d1127d924c4a0228bec")
 		]
 	}
 

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -17,7 +17,7 @@ use sidechain_domain::{NetworkType, SidechainPublicKey, UtxoId};
 use sp_core::bytes::from_hex;
 use sp_core::{ecdsa, Pair};
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct Register1Cmd {}
 
 impl CmdRun for Register1Cmd {

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -50,10 +50,10 @@ impl CmdRun for Register2Cmd {
 
 		let spo_public_key = hex::encode(verification_key);
 		let spo_signature = hex::encode(mc_signature.to_vec());
-
+		let executable = context.current_executable()?;
 		context.print("To finish the registration process, run the following command on the machine with the partner chain dependencies running:\n");
 		context.print(&format!(
-			"./partner-chains-cli register3 \\\n--genesis-utxo {} \\\n--registration-utxo {} \\\n--aura-pub-key {} \\\n--grandpa-pub-key {} \\\n--partner-chain-pub-key {} \\\n--partner-chain-signature {} \\\n--spo-public-key {} \\\n--spo-signature {}",
+			"{executable} wizards register3 \\\n--genesis-utxo {} \\\n--registration-utxo {} \\\n--aura-pub-key {} \\\n--grandpa-pub-key {} \\\n--partner-chain-pub-key {} \\\n--partner-chain-signature {} \\\n--spo-public-key {} \\\n--spo-signature {}",
 			self.genesis_utxo, self.registration_utxo, self.aura_pub_key, self.grandpa_pub_key, self.sidechain_pub_key, self.sidechain_signature, spo_public_key, spo_signature));
 		Ok(())
 	}
@@ -124,7 +124,7 @@ mod tests {
 	fn output_result_io() -> Vec<MockIO> {
 		vec![
             MockIO::print("To finish the registration process, run the following command on the machine with the partner chain dependencies running:\n"),
-            MockIO::print("./partner-chains-cli register3 \\\n--genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n--registration-utxo 7e9ebd0950ae1bec5606f0cd7ac88b3c60b1103d7feb6ffa36402edae4d1b617#0 \\\n--aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n--grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n--partner-chain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n--partner-chain-signature 7a7e3e585a5dc248d4a2772814e1b58c90313443dd99369f994e960ecc4931442a08305743db7ab42ab9b8672e00250e1cc7c08bc018b0630a8197c4f95528a301 \\\n--spo-public-key cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 \\\n--spo-signature aaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801"),
+            MockIO::print("<mock executable> wizards register3 \\\n--genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n--registration-utxo 7e9ebd0950ae1bec5606f0cd7ac88b3c60b1103d7feb6ffa36402edae4d1b617#0 \\\n--aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n--grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n--partner-chain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n--partner-chain-signature 7a7e3e585a5dc248d4a2772814e1b58c90313443dd99369f994e960ecc4931442a08305743db7ab42ab9b8672e00250e1cc7c08bc018b0630a8197c4f95528a301 \\\n--spo-public-key cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 \\\n--spo-signature aaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801"),
         ]
 	}
 	// non 0 genesis utxo 8ea10040249ad3033ae7c4d4b69e0b2e2b50a90741b783491cb5ddf8ced0d861

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -114,9 +114,7 @@ fn show_registration_status(
 		.into_os_string()
 		.into_string()
 		.expect("PathBuf is a valid UTF-8 String");
-	let node_executable = config_fields::NODE_EXECUTABLE
-		.load_from_file(context)
-		.ok_or_else(|| anyhow::anyhow!("⚠️ Unable to load node executable"))?;
+	let node_executable = context.current_executable()?;
 	let command = format!(
 		"{} registration-status --mainchain-pub-key {} --mc-epoch-number {} --chain chain-spec.json --base-path {temp_dir_path}",
 		node_executable, mc_public_key.to_hex_string(), mc_epoch_number
@@ -315,8 +313,7 @@ mod tests {
         MockIO::set_env_var("MC__FIRST_SLOT_NUMBER", "4320"),
 		MockIO::print("Registrations status for epoch 25:"),
         MockIO::new_tmp_dir(),
-        MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
-        MockIO::run_command("/path/to/node registration-status --mainchain-pub-key 0xcef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 --mc-epoch-number 25 --chain chain-spec.json --base-path /tmp/MockIOContext_tmp_dir", "{\"epoch\":1,\"validators\":[{\"public_key\":\"cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7\",\"status\":\"Registered\"}]}"),
+        MockIO::run_command("<mock executable> registration-status --mainchain-pub-key 0xcef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 --mc-epoch-number 25 --chain chain-spec.json --base-path /tmp/MockIOContext_tmp_dir", "{\"epoch\":1,\"validators\":[{\"public_key\":\"cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7\",\"status\":\"Registered\"}]}"),
         MockIO::print("Registration status:"),
         MockIO::print("{\"epoch\":1,\"validators\":[{\"public_key\":\"cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7\",\"status\":\"Registered\"}]}"),
 		]

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -16,7 +16,7 @@ use sidechain_domain::{McEpochNumber, UtxoId};
 #[cfg(test)]
 mod tests;
 
-#[derive(Debug, clap::Parser)]
+#[derive(Clone, Debug, clap::Parser)]
 pub struct SetupMainChainStateCmd;
 
 /// Formats of the output of the `ariadne-parameters` command.
@@ -160,8 +160,7 @@ fn get_ariadne_parameters<C: IOContext>(
 		&chain_config.cardano,
 		&postgres_connection_string,
 	);
-	let executable =
-		config_fields::NODE_EXECUTABLE.prompt_with_default_from_file_parse_and_save(context)?;
+	let executable = context.current_executable()?;
 	// Call for state that will be effective in two main chain epochs from now.
 	let epoch = get_current_mainchain_epoch(context, chain_config)?.0 + 2;
 	let temp_dir = context.new_tmp_dir();

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,6 +1,6 @@
-use crate::config::{config_fields, RESOURCES_CONFIG_FILE_PATH};
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
 use crate::config::CHAIN_CONFIG_FILE_PATH;
+use crate::config::{config_fields, RESOURCES_CONFIG_FILE_PATH};
 use crate::ogmios::config::tests::{default_ogmios_service_config, prompt_ogmios_configuration_io};
 use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,6 +1,6 @@
-use crate::config::config_fields;
+use crate::config::{config_fields, RESOURCES_CONFIG_FILE_PATH};
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
-use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
+use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::ogmios::config::tests::{default_ogmios_service_config, prompt_ogmios_configuration_io};
 use crate::prepare_configuration::tests::{
 	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
@@ -208,10 +208,9 @@ fn get_ariadne_parameters_io(result: serde_json::Value) -> MockIO {
 		MockIO::print("Will read the current D-Parameter and Permissioned Candidates from the main chain, using 'partner-chains-node ariadne-parameters' command."),
 		prompt_and_save_to_existing_file(config_fields::POSTGRES_CONNECTION_STRING, "postgres://postgres:password123@localhost:5432/cexplorer"),
 		set_env_for_node_io(),
-		prompt_and_save_to_existing_file(config_fields::NODE_EXECUTABLE,"./partner-chains-node"),
 		MockIO::current_timestamp(timestamp_for_preview_epoch_605),
 		MockIO::new_tmp_dir(),
-		MockIO::run_command("./partner-chains-node ariadne-parameters --base-path /tmp/MockIOContext_tmp_dir --chain chain-spec.json --mc-epoch-number 607", &ariadne_parameters_command_output),
+		MockIO::run_command("<mock executable> ariadne-parameters --base-path /tmp/MockIOContext_tmp_dir --chain chain-spec.json --mc-epoch-number 607", &ariadne_parameters_command_output),
 		MockIO::print(&ariadne_parameters_command_output),
 	])
 }
@@ -427,9 +426,7 @@ fn chain_parameters_json() -> serde_json::Value {
 }
 
 fn test_resources_config_content() -> serde_json::Value {
-	json!({
-		"substrate_node_executable_path": "./partner-chains-node"
-	})
+	json!({})
 }
 
 fn ariadne_parameters_not_found_response() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -477,6 +477,10 @@ impl IOContext for MockIOContext {
 		})
 	}
 
+	fn current_executable(&self) -> anyhow::Result<String> {
+		Ok("<mock executable>".to_owned())
+	}
+
 	fn eprint(&self, msg: &str) {
 		let next = self.pop_next_action(&format!("eprint({msg})"));
 		next.print_mock_location_on_panic(|next| match next {


### PR DESCRIPTION
# Description

`partner-chains-cli` separate binary is transformed to a library crated and integreted in `partner-chains-node-commands` library crate.
Every invocation of `partner-chains-cli` should be replaced with `<node> wizards` subcommand of the node built with Partner Chains SDK.
The only other change is that "node executable path" configuration is not present in `partner-chains-cli-resources.json` anymore, because it is not needed anymore.
Code will always invoke "self" executable instead.
Since this change, all functionality of Partner Chains is available in the one executable of the node.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages. -> Will be squashed on merge
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
