### PR TITLE
chore: rename MainchainAddressHash to MainchainKeyHash

### DIFF
--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -164,7 +164,9 @@ where
 		},
 		PartnerChainsSubcommand::Wizards(cmd) => {
 			setup_log4rs()?;
-			Ok(cmd.run(&DefaultCmdRunContext).map_err(|e| sc_cli::Error::Application(e.into()))?)
+			Ok(cmd
+				.run(&DefaultCmdRunContext)
+				.map_err(|e| sc_cli::Error::Application(e.into()))?)
 		},
 	}
 }

--- a/toolkit/cli/smart-contracts-commands/src/governance.rs
+++ b/toolkit/cli/smart-contracts-commands/src/governance.rs
@@ -4,7 +4,7 @@ use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries, init_governance::run_init_governance,
 	update_governance::run_update_governance,
 };
-use sidechain_domain::{MainchainAddressHash, UtxoId};
+use sidechain_domain::{MainchainKeyHash, UtxoId};
 
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
@@ -30,7 +30,7 @@ pub struct InitGovernanceCmd {
 	common_arguments: crate::CommonArguments,
 	/// Governance authority hash to be set.
 	#[arg(long, short = 'g')]
-	governance_authority: MainchainAddressHash,
+	governance_authority: MainchainKeyHash,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the new chain, it will be spent durning initialization. If not set, then one will be selected from UTXOs of the payment key.
@@ -61,7 +61,7 @@ pub struct UpdateGovernanceCmd {
 	common_arguments: crate::CommonArguments,
 	/// Governance authority hash to be set.
 	#[arg(long, short = 'g')]
-	new_governance_authority: MainchainAddressHash,
+	new_governance_authority: MainchainKeyHash,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
 	/// Genesis UTXO of the chain

--- a/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -181,15 +181,15 @@ impl CandidatesDataSourceImpl {
 
 	fn make_stake_map(
 		stake_pool_entries: Vec<StakePoolEntry>,
-	) -> HashMap<MainchainAddressHash, StakeDelegation> {
+	) -> HashMap<MainchainKeyHash, StakeDelegation> {
 		stake_pool_entries
 			.into_iter()
-			.map(|e| (MainchainAddressHash(e.pool_hash), StakeDelegation(e.stake.0)))
+			.map(|e| (MainchainKeyHash(e.pool_hash), StakeDelegation(e.stake.0)))
 			.collect()
 	}
 
 	fn get_stake_delegation(
-		stake_map: &HashMap<MainchainAddressHash, StakeDelegation>,
+		stake_map: &HashMap<MainchainKeyHash, StakeDelegation>,
 		mainchain_pub_key: &MainchainPublicKey,
 	) -> Option<StakeDelegation> {
 		if stake_map.is_empty() {
@@ -197,7 +197,7 @@ impl CandidatesDataSourceImpl {
 		} else {
 			Some(
 				stake_map
-					.get(&MainchainAddressHash::from_vkey(mainchain_pub_key.0))
+					.get(&MainchainKeyHash::from_vkey(mainchain_pub_key.0))
 					.cloned()
 					.unwrap_or(StakeDelegation(0)),
 			)

--- a/toolkit/offchain/src/csl.rs
+++ b/toolkit/offchain/src/csl.rs
@@ -10,7 +10,7 @@ use ogmios_client::{
 	transactions::OgmiosEvaluateTransactionResponse,
 	types::{OgmiosUtxo, OgmiosValue},
 };
-use sidechain_domain::{AssetId, MainchainAddressHash, MainchainPrivateKey, NetworkType, UtxoId};
+use sidechain_domain::{AssetId, MainchainKeyHash, MainchainPrivateKey, NetworkType, UtxoId};
 use std::collections::HashMap;
 
 pub(crate) fn plutus_script_hash(script_bytes: &[u8], language: Language) -> [u8; 28] {
@@ -364,11 +364,11 @@ impl UtxoIdExt for UtxoId {
 }
 
 pub trait MainchainPrivateKeyExt {
-	fn to_pub_key_hash(&self) -> MainchainAddressHash;
+	fn to_pub_key_hash(&self) -> MainchainKeyHash;
 }
 
 impl MainchainPrivateKeyExt for MainchainPrivateKey {
-	fn to_pub_key_hash(&self) -> MainchainAddressHash {
+	fn to_pub_key_hash(&self) -> MainchainKeyHash {
 		cardano_serialization_lib::PrivateKey::from_normal_bytes(&self.0)
 			.expect("Conversion cannot fail on valid MainchainPrivateKey values")
 			.to_public()
@@ -376,7 +376,7 @@ impl MainchainPrivateKeyExt for MainchainPrivateKey {
 			.to_bytes()
 			.as_slice()
 			.try_into()
-			.map(MainchainAddressHash)
+			.map(MainchainKeyHash)
 			.expect("Conversion cannot fail as representation is the same")
 	}
 }

--- a/toolkit/offchain/src/init_governance/mod.rs
+++ b/toolkit/offchain/src/init_governance/mod.rs
@@ -16,7 +16,7 @@ use ogmios_client::{
 	types::{OgmiosTx, OgmiosUtxo},
 };
 use partner_chains_plutus_data::version_oracle::VersionOracleDatum;
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey, UtxoId};
+use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, UtxoId};
 
 #[cfg(test)]
 mod tests;
@@ -29,7 +29,7 @@ pub trait InitGovernance {
 	#[allow(async_fn_in_trait)]
 	async fn init_governance(
 		&self,
-		governance_authority: MainchainAddressHash,
+		governance_authority: MainchainKeyHash,
 		payment_key: MainchainPrivateKey,
 		genesis_utxo_id: UtxoId,
 	) -> Result<OgmiosTx, OffchainError>;
@@ -41,7 +41,7 @@ where
 {
 	async fn init_governance(
 		&self,
-		governance_authority: MainchainAddressHash,
+		governance_authority: MainchainKeyHash,
 		payment_key: MainchainPrivateKey,
 		genesis_utxo_id: UtxoId,
 	) -> Result<OgmiosTx, OffchainError> {
@@ -62,7 +62,7 @@ pub async fn run_init_governance<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 	A: AwaitTx,
 >(
-	governance_authority: MainchainAddressHash,
+	governance_authority: MainchainKeyHash,
 	payment_key: MainchainPrivateKey,
 	genesis_utxo_id: Option<UtxoId>,
 	client: &T,

--- a/toolkit/offchain/src/init_governance/tests.rs
+++ b/toolkit/offchain/src/init_governance/tests.rs
@@ -14,7 +14,7 @@ use ogmios_client::transactions::{
 use ogmios_client::types::*;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey};
+use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey};
 
 fn expected_transaction() -> serde_json::Value {
 	json!({
@@ -229,8 +229,8 @@ fn version_oracle_policy() -> crate::plutus_script::PlutusScript {
 	version_oracle_policy
 }
 
-fn governance_authority() -> MainchainAddressHash {
-	MainchainAddressHash(hex!("76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"))
+fn governance_authority() -> MainchainKeyHash {
+	MainchainKeyHash(hex!("76da17b2e3371ab7ca88ce0500441149f03cc5091009f99c99c080d9"))
 }
 
 fn payment_utxo() -> OgmiosUtxo {

--- a/toolkit/offchain/src/init_governance/transaction.rs
+++ b/toolkit/offchain/src/init_governance/transaction.rs
@@ -6,10 +6,10 @@ use crate::{
 use cardano_serialization_lib::*;
 use ogmios_client::types::OgmiosUtxo;
 use partner_chains_plutus_data::version_oracle::VersionOracleDatum;
-use sidechain_domain::MainchainAddressHash;
+use sidechain_domain::MainchainKeyHash;
 
 pub(crate) fn init_governance_transaction(
-	governance_authority: MainchainAddressHash,
+	governance_authority: MainchainKeyHash,
 	genesis_utxo: OgmiosUtxo,
 	costs: Costs,
 	ctx: &TransactionContext,

--- a/toolkit/offchain/src/register.rs
+++ b/toolkit/offchain/src/register.rs
@@ -1,5 +1,6 @@
 use crate::csl::{
-	unit_plutus_data, CostStore, Costs, InputsBuilderExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext
+	unit_plutus_data, CostStore, Costs, InputsBuilderExt, OgmiosUtxoExt, TransactionBuilderExt,
+	TransactionContext,
 };
 use crate::csl::{MainchainPrivateKeyExt, TransactionOutputAmountBuilderExt};
 use crate::{
@@ -9,8 +10,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use cardano_serialization_lib::{
-	PlutusData, Transaction, TransactionBuilder, TransactionOutputBuilder,
-	TxInputsBuilder,
+	PlutusData, Transaction, TransactionBuilder, TransactionOutputBuilder, TxInputsBuilder,
 };
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
@@ -178,9 +178,7 @@ pub async fn run_deregister<
 	let own_registration_utxos = own_registrations.iter().map(|r| r.0.clone()).collect::<Vec<_>>();
 
 	let tx = Costs::calculate_costs(
-		|costs| {
-			deregister_tx(&validator, &own_registration_utxos, costs, &ctx)
-		},
+		|costs| deregister_tx(&validator, &own_registration_utxos, costs, &ctx),
 		client,
 	)
 	.await?;
@@ -201,7 +199,7 @@ pub async fn run_deregister<
 }
 
 fn get_own_registrations(
-	own_pkh: MainchainAddressHash,
+	own_pkh: MainchainKeyHash,
 	spo_pub_key: MainchainPublicKey,
 	validator_utxos: &[OgmiosUtxo],
 ) -> Vec<(OgmiosUtxo, CandidateRegistration)> {
@@ -302,9 +300,7 @@ mod tests {
 	use super::register_tx;
 	use crate::csl::{Costs, OgmiosUtxoExt, TransactionContext};
 	use crate::test_values::{self, *};
-	use cardano_serialization_lib::{
-		Address, NetworkIdKind, Transaction, TransactionInputs,
-	};
+	use cardano_serialization_lib::{Address, NetworkIdKind, Transaction, TransactionInputs};
 	use ogmios_client::types::OgmiosValue;
 	use ogmios_client::types::{OgmiosTx, OgmiosUtxo};
 	use partner_chains_plutus_data::registered_candidates::candidate_registration_to_plutus_data;
@@ -315,9 +311,8 @@ mod tests {
 	};
 
 	use sidechain_domain::{
-		AdaBasedStaking, AuraPublicKey, CandidateRegistration, GrandpaPublicKey,
-		MainchainAddressHash, MainchainSignature, McTxHash, SidechainPublicKey, SidechainSignature,
-		UtxoId, UtxoIndex,
+		AdaBasedStaking, AuraPublicKey, CandidateRegistration, GrandpaPublicKey, MainchainKeyHash,
+		MainchainSignature, McTxHash, SidechainPublicKey, SidechainSignature, UtxoId, UtxoIndex,
 	};
 
 	fn sum_lovelace(utxos: &[OgmiosUtxo]) -> u64 {
@@ -327,8 +322,8 @@ mod tests {
 	const MIN_UTXO_LOVELACE: u64 = 1000000;
 	const FIVE_ADA: u64 = 5000000;
 
-	fn own_pkh() -> MainchainAddressHash {
-		MainchainAddressHash([0; 28])
+	fn own_pkh() -> MainchainKeyHash {
+		MainchainKeyHash([0; 28])
 	}
 	fn candidate_registration(registration_utxo: UtxoId) -> CandidateRegistration {
 		CandidateRegistration {

--- a/toolkit/offchain/src/scripts_data.rs
+++ b/toolkit/offchain/src/scripts_data.rs
@@ -2,7 +2,7 @@ use crate::{csl::NetworkTypeExt, plutus_script::PlutusScript, OffchainError};
 use cardano_serialization_lib::{Language, NetworkIdKind};
 use ogmios_client::query_network::QueryNetwork;
 use serde::Serialize;
-use sidechain_domain::{MainchainAddressHash, PolicyId, UtxoId};
+use sidechain_domain::{MainchainKeyHash, PolicyId, UtxoId};
 use uplc::PlutusData;
 
 /// Provides convenient access to the addresses and hashes of the partner chain smart contracts.
@@ -242,7 +242,7 @@ pub(crate) fn reserve_scripts(
 // Returns the simplest MultiSig policy configuration plutus data:
 // there is one required authority and it is the governance authority from sidechain params.
 pub(crate) fn multisig_governance_policy_configuration(
-	governance_authority: MainchainAddressHash,
+	governance_authority: MainchainKeyHash,
 ) -> PlutusData {
 	PlutusData::Array(vec![
 		PlutusData::Array(vec![uplc::PlutusData::BoundedBytes(

--- a/toolkit/offchain/src/update_governance/mod.rs
+++ b/toolkit/offchain/src/update_governance/mod.rs
@@ -22,7 +22,7 @@ use ogmios_client::{
 	transactions::Transactions,
 	types::OgmiosTx,
 };
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey, McTxHash, UtxoId, UtxoIndex};
+use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, McTxHash, UtxoId, UtxoIndex};
 
 #[cfg(test)]
 mod test;
@@ -33,7 +33,7 @@ pub async fn run_update_governance<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 	A: AwaitTx,
 >(
-	new_governance_authority: MainchainAddressHash,
+	new_governance_authority: MainchainKeyHash,
 	payment_key: MainchainPrivateKey,
 	genesis_utxo_id: UtxoId,
 	client: &T,
@@ -80,7 +80,7 @@ fn update_governance_tx(
 	version_oracle_validator: &[u8],
 	version_oracle_policy: &[u8],
 	genesis_utxo: UtxoId,
-	new_governance_authority: MainchainAddressHash,
+	new_governance_authority: MainchainKeyHash,
 	governance_data: &GovernanceData,
 	costs: Costs,
 	ctx: &TransactionContext,

--- a/toolkit/offchain/src/update_governance/test.rs
+++ b/toolkit/offchain/src/update_governance/test.rs
@@ -6,7 +6,7 @@ use cardano_serialization_lib::*;
 use hex_literal::hex;
 use ogmios_client::types::{Asset, Datum, OgmiosTx, OgmiosUtxo, OgmiosValue};
 use pretty_assertions::assert_eq;
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey};
+use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey};
 
 fn payment_key_domain() -> MainchainPrivateKey {
 	MainchainPrivateKey(hex!("94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"))
@@ -95,10 +95,8 @@ fn governance_data() -> GovernanceData {
 	GovernanceData { policy_script: governance_script(), utxo: governance_utxo() }
 }
 
-fn new_governance_authority() -> MainchainAddressHash {
-	MainchainAddressHash(hex_literal::hex!(
-		"84ba05c28879b299a8377e62128adc7a0e0df3ac438ff95efc7c8443"
-	))
+fn new_governance_authority() -> MainchainKeyHash {
+	MainchainKeyHash(hex_literal::hex!("84ba05c28879b299a8377e62128adc7a0e0df3ac438ff95efc7c8443"))
 }
 
 fn mint_ex_units() -> ExUnits {

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -25,7 +25,7 @@ use partner_chains_cardano_offchain::{
 use partner_chains_plutus_data::reserve::ReserveDatum;
 use sidechain_domain::{
 	AdaBasedStaking, AssetId, AssetName, AuraPublicKey, CandidateRegistration, DParameter,
-	GrandpaPublicKey, MainchainAddressHash, MainchainPrivateKey, MainchainPublicKey,
+	GrandpaPublicKey, MainchainKeyHash, MainchainPrivateKey, MainchainPublicKey,
 	MainchainSignature, McTxHash, PermissionedCandidateData, PolicyId, SidechainPublicKey,
 	SidechainSignature, UtxoId, UtxoIndex,
 };
@@ -37,8 +37,8 @@ const TEST_IMAGE: &str = "ghcr.io/input-output-hk/smart-contracts-tests-cardano-
 
 const TEST_IMAGE_TAG: &str = "v10.1.4-v6.11.0";
 
-const GOVERNANCE_AUTHORITY: MainchainAddressHash =
-	MainchainAddressHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b"));
+const GOVERNANCE_AUTHORITY: MainchainKeyHash =
+	MainchainKeyHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b"));
 
 const GOVERNANCE_AUTHORITY_PAYMENT_KEY: MainchainPrivateKey =
 	MainchainPrivateKey(hex!("d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"));
@@ -52,8 +52,8 @@ const EVE_PAYMENT_KEY: MainchainPrivateKey =
 const EVE_PUBLIC_KEY: MainchainPublicKey =
 	MainchainPublicKey(hex!("a5ab6e82531cac3480cf7ff360f38a0beeea93cabfdd1ed0495e0423f7875c57"));
 
-const EVE_PUBLIC_KEY_HASH: MainchainAddressHash =
-	MainchainAddressHash(hex!("84ba05c28879b299a8377e62128adc7a0e0df3ac438ff95efc7c8443"));
+const EVE_PUBLIC_KEY_HASH: MainchainKeyHash =
+	MainchainKeyHash(hex!("84ba05c28879b299a8377e62128adc7a0e0df3ac438ff95efc7c8443"));
 
 const EVE_ADDRESS: &str = "addr_test1vzzt5pwz3pum9xdgxalxyy52m3aqur0n43pcl727l37ggscl8h7v8";
 

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -6,7 +6,7 @@ use crate::{
 use ogmios_client::types::OgmiosTx;
 use partner_chains_cardano_offchain::csl::MainchainPrivateKeyExt;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
-use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey, UtxoId};
+use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, UtxoId};
 
 pub(crate) fn run_init_governance<C: IOContext>(
 	genesis_utxo: UtxoId,
@@ -23,7 +23,7 @@ pub(crate) fn run_init_governance<C: IOContext>(
 
 fn get_private_key_and_key_hash<C: IOContext>(
 	context: &C,
-) -> Result<(MainchainPrivateKey, MainchainAddressHash), anyhow::Error> {
+) -> Result<(MainchainPrivateKey, MainchainKeyHash), anyhow::Error> {
 	let cardano_signing_key_file = config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE
 		.prompt_with_default_from_file_and_save(context);
 	let pkey = cardano_key::get_mc_pkey_from_file(&cardano_signing_key_file, context)?;
@@ -45,7 +45,7 @@ mod tests {
 	use hex_literal::hex;
 	use ogmios_client::types::OgmiosTx;
 	use serde_json::{json, Value};
-	use sidechain_domain::{MainchainAddressHash, MainchainPrivateKey, UtxoId};
+	use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey, UtxoId};
 
 	#[test]
 	fn happy_path() {
@@ -98,7 +98,7 @@ mod tests {
 	fn preprod_offchain_mocks() -> OffchainMocks {
 		let mock = OffchainMock::new().with_init_governance(
 			TEST_GENESIS_UTXO,
-			MainchainAddressHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b")),
+			MainchainKeyHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b")),
 			MainchainPrivateKey(hex!(
 				"d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
 			)),

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -421,7 +421,7 @@ mod tests {
 			},
 			partner_chain_pub_key: SidechainPublicKey(hex!("020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1").to_vec()),
 			partner_chain_signature: SidechainSignature(hex!("cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854").to_vec()),
-			own_pkh: MainchainAddressHash(hex!("7fa48bb8fb5d6804fad26237738ce490d849e4567161e38ab8415ff3")),
+			own_pkh: MainchainKeyHash(hex!("7fa48bb8fb5d6804fad26237738ce490d849e4567161e38ab8415ff3")),
 			registration_utxo: UtxoId { tx_hash: McTxHash(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13")), index: UtxoIndex(0) },
 			aura_pub_key: AuraPublicKey(hex!("79c3b7fc0b7697b9414cb87adcb37317d1cab32818ae18c0e97ad76395d1fdcf").to_vec()),
 			grandpa_pub_key: GrandpaPublicKey(hex!("1a55db596380bc63f5ee964565359b5ea8e0096c798c3281692df097abbd9aa4b657f887915ad2a52fc85c674ef4044baeaf7149546af93a2744c379b9798f07").to_vec())

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -10,8 +10,8 @@ use partner_chains_cardano_offchain::scripts_data::{GetScriptsData, ScriptsData}
 use partner_chains_cardano_offchain::OffchainError;
 use pretty_assertions::assert_eq;
 use sidechain_domain::{
-	CandidateRegistration, DParameter, MainchainAddressHash, MainchainPrivateKey,
-	MainchainPublicKey, McTxHash, UtxoId,
+	CandidateRegistration, DParameter, MainchainKeyHash, MainchainPrivateKey, MainchainPublicKey,
+	McTxHash, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 use std::collections::HashMap;
@@ -256,10 +256,8 @@ impl OffchainMocks {
 #[derive(Default, Clone)]
 pub struct OffchainMock {
 	pub scripts_data: HashMap<UtxoId, Result<ScriptsData, OffchainError>>,
-	pub init_governance: HashMap<
-		(UtxoId, MainchainAddressHash, MainchainPrivateKey),
-		Result<OgmiosTx, OffchainError>,
-	>,
+	pub init_governance:
+		HashMap<(UtxoId, MainchainKeyHash, MainchainPrivateKey), Result<OgmiosTx, OffchainError>>,
 	pub upsert_d_param: HashMap<(UtxoId, DParameter, [u8; 32]), Result<Option<McTxHash>, String>>,
 	pub upsert_permissioned_candidates: HashMap<
 		(UtxoId, Vec<sidechain_domain::PermissionedCandidateData>, [u8; 32]),
@@ -291,7 +289,7 @@ impl OffchainMock {
 	pub(crate) fn with_init_governance(
 		self,
 		genesis_utxo: UtxoId,
-		governance: MainchainAddressHash,
+		governance: MainchainKeyHash,
 		payment_key: MainchainPrivateKey,
 		result: Result<OgmiosTx, OffchainError>,
 	) -> Self {
@@ -369,7 +367,7 @@ impl GetScriptsData for OffchainMock {
 impl InitGovernance for OffchainMock {
 	async fn init_governance(
 		&self,
-		governance_authority: MainchainAddressHash,
+		governance_authority: MainchainKeyHash,
 		payment_key: MainchainPrivateKey,
 		genesis_utxo_id: UtxoId,
 	) -> Result<OgmiosTx, OffchainError> {

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -274,9 +274,10 @@ impl TryFrom<Vec<u8>> for MainchainPublicKey {
 	}
 }
 
-pub const MAINCHAIN_ADDRESS_HASH_LEN: usize = 28;
+pub const MAINCHAIN_KEY_HASH_LEN: usize = 28;
 
-/// Some hash of MainchainAddress, 28 bytes. Presumably blake2b_224.
+/// blake2b_224 hash of a Cardano Verification (Public) Key.
+/// It can be a hash of Payment Verification, Payment Extended Verification or Staking Verification Key.
 /// Way to get it: cardano-cli latest address key-hash --payment-verification-key-file FILE
 #[derive(
 	Clone, Copy, Decode, Default, Eq, Encode, Hash, MaxEncodedLen, PartialEq, ToDatum, TypeInfo,
@@ -284,16 +285,16 @@ pub const MAINCHAIN_ADDRESS_HASH_LEN: usize = 28;
 #[byte_string(debug)]
 #[cfg_attr(feature = "std", byte_string(to_hex_string, decode_hex))]
 #[cfg_attr(feature = "serde", byte_string(hex_serialize, hex_deserialize))]
-pub struct MainchainAddressHash(pub [u8; MAINCHAIN_ADDRESS_HASH_LEN]);
+pub struct MainchainKeyHash(pub [u8; MAINCHAIN_KEY_HASH_LEN]);
 
-impl Display for MainchainAddressHash {
+impl Display for MainchainKeyHash {
 	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
 		let hash = sp_core::hexdisplay::HexDisplay::from(&self.0);
 		write!(f, "0x{}", hash)
 	}
 }
 
-impl MainchainAddressHash {
+impl MainchainKeyHash {
 	pub fn from_vkey(vkey: [u8; 32]) -> Self {
 		Self(blake2b(&vkey))
 	}
@@ -695,7 +696,7 @@ pub struct CandidateRegistration {
 	pub stake_ownership: AdaBasedStaking,
 	pub partner_chain_pub_key: SidechainPublicKey,
 	pub partner_chain_signature: SidechainSignature,
-	pub own_pkh: MainchainAddressHash,
+	pub own_pkh: MainchainKeyHash,
 	pub registration_utxo: UtxoId,
 	pub aura_pub_key: AuraPublicKey,
 	pub grandpa_pub_key: GrandpaPublicKey,

--- a/toolkit/primitives/plutus-data/src/registered_candidates.rs
+++ b/toolkit/primitives/plutus-data/src/registered_candidates.rs
@@ -43,7 +43,7 @@ pub enum RegisterValidatorDatum {
 		sidechain_signature: SidechainSignature,
 		registration_utxo: UtxoId,
 		//own_pkh is used by offchain code to find the registration UTXO when re-registering or deregistering
-		own_pkh: MainchainAddressHash,
+		own_pkh: MainchainKeyHash,
 		aura_pub_key: AuraPublicKey,
 		grandpa_pub_key: GrandpaPublicKey,
 	},
@@ -132,7 +132,7 @@ fn decode_v0_register_validator_datum(
 	let aura_pub_key = fields.get(4).as_bytes().map(AuraPublicKey)?;
 	let grandpa_pub_key = fields.get(5).as_bytes().map(GrandpaPublicKey)?;
 
-	let own_pkh = MainchainAddressHash(datum.as_bytes()?.try_into().ok()?);
+	let own_pkh = MainchainKeyHash(datum.as_bytes()?.try_into().ok()?);
 	Some(RegisterValidatorDatum::V0 {
 		stake_ownership,
 		sidechain_pub_key,
@@ -155,7 +155,7 @@ fn decode_legacy_register_validator_datum(datum: &PlutusData) -> Option<Register
 	let sidechain_pub_key = fields.get(1).as_bytes().map(SidechainPublicKey)?;
 	let sidechain_signature = fields.get(2).as_bytes().map(SidechainSignature)?;
 	let registration_utxo = decode_utxo_id_datum(fields.get(3))?;
-	let own_pkh = MainchainAddressHash(fields.get(4).as_bytes()?.try_into().ok()?);
+	let own_pkh = MainchainKeyHash(fields.get(4).as_bytes()?.try_into().ok()?);
 	let aura_pub_key = fields.get(5).as_bytes().map(AuraPublicKey)?;
 	let grandpa_pub_key = fields.get(6).as_bytes().map(GrandpaPublicKey)?;
 	Some(RegisterValidatorDatum::V0 {
@@ -270,7 +270,7 @@ mod tests {
 				tx_hash: McTxHash(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13")),
 				index: UtxoIndex(1),
 			},
-			own_pkh: MainchainAddressHash(hex!("aabbccddeeff00aabbccddeeff00aabbccddeeff00aabbccddeeff00")),
+			own_pkh: MainchainKeyHash(hex!("aabbccddeeff00aabbccddeeff00aabbccddeeff00aabbccddeeff00")),
 			aura_pub_key: AuraPublicKey(hex!("d43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d").into()),
 			grandpa_pub_key: GrandpaPublicKey(hex!("88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee").into()),
 		}


### PR DESCRIPTION
# Description

`MainchainAddressHash` name is just invalid. It is not a hash of address.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff


