### PR TITLE
ETCM-9064 make ReserveDatum offchain match onchain

### DIFF
--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -82,7 +82,10 @@ pub struct ReserveParameters {
 impl From<&ReserveParameters> for ReserveDatum {
 	fn from(value: &ReserveParameters) -> Self {
 		ReserveDatum {
-			immutable_settings: ReserveImmutableSettings { token: value.token.clone() },
+			// `t0` field is not used by on-chain code of partner-chains smart-contracts,
+			// but only gave a possiblity for user to store "t0" for his own V-function.
+			// Not configurable anymore, hardcoded to 0. If users need "t0" for their V-function, they are responsible for storing it somewhere.
+			immutable_settings: ReserveImmutableSettings { t0: 0, token: value.token.clone() },
 			mutable_settings: ReserveMutableSettings {
 				total_accrued_function_script_hash: value
 					.total_accrued_function_script_hash

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -372,7 +372,7 @@ mod tests {
 
 	fn previous_reserve_datum() -> ReserveDatum {
 		ReserveDatum {
-			immutable_settings: ReserveImmutableSettings { token: token_id() },
+			immutable_settings: ReserveImmutableSettings { t0: 0, token: token_id() },
 			mutable_settings: ReserveMutableSettings {
 				total_accrued_function_script_hash: applied_v_function().policy_id(),
 				initial_incentive: 0,


### PR DESCRIPTION
# Description

This PR makes ReserveDatum in offchain rust code match its counterpart in onchain smart-contract code.
T0 field was ignored during decoding, and hidden from the offchain type, which led to a confusing error when a transaction only intending to change other fields also changed T0 because encoding implicitly sets it to 0.
I would consider it a bad practice in general not to have 1:1 matching encoded/decoded types in onchain and offchain code.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

