### PR TITLE
feat: allow use of BIP32 extended key as Payment Signing key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6759,7 +6759,6 @@ dependencies = [
 name = "partner-chains-smart-contracts-commands"
 version = "1.4.0"
 dependencies = [
- "cardano-serialization-lib",
  "clap",
  "env_logger 0.11.3",
  "hex",

--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ Every invocation of `partner-chains-cli` should be replaced with `<node> wizards
 The only other change is that "node executable path" configuration is not present in `partner-chains-cli-resources.json` anymore, because it is not needed anymore.
 Code will always invoke "self" executable instead.
 Since this change, all functionality of Partner Chains is available in the one executable of the node.
+* Added support for extended payment signing and verification keys.
 
 ## Removed
 

--- a/toolkit/cli/smart-contracts-commands/Cargo.toml
+++ b/toolkit/cli/smart-contracts-commands/Cargo.toml
@@ -14,7 +14,6 @@ ogmios-client = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-cardano-serialization-lib = { workspace = true }
 
 [dev-dependencies]
 hex-literal = { workspace = true }

--- a/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
+++ b/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
@@ -31,7 +31,7 @@ impl UpsertDParameterCmd {
 		upsert_d_param(
 			self.genesis_utxo,
 			&d_param,
-			payment_key.0,
+			&payment_key,
 			&client,
 			&FixedDelayRetries::two_minutes(),
 		)

--- a/toolkit/cli/smart-contracts-commands/src/governance.rs
+++ b/toolkit/cli/smart-contracts-commands/src/governance.rs
@@ -45,7 +45,7 @@ impl InitGovernanceCmd {
 
 		run_init_governance(
 			self.governance_authority,
-			payment_key,
+			&payment_key,
 			self.genesis_utxo,
 			&client,
 			FixedDelayRetries::two_minutes(),
@@ -76,7 +76,7 @@ impl UpdateGovernanceCmd {
 
 		run_update_governance(
 			self.new_governance_authority,
-			payment_key,
+			&payment_key,
 			self.genesis_utxo,
 			&client,
 			FixedDelayRetries::two_minutes(),

--- a/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
+++ b/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
@@ -44,7 +44,7 @@ impl UpsertPermissionedCandidatesCmd {
 		upsert_permissioned_candidates(
 			self.genesis_utxo,
 			&permissioned_candidates,
-			payment_key.0,
+			&payment_key,
 			&client,
 			&FixedDelayRetries::two_minutes(),
 		)

--- a/toolkit/cli/smart-contracts-commands/src/register.rs
+++ b/toolkit/cli/smart-contracts-commands/src/register.rs
@@ -1,6 +1,5 @@
 use crate::{parse_partnerchain_public_keys, PaymentFilePath};
 use ogmios_client::jsonrpsee::client_for_url;
-use partner_chains_cardano_offchain::csl::MainchainPrivateKeyExt;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
 	register::{run_deregister, run_register},
@@ -61,7 +60,7 @@ impl RegisterCmd {
 		run_register(
 			self.genesis_utxo,
 			&candidate_registration,
-			payment_key,
+			&payment_key,
 			&client,
 			FixedDelayRetries::two_minutes(),
 		)
@@ -92,7 +91,7 @@ impl DeregisterCmd {
 
 		run_deregister(
 			self.genesis_utxo,
-			payment_signing_key,
+			&payment_signing_key,
 			self.spo_public_key,
 			&client,
 			FixedDelayRetries::two_minutes(),

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -58,7 +58,7 @@ impl InitReserveCmd {
 		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
 		let _ = init_reserve_management(
 			self.genesis_utxo,
-			payment_key.0,
+			&payment_key,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
 		)
@@ -98,7 +98,7 @@ impl CreateReserveCmd {
 				initial_deposit: self.initial_deposit_amount,
 			},
 			self.genesis_utxo,
-			payment_key.0,
+			&payment_key,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
 		)
@@ -131,7 +131,7 @@ impl DepositReserveCmd {
 		let _ = deposit_to_reserve(
 			TokenAmount { token: self.token, amount: self.amount },
 			self.genesis_utxo,
-			payment_key.0,
+			&payment_key,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
 		)
@@ -160,7 +160,7 @@ impl UpdateReserveSettingsCmd {
 		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
 		let _ = update_reserve_settings(
 			self.genesis_utxo,
-			payment_key.0,
+			&payment_key,
 			self.total_accrued_function_script_hash,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
@@ -187,7 +187,7 @@ impl HandoverReserveCmd {
 		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
 		let _ = handover_reserve(
 			self.genesis_utxo,
-			payment_key.0,
+			&payment_key,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
 		)
@@ -224,7 +224,7 @@ impl ReleaseReserveCmd {
 			TokenAmount { token: self.token, amount: self.amount },
 			self.genesis_utxo,
 			self.reference_utxo,
-			payment_key.0,
+			&payment_key,
 			&ogmios_client,
 			&FixedDelayRetries::two_minutes(),
 		)

--- a/toolkit/offchain/src/cardano_keys.rs
+++ b/toolkit/offchain/src/cardano_keys.rs
@@ -9,7 +9,7 @@ use sidechain_domain::MainchainKeyHash;
 pub struct CardanoPaymentSigningKey(pub(crate) PrivateKey);
 
 impl CardanoPaymentSigningKey {
-	pub fn from_extended_128_bytes(bytes: [u8; 128]) -> Result<Self, anyhow::Error> {
+	pub fn from_extended_128_bytes(bytes: [u8; 128]) -> anyhow::Result<Self> {
 		// All 128 bytes are: 64 bytes of prefix, 32 bytes of verification key, 32 bytes of chain code
 		let prefix: [u8; 64] = bytes[0..64].try_into().unwrap();
 		Ok(Self(

--- a/toolkit/offchain/src/cardano_keys.rs
+++ b/toolkit/offchain/src/cardano_keys.rs
@@ -1,0 +1,159 @@
+use anyhow::anyhow;
+use cardano_serialization_lib::PrivateKey;
+use sidechain_domain::MainchainKeyHash;
+
+/// Signing (payment) key abstraction layer. Hides internal crytpo library details.
+/// It is either:
+/// * 32 bytes regural private key
+/// * 64 bytes extended private key
+pub struct CardanoPaymentSigningKey(pub(crate) PrivateKey);
+
+impl CardanoPaymentSigningKey {
+	pub fn from_extended_128_bytes(bytes: [u8; 128]) -> Result<Self, anyhow::Error> {
+		// All 128 bytes are: 64 bytes of prefix, 32 bytes of verification key, 32 bytes of chain code
+		let prefix: [u8; 64] = bytes[0..64].try_into().unwrap();
+		Ok(Self(
+			PrivateKey::from_extended_bytes(&prefix)
+				.map_err(|e| anyhow!("Couldn't parse 128 bytes into a BIP32 Private Key: {e}"))?,
+		))
+	}
+
+	pub fn from_normal_bytes(bytes: [u8; 32]) -> Result<Self, anyhow::Error> {
+		Ok(Self(
+			PrivateKey::from_normal_bytes(&bytes)
+				.map_err(|e| anyhow!("Couldn't parse 32 bytes into a Private Key: {e}"))?,
+		))
+	}
+
+	pub fn sign(&self, message: &[u8]) -> Result<Vec<u8>, anyhow::Error> {
+		Ok(self.0.sign(message).to_bytes())
+	}
+
+	pub fn to_pub_key_hash(&self) -> MainchainKeyHash {
+		MainchainKeyHash(
+			self.0
+				.to_public()
+				.hash()
+				.to_bytes()
+				.as_slice()
+				.try_into()
+				.expect("CSL PublicKeyHash is 28 bytes"),
+		)
+	}
+
+	pub fn to_bytes(&self) -> Vec<u8> {
+		self.0.as_bytes()
+	}
+}
+
+impl TryFrom<CardanoKeyFileContent> for CardanoPaymentSigningKey {
+	type Error = anyhow::Error;
+
+	fn try_from(key: CardanoKeyFileContent) -> Result<Self, Self::Error> {
+		let key_type = key.r#type.clone();
+		if key_type == "PaymentSigningKeyShelley_ed25519" {
+			Ok(CardanoPaymentSigningKey::from_normal_bytes(key.raw_key_bytes()?)?)
+		} else if key_type == "PaymentExtendedSigningKeyShelley_ed25519_bip32" {
+			Ok(CardanoPaymentSigningKey::from_extended_128_bytes(key.raw_key_bytes()?)?)
+		} else {
+			Err(anyhow!("Unsupported key type: {}. Expected a signing key", key_type))
+		}
+	}
+}
+
+impl Clone for CardanoPaymentSigningKey {
+	fn clone(&self) -> Self {
+		let bytes = self.0.as_bytes();
+		let private_key = if bytes.len() == 32 {
+			PrivateKey::from_normal_bytes(&bytes)
+				.expect("PrivateKey bytes are valid to clone the key")
+		} else {
+			PrivateKey::from_extended_bytes(&bytes)
+				.expect("PrivateKey bytes are valid to clone the key")
+		};
+		Self(private_key)
+	}
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CardanoKeyFileContent {
+	pub r#type: String,
+	pub cbor_hex: String,
+}
+
+impl CardanoKeyFileContent {
+	pub fn parse_file(path: &str) -> anyhow::Result<Self> {
+		let file_content = std::fs::read_to_string(path)
+			.map_err(|e| anyhow!("Could not read Cardano key file at: {path}. Cause: {e}"))?;
+		serde_json::from_str::<Self>(&file_content)
+			.map_err(|e| anyhow!("{path} is not valid Cardano key JSON file. {e}"))
+	}
+	/// Parses raw bytes of 'cborHex' field of Cardano key file content.
+	/// Works for 32, 64 and 128 bytes hex strings (68, 132, 260 hex digits) - assumes CBOR prefix has 4 hex digits.
+	pub fn raw_key_bytes<const N: usize>(&self) -> anyhow::Result<[u8; N]> {
+		let (_cbor_prefix, vkey) = self.cbor_hex.split_at(4);
+		let bytes: [u8; N] = hex::decode(vkey)
+			.map_err(|err| {
+				anyhow!(
+					"Invalid cborHex value of Cardano key - not valid hex: {}\n{err:?}",
+					self.cbor_hex
+				)
+			})?
+			.try_into()
+			.map_err(|_| {
+				anyhow!(
+					"Invalid cborHex value of Cardano key - incorrect length: {}",
+					self.cbor_hex
+				)
+			})?;
+		Ok(bytes)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use crate::cardano_keys::{CardanoKeyFileContent, CardanoPaymentSigningKey};
+
+	#[test]
+	fn cardano_key_content_key_raw_bytes() {
+		let key_file_content = CardanoKeyFileContent {
+			r#type: "PaymentSigningKeyShelley_ed25519".to_owned(),
+			cbor_hex: "5820d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
+				.to_owned(),
+		};
+		assert!(key_file_content.raw_key_bytes::<31>().is_err());
+		assert_eq!(
+			hex::encode(key_file_content.raw_key_bytes::<32>().unwrap()),
+			"d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
+		);
+		assert!(key_file_content.raw_key_bytes::<33>().is_err());
+	}
+
+	#[test]
+	fn signing_key_from_extended() {
+		let key_file_content = CardanoKeyFileContent {
+			r#type: "PaymentExtendedSigningKeyShelley_ed25519_bip32".to_owned(),
+			cbor_hex: "588020baf85b0e955e969cdaa852b31f223bad0348c274790c2a924602efdaba144266994eeb10f17618065431db154d28c0c7ce11277f412d614ebe82c59688b0244fbd942f1a7b94da07dfcf1c8be9826fd6222c0bae8604eebe0b6215f5d9b841203e23e0617b7e5191898dba700a7541152a3e03a816fc61b3887fe85c6d37d1".to_owned()
+		};
+		let key = CardanoPaymentSigningKey::try_from(key_file_content).unwrap();
+		assert_eq!(
+			hex::encode(key.to_pub_key_hash().0),
+			"9e287cbfac63670ff624edc69eea5f26c6f56f86f474e3e0d83f7c5c"
+		);
+	}
+
+	#[test]
+	fn signing_key_from_normal() {
+		let key_file_content = CardanoKeyFileContent {
+			r#type: "PaymentSigningKeyShelley_ed25519".to_owned(),
+			cbor_hex: "5820d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
+				.to_owned(),
+		};
+		let key = CardanoPaymentSigningKey::try_from(key_file_content).unwrap();
+		assert_eq!(
+			hex::encode(key.to_pub_key_hash().0),
+			"e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b"
+		);
+	}
+}

--- a/toolkit/offchain/src/csl.rs
+++ b/toolkit/offchain/src/csl.rs
@@ -1,3 +1,4 @@
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::plutus_script::PlutusScript;
 use anyhow::Context;
 use cardano_serialization_lib::*;
@@ -10,7 +11,7 @@ use ogmios_client::{
 	transactions::OgmiosEvaluateTransactionResponse,
 	types::{OgmiosUtxo, OgmiosValue},
 };
-use sidechain_domain::{AssetId, MainchainKeyHash, MainchainPrivateKey, NetworkType, UtxoId};
+use sidechain_domain::{AssetId, NetworkType, UtxoId};
 use std::collections::HashMap;
 
 pub(crate) fn plutus_script_hash(script_bytes: &[u8], language: Language) -> [u8; 28] {
@@ -363,24 +364,6 @@ impl UtxoIdExt for UtxoId {
 	}
 }
 
-pub trait MainchainPrivateKeyExt {
-	fn to_pub_key_hash(&self) -> MainchainKeyHash;
-}
-
-impl MainchainPrivateKeyExt for MainchainPrivateKey {
-	fn to_pub_key_hash(&self) -> MainchainKeyHash {
-		cardano_serialization_lib::PrivateKey::from_normal_bytes(&self.0)
-			.expect("Conversion cannot fail on valid MainchainPrivateKey values")
-			.to_public()
-			.hash()
-			.to_bytes()
-			.as_slice()
-			.try_into()
-			.map(MainchainKeyHash)
-			.expect("Conversion cannot fail as representation is the same")
-	}
-}
-
 pub(crate) struct TransactionContext {
 	/// This key is added as required signer and used to sign the transaction.
 	pub(crate) payment_key: PrivateKey,
@@ -395,10 +378,10 @@ impl TransactionContext {
 	/// Gets `TransactionContext`, having UTXOs for the given payment key and the network configuration,
 	/// required to perform most of the partner-chains smart contract operations.
 	pub(crate) async fn for_payment_key<C: QueryLedgerState + QueryNetwork>(
-		payment_signing_key: [u8; 32],
+		payment_key: &CardanoPaymentSigningKey,
 		client: &C,
 	) -> Result<TransactionContext, anyhow::Error> {
-		let payment_key = PrivateKey::from_normal_bytes(&payment_signing_key)?;
+		let payment_key = payment_key.clone().0;
 		let network = client.shelley_genesis_configuration().await?.network.to_csl();
 		let protocol_parameters = client.query_protocol_parameters().await?;
 		let payment_address = key_hash_address(&payment_key.to_public().hash(), network);

--- a/toolkit/offchain/src/d_param/mod.rs
+++ b/toolkit/offchain/src/d_param/mod.rs
@@ -5,6 +5,7 @@
 //! `datum` field being `[num_permissioned_candidates, num_registered_candidates]`.
 
 use crate::await_tx::{AwaitTx, FixedDelayRetries};
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::{
 	empty_asset_name, get_builder_config, unit_plutus_data, CostStore, Costs, InputsBuilderExt,
 	TransactionBuilderExt, TransactionContext,
@@ -30,7 +31,7 @@ pub trait UpsertDParam {
 		&self,
 		genesis_utxo: UtxoId,
 		d_parameter: &DParameter,
-		payment_signing_key: [u8; 32],
+		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> anyhow::Result<Option<McTxHash>>;
 }
 
@@ -39,7 +40,7 @@ impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId> Upse
 		&self,
 		genesis_utxo: UtxoId,
 		d_parameter: &DParameter,
-		payment_signing_key: [u8; 32],
+		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> anyhow::Result<Option<McTxHash>> {
 		upsert_d_param(
 			genesis_utxo,
@@ -58,7 +59,7 @@ pub async fn upsert_d_param<
 >(
 	genesis_utxo: UtxoId,
 	d_parameter: &DParameter,
-	payment_signing_key: [u8; 32],
+	payment_signing_key: &CardanoPaymentSigningKey,
 	ogmios_client: &C,
 	await_tx: &A,
 ) -> anyhow::Result<Option<McTxHash>> {

--- a/toolkit/offchain/src/init_governance/mod.rs
+++ b/toolkit/offchain/src/init_governance/mod.rs
@@ -1,3 +1,4 @@
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::Costs;
 use crate::csl::OgmiosUtxoExt;
 use crate::plutus_script;
@@ -16,7 +17,7 @@ use ogmios_client::{
 	types::{OgmiosTx, OgmiosUtxo},
 };
 use partner_chains_plutus_data::version_oracle::VersionOracleDatum;
-use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, UtxoId};
+use sidechain_domain::{MainchainKeyHash, UtxoId};
 
 #[cfg(test)]
 mod tests;
@@ -30,7 +31,7 @@ pub trait InitGovernance {
 	async fn init_governance(
 		&self,
 		governance_authority: MainchainKeyHash,
-		payment_key: MainchainPrivateKey,
+		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
 	) -> Result<OgmiosTx, OffchainError>;
 }
@@ -42,7 +43,7 @@ where
 	async fn init_governance(
 		&self,
 		governance_authority: MainchainKeyHash,
-		payment_key: MainchainPrivateKey,
+		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
 	) -> Result<OgmiosTx, OffchainError> {
 		run_init_governance(
@@ -63,22 +64,18 @@ pub async fn run_init_governance<
 	A: AwaitTx,
 >(
 	governance_authority: MainchainKeyHash,
-	payment_key: MainchainPrivateKey,
+	payment_key: &CardanoPaymentSigningKey,
 	genesis_utxo_id: Option<UtxoId>,
 	client: &T,
 	await_tx: A,
 ) -> anyhow::Result<(UtxoId, OgmiosTx)> {
-	let payment_key = PrivateKey::from_normal_bytes(&payment_key.0)
-		.expect("MainchainPrivateKey is a valid PrivateKey");
+	let ctx = crate::csl::TransactionContext::for_payment_key(payment_key, client).await?;
 
-	let network = client.shelley_genesis_configuration().await?.network;
-
-	let own_address = key_hash_address(&payment_key.to_public().hash(), network.to_csl());
+	let own_address = key_hash_address(&ctx.payment_key_hash(), ctx.network);
 	log::info!("✉️ Submitter address: {}", own_address.to_bech32(None).unwrap());
 
-	let own_utxos = client.query_utxos(&[own_address.to_bech32(None)?]).await?;
+	let own_utxos = ctx.payment_key_utxos.clone();
 	log::info!("💱 {} UTXOs available", own_utxos.len());
-	let protocol_parameters = client.query_protocol_parameters().await?;
 
 	let genesis_utxo = match genesis_utxo_id {
 		None => {
@@ -92,13 +89,6 @@ pub async fn run_init_governance<
 			.find(|utxo| utxo.transaction.id == utxo_id.tx_hash.0 && utxo.index == utxo_id.index.0)
 			.ok_or(anyhow!("Could not find genesis UTXO: {utxo_id}"))?
 			.clone(),
-	};
-
-	let ctx = crate::csl::TransactionContext {
-		payment_key,
-		payment_key_utxos: own_utxos,
-		network: network.to_csl(),
-		protocol_parameters,
 	};
 
 	let tx = Costs::calculate_costs(

--- a/toolkit/offchain/src/init_governance/tests.rs
+++ b/toolkit/offchain/src/init_governance/tests.rs
@@ -1,5 +1,6 @@
 use super::transaction::*;
 use crate::await_tx::mock::ImmediateSuccess;
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::{Costs, OgmiosUtxoExt};
 use crate::init_governance::run_init_governance;
 use crate::scripts_data;
@@ -14,7 +15,7 @@ use ogmios_client::transactions::{
 use ogmios_client::types::*;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey};
+use sidechain_domain::MainchainKeyHash;
 
 fn expected_transaction() -> serde_json::Value {
 	json!({
@@ -168,7 +169,7 @@ async fn transaction_run() {
 	let genesis_utxo = genesis_utxo().to_domain();
 	let (result_genesis_utxo, result_tx) = run_init_governance(
 		governance_authority(),
-		payment_key_domain(),
+		&payment_key_domain(),
 		Some(genesis_utxo),
 		&mock_client,
 		ImmediateSuccess,
@@ -193,12 +194,15 @@ fn genesis_utxo() -> OgmiosUtxo {
 	}
 }
 
-fn payment_key_domain() -> MainchainPrivateKey {
-	MainchainPrivateKey(hex!("94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"))
+const PAYMENT_KEY_BYTES: [u8; 32] =
+	hex!("94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04");
+
+fn payment_key_domain() -> CardanoPaymentSigningKey {
+	CardanoPaymentSigningKey::from_normal_bytes(PAYMENT_KEY_BYTES).unwrap()
 }
 
 fn payment_key() -> PrivateKey {
-	PrivateKey::from_normal_bytes(&payment_key_domain().0).unwrap()
+	PrivateKey::from_normal_bytes(&PAYMENT_KEY_BYTES).unwrap()
 }
 
 fn tx_context() -> TransactionContext {

--- a/toolkit/offchain/src/lib.rs
+++ b/toolkit/offchain/src/lib.rs
@@ -2,6 +2,8 @@
 
 /// Primitives used for awaiting for tx being observed on the blockchain
 pub mod await_tx;
+/// Parsing and wrapping of Cardano keys
+pub mod cardano_keys;
 /// General purpose code for interacting with cardano-serialization-lib
 pub mod csl;
 /// Supports D-Parameter upsert

--- a/toolkit/offchain/src/permissioned_candidates.rs
+++ b/toolkit/offchain/src/permissioned_candidates.rs
@@ -13,7 +13,7 @@ use crate::csl::{
 };
 use crate::init_governance::{self, GovernanceData};
 use crate::plutus_script::PlutusScript;
-use crate::scripts_data;
+use crate::{cardano_keys::CardanoPaymentSigningKey, scripts_data};
 use anyhow::anyhow;
 use cardano_serialization_lib::{
 	BigInt, PlutusData, Transaction, TransactionBuilder, TxInputsBuilder,
@@ -33,7 +33,7 @@ pub trait UpsertPermissionedCandidates {
 		&self,
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
-		payment_signing_key: [u8; 32],
+		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> anyhow::Result<Option<McTxHash>>;
 }
 
@@ -44,7 +44,7 @@ impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId>
 		&self,
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
-		payment_signing_key: [u8; 32],
+		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> anyhow::Result<Option<McTxHash>> {
 		upsert_permissioned_candidates(
 			genesis_utxo,
@@ -63,7 +63,7 @@ pub async fn upsert_permissioned_candidates<
 >(
 	genesis_utxo: UtxoId,
 	candidates: &[PermissionedCandidateData],
-	payment_signing_key: [u8; 32],
+	payment_signing_key: &CardanoPaymentSigningKey,
 	ogmios_client: &C,
 	await_tx: &A,
 ) -> anyhow::Result<Option<McTxHash>> {

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -18,6 +18,7 @@
 use super::ReserveData;
 use crate::{
 	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
 	csl::{
 		get_builder_config, CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt,
 		TransactionContext, TransactionOutputAmountBuilderExt,
@@ -45,7 +46,7 @@ pub async fn create_reserve_utxo<
 >(
 	parameters: ReserveParameters,
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<McTxHash> {

--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -18,6 +18,7 @@
 use super::{reserve_utxo_input_with_validator_script_reference, ReserveData, TokenAmount};
 use crate::{
 	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
 	csl::{
 		get_builder_config, CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt,
 		TransactionContext, TransactionOutputAmountBuilderExt,
@@ -45,7 +46,7 @@ pub async fn deposit_to_reserve<
 >(
 	parameters: TokenAmount,
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<McTxHash> {

--- a/toolkit/offchain/src/reserve/handover.rs
+++ b/toolkit/offchain/src/reserve/handover.rs
@@ -21,6 +21,7 @@
 use super::{reserve_utxo_input_with_validator_script_reference, ReserveUtxo, TokenAmount};
 use crate::{
 	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
 	csl::{
 		get_builder_config, unit_plutus_data, AssetIdExt, CostStore, Costs, OgmiosUtxoExt,
 		TransactionBuilderExt, TransactionContext, TransactionOutputAmountBuilderExt,
@@ -46,7 +47,7 @@ pub async fn handover_reserve<
 	A: AwaitTx,
 >(
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<McTxHash> {

--- a/toolkit/offchain/src/reserve/init.rs
+++ b/toolkit/offchain/src/reserve/init.rs
@@ -16,6 +16,7 @@
 
 use crate::{
 	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
 	csl::{
 		get_builder_config, CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt,
 		TransactionContext, TransactionOutputAmountBuilderExt,
@@ -45,7 +46,7 @@ pub async fn init_reserve_management<
 	A: AwaitTx,
 >(
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<Vec<McTxHash>> {
@@ -104,7 +105,7 @@ async fn initialize_script<
 >(
 	script: ScriptData,
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<Option<McTxHash>> {

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -20,7 +20,10 @@
 //!       and M tokens are being released, the transaction should mint N+M V-Function tokens.
 //!       These tokens are worthless and don't serve any purpose after the transaction is done.
 use super::{reserve_utxo_input_with_validator_script_reference, ReserveData, TokenAmount};
-use crate::{await_tx::AwaitTx, csl::*, plutus_script::PlutusScript, reserve::ReserveUtxo};
+use crate::{
+	await_tx::AwaitTx, cardano_keys::CardanoPaymentSigningKey, csl::*, plutus_script::PlutusScript,
+	reserve::ReserveUtxo,
+};
 use anyhow::anyhow;
 use cardano_serialization_lib::{
 	Int, MultiAsset, PlutusData, Transaction, TransactionBuilder, TransactionOutputBuilder,
@@ -43,7 +46,7 @@ pub async fn release_reserve_funds<
 	token: TokenAmount,
 	genesis_utxo: UtxoId,
 	reference_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
 ) -> anyhow::Result<McTxHash> {

--- a/toolkit/offchain/src/reserve/update_settings.rs
+++ b/toolkit/offchain/src/reserve/update_settings.rs
@@ -17,6 +17,7 @@
 //!   * Governance Policy Script
 
 use super::{reserve_utxo_input_with_validator_script_reference, ReserveData};
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::reserve::ReserveUtxo;
 use crate::{
 	await_tx::AwaitTx, csl::*, init_governance::get_governance_data,
@@ -37,7 +38,7 @@ pub async fn update_reserve_settings<
 	A: AwaitTx,
 >(
 	genesis_utxo: UtxoId,
-	payment_key: [u8; 32],
+	payment_key: &CardanoPaymentSigningKey,
 	total_accrued_function_script_hash: ScriptHash,
 	client: &T,
 	await_tx: &A,

--- a/toolkit/offchain/src/update_governance/mod.rs
+++ b/toolkit/offchain/src/update_governance/mod.rs
@@ -8,7 +8,9 @@
 use crate::csl::Costs;
 use crate::{
 	await_tx::AwaitTx,
-	csl::{CostStore, InputsBuilderExt, TransactionBuilderExt, TransactionContext},
+	cardano_keys::CardanoPaymentSigningKey,
+	csl::CostStore,
+	csl::{InputsBuilderExt, TransactionBuilderExt, TransactionContext},
 	init_governance::{self, transaction::version_oracle_datum_output, GovernanceData},
 	plutus_script::PlutusScript,
 	scripts_data::multisig_governance_policy_configuration,
@@ -22,7 +24,7 @@ use ogmios_client::{
 	transactions::Transactions,
 	types::OgmiosTx,
 };
-use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, McTxHash, UtxoId, UtxoIndex};
+use sidechain_domain::{MainchainKeyHash, McTxHash, UtxoId, UtxoIndex};
 
 #[cfg(test)]
 mod test;
@@ -34,13 +36,12 @@ pub async fn run_update_governance<
 	A: AwaitTx,
 >(
 	new_governance_authority: MainchainKeyHash,
-	payment_key: MainchainPrivateKey,
+	payment_key: &CardanoPaymentSigningKey,
 	genesis_utxo_id: UtxoId,
 	client: &T,
 	await_tx: A,
 ) -> anyhow::Result<OgmiosTx> {
-	let ctx = TransactionContext::for_payment_key(payment_key.0, client).await?;
-
+	let ctx = TransactionContext::for_payment_key(payment_key, client).await?;
 	let governance_data = init_governance::get_governance_data(genesis_utxo_id, client).await?;
 
 	let tx = Costs::calculate_costs(

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -17,6 +17,7 @@ use ogmios_client::{
 };
 use partner_chains_cardano_offchain::{
 	await_tx::{AwaitTx, FixedDelayRetries},
+	cardano_keys::CardanoPaymentSigningKey,
 	d_param, init_governance, permissioned_candidates,
 	register::Register,
 	reserve::{self, release::release_reserve_funds, TokenAmount},
@@ -25,9 +26,8 @@ use partner_chains_cardano_offchain::{
 use partner_chains_plutus_data::reserve::ReserveDatum;
 use sidechain_domain::{
 	AdaBasedStaking, AssetId, AssetName, AuraPublicKey, CandidateRegistration, DParameter,
-	GrandpaPublicKey, MainchainKeyHash, MainchainPrivateKey, MainchainPublicKey,
-	MainchainSignature, McTxHash, PermissionedCandidateData, PolicyId, SidechainPublicKey,
-	SidechainSignature, UtxoId, UtxoIndex,
+	GrandpaPublicKey, MainchainKeyHash, MainchainPublicKey, MainchainSignature, McTxHash,
+	PermissionedCandidateData, PolicyId, SidechainPublicKey, SidechainSignature, UtxoId, UtxoIndex,
 };
 use std::time::Duration;
 use testcontainers::{clients::Cli, Container, GenericImage};
@@ -40,14 +40,22 @@ const TEST_IMAGE_TAG: &str = "v10.1.4-v6.11.0";
 const GOVERNANCE_AUTHORITY: MainchainKeyHash =
 	MainchainKeyHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b"));
 
-const GOVERNANCE_AUTHORITY_PAYMENT_KEY: MainchainPrivateKey =
-	MainchainPrivateKey(hex!("d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"));
+fn governance_authority_payment_key() -> CardanoPaymentSigningKey {
+	CardanoPaymentSigningKey::from_normal_bytes(hex!(
+		"d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
+	))
+	.unwrap()
+}
 
 const GOVERNANCE_AUTHORITY_ADDRESS: &str =
 	"addr_test1vr5vxqpnpl3325cu4zw55tnapjqzzx78pdrnk8k5j7wl72c6y08nd";
 
-const EVE_PAYMENT_KEY: MainchainPrivateKey =
-	MainchainPrivateKey(hex!("34a6ce19688e950b58ea73803a00db61d0505ba10d65756d85f27c37d24c06af"));
+fn eve_payment_key() -> CardanoPaymentSigningKey {
+	CardanoPaymentSigningKey::from_normal_bytes(hex!(
+		"34a6ce19688e950b58ea73803a00db61d0505ba10d65756d85f27c37d24c06af"
+	))
+	.unwrap()
+}
 
 const EVE_PUBLIC_KEY: MainchainPublicKey =
 	MainchainPublicKey(hex!("a5ab6e82531cac3480cf7ff360f38a0beeea93cabfdd1ed0495e0423f7875c57"));
@@ -84,7 +92,9 @@ async fn governance_flow() {
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_goveranance(&client).await;
 	let _ = run_update_goveranance(&client, genesis_utxo).await;
-	assert!(run_upsert_d_param(genesis_utxo, 0, 1, EVE_PAYMENT_KEY, &client).await.is_some());
+	assert!(run_upsert_d_param(genesis_utxo, 0, 1, &eve_payment_key(), &client)
+		.await
+		.is_some());
 }
 
 #[tokio::test]
@@ -94,13 +104,13 @@ async fn upsert_d_param() {
 	let container = client.run(image);
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_goveranance(&client).await;
-	assert!(run_upsert_d_param(genesis_utxo, 0, 1, GOVERNANCE_AUTHORITY_PAYMENT_KEY, &client)
+	assert!(run_upsert_d_param(genesis_utxo, 0, 1, &governance_authority_payment_key(), &client)
 		.await
 		.is_some());
-	assert!(run_upsert_d_param(genesis_utxo, 0, 1, GOVERNANCE_AUTHORITY_PAYMENT_KEY, &client)
+	assert!(run_upsert_d_param(genesis_utxo, 0, 1, &governance_authority_payment_key(), &client)
 		.await
 		.is_none());
-	assert!(run_upsert_d_param(genesis_utxo, 1, 1, GOVERNANCE_AUTHORITY_PAYMENT_KEY, &client)
+	assert!(run_upsert_d_param(genesis_utxo, 1, 1, &governance_authority_payment_key(), &client)
 		.await
 		.is_some())
 }
@@ -222,7 +232,7 @@ async fn run_init_goveranance<
 	let genesis_utxo = governance_utxos.first().cloned().unwrap().utxo_id();
 	let _ = init_governance::run_init_governance(
 		GOVERNANCE_AUTHORITY,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY,
+		&governance_authority_payment_key(),
 		Some(genesis_utxo),
 		client,
 		FixedDelayRetries::new(Duration::from_millis(500), 100),
@@ -240,7 +250,7 @@ async fn run_update_goveranance<
 ) {
 	let _ = update_governance::run_update_governance(
 		EVE_PUBLIC_KEY_HASH,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY,
+		&governance_authority_payment_key(),
 		genesis_utxo,
 		client,
 		FixedDelayRetries::new(Duration::from_millis(500), 100),
@@ -255,13 +265,13 @@ async fn run_upsert_d_param<
 	genesis_utxo: UtxoId,
 	num_permissioned_candidates: u16,
 	num_registered_candidates: u16,
-	pkey: MainchainPrivateKey,
+	pkey: &CardanoPaymentSigningKey,
 	client: &T,
 ) -> Option<McTxHash> {
 	let tx_hash = d_param::upsert_d_param(
 		genesis_utxo,
 		&DParameter { num_permissioned_candidates, num_registered_candidates },
-		pkey.0,
+		pkey,
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -291,7 +301,7 @@ async fn run_upsert_permissioned_candidates<
 	let tx_hash = permissioned_candidates::upsert_permissioned_candidates(
 		genesis_utxo,
 		&candidates,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -314,7 +324,7 @@ async fn run_init_reserve_management<
 ) -> Vec<McTxHash> {
 	reserve::init::init_reserve_management(
 		genesis_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -339,7 +349,7 @@ async fn run_create_reserve_management<
 			initial_deposit: INITIAL_DEPOSIT_AMOUNT,
 		},
 		genesis_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -356,7 +366,7 @@ async fn run_update_reserve_settings_management<
 ) -> Option<McTxHash> {
 	reserve::update_settings::update_reserve_settings(
 		genesis_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		updated_total_accrued_function_script_hash,
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
@@ -380,7 +390,7 @@ async fn run_deposit_to_reserve<
 			amount: DEPOSIT_AMOUNT,
 		},
 		genesis_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -396,7 +406,7 @@ async fn run_handover_reserve<
 ) -> Result<McTxHash, anyhow::Error> {
 	reserve::handover::handover_reserve(
 		genesis_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -421,7 +431,7 @@ async fn run_release_reserve_funds<
 		},
 		genesis_utxo,
 		reference_utxo,
-		GOVERNANCE_AUTHORITY_PAYMENT_KEY.0,
+		&governance_authority_payment_key(),
 		client,
 		&FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
@@ -451,7 +461,7 @@ async fn run_register<T: QueryLedgerState + Transactions + QueryNetwork + QueryU
 				aura_pub_key: AuraPublicKey([22u8; 32].to_vec()),
 				grandpa_pub_key: GrandpaPublicKey([23u8; 32].to_vec()),
 			},
-			EVE_PAYMENT_KEY,
+			&eve_payment_key(),
 		)
 		.await
 		.unwrap()

--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -1,7 +1,9 @@
 #[cfg(test)]
 mod tests;
 
-use crate::cardano_key::{get_mc_pkey_from_file, get_mc_pubkey_from_file};
+use crate::cardano_key::{
+	get_mc_payment_signing_key_from_file, get_mc_staking_verification_key_from_file,
+};
 use crate::config::config_fields::{
 	CARDANO_COLD_VERIFICATION_KEY_FILE, CARDANO_PAYMENT_SIGNING_KEY_FILE,
 };
@@ -26,10 +28,12 @@ impl CmdRun for DeregisterCmd {
 		context.print("Payment signing key and cold verification key used for registration are required to deregister.");
 		let payment_signing_key_path =
 			CARDANO_PAYMENT_SIGNING_KEY_FILE.prompt_with_default_from_file_and_save(context);
-		let payment_signing_key = get_mc_pkey_from_file(&payment_signing_key_path, context)?;
+		let payment_signing_key =
+			get_mc_payment_signing_key_from_file(&payment_signing_key_path, context)?;
 		let cold_vkey_path =
 			CARDANO_COLD_VERIFICATION_KEY_FILE.prompt_with_default_from_file_and_save(context);
-		let stake_ownership_pub_key = get_mc_pubkey_from_file(&cold_vkey_path, context)?;
+		let stake_ownership_pub_key =
+			get_mc_staking_verification_key_from_file(&cold_vkey_path, context)?;
 		let ogmios_config = establish_ogmios_configuration(context)?;
 		let offchain = context.offchain_impl(&ogmios_config)?;
 
@@ -37,7 +41,7 @@ impl CmdRun for DeregisterCmd {
 		runtime
 			.block_on(offchain.deregister(
 				chain_config.chain_parameters.genesis_utxo,
-				payment_signing_key,
+				&payment_signing_key,
 				stake_ownership_pub_key,
 			))
 			.map_err(|e| anyhow::anyhow!("Candidate deregistration failed: {e:?}!"))?;

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -93,7 +93,7 @@ fn fails_when_payment_signing_key_is_not_valid() {
 	let result = DeregisterCmd.run(&mock_context);
 	assert_eq!(
 		result.err().unwrap().to_string(),
-		r#"Failed to parse Cardano key file my_payment.skey: Error("expected ident", line: 1, column: 2)"#
+		"Failed to parse Cardano key file my_payment.skey: 'expected ident at line 1 column 2'"
 	);
 }
 
@@ -112,7 +112,7 @@ fn fails_when_cold_key_is_not_valid() {
 	let result = DeregisterCmd.run(&mock_context);
 	assert_eq!(
 		result.err().unwrap().to_string(),
-		r#"Failed to parse Cardano key file my_cold.vkey: Error("expected ident", line: 1, column: 2)"#
+		"Failed to parse Cardano key file my_cold.vkey: 'expected ident at line 1 column 2'"
 	);
 }
 
@@ -245,8 +245,8 @@ fn genesis_utxo() -> UtxoId {
 		.unwrap()
 }
 
-fn payment_signing_key() -> MainchainPrivateKey {
-	MainchainPrivateKey(hex!("0000000000000000000000000000000000000000000000000000000000000001"))
+fn payment_signing_key() -> Vec<u8> {
+	hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec()
 }
 
 fn stake_ownership_pub_key() -> MainchainPublicKey {

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -45,8 +45,11 @@ fn derive_address<C: IOContext>(
 	let cardano_payment_verification_key_file =
 		config_fields::CARDANO_PAYMENT_VERIFICATION_KEY_FILE
 			.prompt_with_default_from_file_and_save(context);
-	let key_bytes: [u8; 32] =
-		cardano_key::get_key_bytes_from_file(&cardano_payment_verification_key_file, context)?;
+	let key_bytes: [u8; 32] = cardano_key::get_mc_payment_verification_key_from_file(
+		&cardano_payment_verification_key_file,
+		context,
+	)?
+	.0;
 	let address =
 		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.to_csl());
 	address.to_bech32(None).map_err(|e| anyhow!(e.to_string()))

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -150,8 +150,11 @@ fn derive_address<C: IOContext>(
 	let cardano_payment_verification_key_file =
 		config_fields::CARDANO_PAYMENT_VERIFICATION_KEY_FILE
 			.prompt_with_default_from_file_and_save(context);
-	let key_bytes: [u8; 32] =
-		cardano_key::get_key_bytes_from_file(&cardano_payment_verification_key_file, context)?;
+	let key_bytes: [u8; 32] = cardano_key::get_mc_payment_verification_key_from_file(
+		&cardano_payment_verification_key_file,
+		context,
+	)?
+	.0;
 	let address =
 		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.to_csl());
 	address.to_bech32(None).map_err(|e| anyhow!(e.to_string()))
@@ -431,8 +434,8 @@ mod tests {
 
 	const PAYMENT_VKEY_CONTENT: &str = r#"
 {
-    "type": "StakePoolVerificationKey_ed25519",
-    "description": "Stake Pool Operator Verification Key",
+    "type": "PaymentVerificationKeyShelley_ed25519",
+    "description": "Payment Verification Key",
     "cborHex": "5820a35ef86f1622172816bb9e916aea86903b2c8d32c728ad5c9b9472be7e3c5e88"
 }
 "#;

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -1,4 +1,4 @@
-use crate::cardano_key::get_key_bytes_from_file;
+use crate::cardano_key::get_mc_staking_signing_key_from_file;
 use crate::io::IOContext;
 use crate::CmdRun;
 use clap::Parser;
@@ -63,7 +63,7 @@ fn get_mainchain_cold_skey<C: IOContext>(
 	context: &C,
 	keys_path: &str,
 ) -> Result<MainchainSigningKeyParam, anyhow::Error> {
-	Ok(MainchainSigningKeyParam::from(get_key_bytes_from_file(keys_path, context)?))
+	Ok(MainchainSigningKeyParam::from(get_mc_staking_signing_key_from_file(keys_path, context)?))
 }
 
 #[cfg(test)]

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -1,4 +1,4 @@
-use crate::cardano_key::get_mc_pkey_from_file;
+use crate::cardano_key::get_mc_payment_signing_key_from_file;
 use crate::config;
 use crate::config::config_fields;
 use crate::config::CHAIN_CONFIG_FILE_PATH;
@@ -7,7 +7,6 @@ use crate::main_chain_follower::set_main_chain_follower_env;
 use crate::ogmios::config::establish_ogmios_configuration;
 use crate::CmdRun;
 use clap::Parser;
-use partner_chains_cardano_offchain::csl::MainchainPrivateKeyExt;
 use partner_chains_cardano_offchain::register::Register;
 use sidechain_domain::mainchain_epoch::{MainchainEpochConfig, MainchainEpochDerivation};
 use sidechain_domain::*;
@@ -51,7 +50,7 @@ impl CmdRun for Register3Cmd {
 			context.prompt("Path to mainchain payment signing key file", Some("payment.skey"));
 
 		let payment_signing_key =
-			get_mc_pkey_from_file(&cardano_payment_signing_key_path, context)?;
+			get_mc_payment_signing_key_from_file(&cardano_payment_signing_key_path, context)?;
 		let ogmios_configuration = establish_ogmios_configuration(context)?;
 		let candidate_registration = CandidateRegistration {
 			stake_ownership: AdaBasedStaking {
@@ -72,7 +71,7 @@ impl CmdRun for Register3Cmd {
 			.block_on(offchain.register(
 				self.genesis_utxo,
 				&candidate_registration,
-				payment_signing_key,
+				&payment_signing_key,
 			))
 			.map_err(|e| anyhow::anyhow!("Candidate registration failed: {e:?}!"))?;
 
@@ -350,10 +349,8 @@ mod tests {
 		})
 	}
 
-	fn payment_signing_key() -> MainchainPrivateKey {
-		MainchainPrivateKey(hex!(
-			"d75c630516c33a66b11b3444a70b65083aeb21353bd919cc5e3daa02c9732a84"
-		))
+	fn payment_signing_key() -> Vec<u8> {
+		hex!("d75c630516c33a66b11b3444a70b65083aeb21353bd919cc5e3daa02c9732a84").to_vec()
 	}
 
 	fn chain_config_content() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -236,14 +236,15 @@ fn set_candidates_on_main_chain<C: IOContext>(
 		let ogmios_config = prompt_ogmios_configuration(context)?;
 		let payment_signing_key_path =
 			CARDANO_PAYMENT_SIGNING_KEY_FILE.prompt_with_default_from_file_and_save(context);
-		let pkey = cardano_key::get_mc_pkey_from_file(&payment_signing_key_path, context)?;
+		let pkey =
+			cardano_key::get_mc_payment_signing_key_from_file(&payment_signing_key_path, context)?;
 		let offchain = context.offchain_impl(&ogmios_config)?;
 		let tokio_runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
 		tokio_runtime
 			.block_on(offchain.upsert_permissioned_candidates(
 				genesis_utxo,
 				&candidates.to_candidate_data(),
-				pkey.0,
+				&pkey,
 			))
 			.context("Permissioned candidates update failed")?;
 		context.print("Permissioned candidates updated. The change will be effective in two main chain epochs.");
@@ -273,7 +274,7 @@ fn set_d_parameter_on_main_chain<C: IOContext>(
 		let payment_signing_key_path =
 			CARDANO_PAYMENT_SIGNING_KEY_FILE.prompt_with_default_from_file_and_save(context);
 		let payment_signing_key =
-			cardano_key::get_mc_pkey_from_file(&payment_signing_key_path, context)?;
+			cardano_key::get_mc_payment_signing_key_from_file(&payment_signing_key_path, context)?;
 		let d_parameter =
 			sidechain_domain::DParameter { num_permissioned_candidates, num_registered_candidates };
 		let offchain = context.offchain_impl(&ogmios_config)?;
@@ -281,7 +282,7 @@ fn set_d_parameter_on_main_chain<C: IOContext>(
 		tokio_runtime.block_on(offchain.upsert_d_param(
 			genesis_utxo,
 			&d_parameter,
-			payment_signing_key.0,
+			&payment_signing_key,
 		))?;
 		context.print(&format!("D-parameter updated to ({}, {}). The change will be effective in two main chain epochs.", p, r));
 	}

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -11,8 +11,7 @@ use crate::CmdRun;
 use hex_literal::hex;
 use serde_json::json;
 use sidechain_domain::{
-	AuraPublicKey, DParameter, GrandpaPublicKey, MainchainPrivateKey, McTxHash, SidechainPublicKey,
-	UtxoId,
+	AuraPublicKey, DParameter, GrandpaPublicKey, McTxHash, SidechainPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 
@@ -502,6 +501,6 @@ fn valid_payment_signing_key_content() -> serde_json::Value {
 	})
 }
 
-fn payment_signing_key() -> MainchainPrivateKey {
-	MainchainPrivateKey(hex!("0000000000000000000000000000000000000000000000000000000000000001"))
+fn payment_signing_key() -> Vec<u8> {
+	hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec()
 }


### PR DESCRIPTION
# Description

This allows to use `PaymentExtendedSigningKeyShelley_ed25519_bip32` as private/signing key and `PaymentExtendedVerificationKeyShelley_ed25519_bip32` as verification/public key.

Introduced `CardanoPaymentSigningKey` this is verbose name, but explains what it is for. Our domain `MainchainPrivateKey` wasn't suitable because it is restricted to 32 bytes and also it in fact represents (or it was meant to represent) **Stake (cold) key**.

`CardanoKeyFileContent` removed from both wizards and smart-contracts-commands crates and placed into offchain, as it is used by all three.

In wizards (partner-chains-cli) I've separate function for reading:
 * payment signing key (extended or normal)
 * payment verification key (extended or normal)
 * staking verification key
 * staking signing key

These function check key type and it is more strict behavior that will trigger error if someone mixes staking with payment keys.


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff



