### PR TITLE
test-refactor: do not overspecify read operations order or number

### DIFF
--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -11,13 +11,11 @@ fn happy_path() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content())
 		.with_json_file("chain-spec.json", test_chain_spec_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			show_intro(),
 			show_chain_parameters(),
 			show_initial_permissioned_candidates(),
 			MockIO::prompt_yes_no("Do you want to continue?", true, true),
 			run_build_spec_io(Ok("ok".to_string())),
-			read_chain_spec_io(),
 			write_updated_chain_spec_io(),
 			show_outro(),
 		]);
@@ -30,7 +28,6 @@ fn shows_warning_when_initial_candidates_are_empty() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_with_empty_initial_permissioned_candidates())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			show_intro(),
 			show_chain_parameters(),
 			MockIO::print(&"WARNING: The list of initial permissioned candidates is empty. Generated chain spec will not allow the chain to start.".red().to_string()),
@@ -49,7 +46,6 @@ fn instruct_user_when_config_file_is_invalid() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_without_initial_permissioned_candidates())
 		.with_expected_io(vec![
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH), //reads initial_permissioned_candidates
 			MockIO::eprint("The 'partner-chains-cli-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
@@ -63,7 +59,6 @@ fn instruct_user_when_config_file_has_a_field_in_wrong_format() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_with_a_field_in_wrong_format())
 		.with_expected_io(vec![
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH), //reads initial_permissioned_candidates
 			MockIO::eprint("The 'partner-chains-cli-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
@@ -77,13 +72,11 @@ fn errors_if_chain_spec_is_missing() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			show_intro(),
 			show_chain_parameters(),
 			show_initial_permissioned_candidates(),
 			MockIO::prompt_yes_no("Do you want to continue?", true, true),
 			run_build_spec_io(Ok("ok".to_string())),
-			read_chain_spec_io(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
 	let err = result.expect_err("should return error");
@@ -100,7 +93,6 @@ fn forwards_build_spec_error_if_it_fails() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content())
 		.with_json_file("chain-spec.json", test_chain_spec_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			show_intro(),
 			show_chain_parameters(),
 			show_initial_permissioned_candidates(),
@@ -267,10 +259,6 @@ fn run_build_spec_io(output: Result<String, anyhow::Error>) -> MockIO {
 	])
 }
 
-fn read_chain_spec_io() -> MockIO {
-	MockIO::Group(vec![MockIO::file_read("chain-spec.json")])
-}
-
 fn write_updated_chain_spec_io() -> MockIO {
 	MockIO::file_write_json(
 		"chain-spec.json",
@@ -334,18 +322,5 @@ fn show_outro() -> MockIO {
 		MockIO::print("chain-spec.json file has been created."),
 		MockIO::print("If you are the governance authority, you can distribute it to the validators."),
 		MockIO::print("Run 'setup-main-chain-state' command to set D-parameter and permissioned candidates on Cardano."),
-	])
-}
-
-fn read_chain_config_io() -> MockIO {
-	MockIO::Group(vec![
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // genesis utxo
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // initial permissioned candidates
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // committee candidates address
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // d parameter policy id
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // permissioned candidates policy id
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // native token policy id
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // native token asset name
-		MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // illiquid supply validator address
 	])
 }

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -30,7 +30,6 @@ fn happy_path() {
 		.with_json_file(MY_COLD_VKEY, valid_cold_verification_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
 			print_info_io(),
 			read_keys_io(),
 			establish_ogmios_configuration_io(None, default_ogmios_service_config()),
@@ -54,7 +53,6 @@ fn errors_if_smart_contracts_dont_output_transaction_id() {
 		.with_json_file(MY_COLD_VKEY, valid_cold_verification_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
 			print_info_io(),
 			read_keys_io(),
 			establish_ogmios_configuration_io(None, default_ogmios_service_config()),
@@ -68,9 +66,8 @@ fn errors_if_smart_contracts_dont_output_transaction_id() {
 
 #[test]
 fn fails_when_chain_config_is_not_valid() {
-	let mock_context = MockIOContext::new()
-		.with_json_file(CHAIN_CONFIG_FILE_PATH, invalid_chain_config_content())
-		.with_expected_io(vec![MockIO::file_read(CHAIN_CONFIG_FILE_PATH)]);
+	let mock_context =
+		MockIOContext::new().with_json_file(CHAIN_CONFIG_FILE_PATH, invalid_chain_config_content());
 	let result = DeregisterCmd.run(&mock_context);
 	assert_eq!(
 	    result.err().unwrap().to_string(),
@@ -85,7 +82,6 @@ fn fails_when_payment_signing_key_is_not_valid() {
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_file(MY_PAYMEMENT_SKEY, "not a proper Cardano key json")
 		.with_expected_io(vec![
-            MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
 			print_info_io(),
             MockIO::print("Payment signing key and cold verification key used for registration are required to deregister."),
             read_payment_signing_key()
@@ -104,11 +100,7 @@ fn fails_when_cold_key_is_not_valid() {
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_json_file(MY_PAYMEMENT_SKEY, valid_payment_signing_key_content())
 		.with_file(MY_COLD_VKEY, "not a proper Cardano key json")
-		.with_expected_io(vec![
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
-			print_info_io(),
-			read_keys_io(),
-		]);
+		.with_expected_io(vec![print_info_io(), read_keys_io()]);
 	let result = DeregisterCmd.run(&mock_context);
 	assert_eq!(
 		result.err().unwrap().to_string(),
@@ -137,33 +129,27 @@ fn read_keys_io() -> MockIO {
 
 fn read_payment_signing_key() -> MockIO {
 	MockIO::Group(vec![
-		MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 		MockIO::prompt(
 			"path to the payment signing key file",
 			Some("payment.skey"),
 			MY_PAYMEMENT_SKEY,
 		),
-		MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 		MockIO::file_write_json_contains(
 			RESOURCES_CONFIG_FILE_PATH,
 			"/cardano_payment_signing_key_file",
 			MY_PAYMEMENT_SKEY,
 		),
-		MockIO::file_read(MY_PAYMEMENT_SKEY),
 	])
 }
 
 fn read_cold_verification_key() -> MockIO {
 	MockIO::Group(vec![
-		MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 		MockIO::prompt("path to the cold verification key file", Some("cold.vkey"), MY_COLD_VKEY),
-		MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 		MockIO::file_write_json_contains(
 			RESOURCES_CONFIG_FILE_PATH,
 			"/cardano_cold_verification_key_file",
 			MY_COLD_VKEY,
 		),
-		MockIO::file_read(MY_COLD_VKEY),
 	])
 }
 

--- a/toolkit/partner-chains-cli/src/generate_keys/tests.rs
+++ b/toolkit/partner-chains-cli/src/generate_keys/tests.rs
@@ -85,7 +85,6 @@ pub mod scenarios {
 
 	pub fn generate_network_key() -> MockIO {
 		MockIO::Group(vec![
-			MockIO::file_read(&network_key_file()),
 			MockIO::eprint("⚙️ Generating network key"),
 			MockIO::run_command(
 				&format!("<mock executable> key generate-node-key --base-path {DATA_PATH}"),
@@ -193,12 +192,9 @@ mod config_read {
 					"substrate_node_base_path": DATA_PATH,
 				}),
 			)
-			.with_expected_io(vec![
-				MockIO::file_read(RESOURCES_CONFIG_PATH),
-				MockIO::eprint(&format!(
-					"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_PATH}): {DATA_PATH}"
-				)),
-			]);
+			.with_expected_io(vec![MockIO::eprint(&format!(
+				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_PATH}): {DATA_PATH}"
+			))]);
 
 		let result = GenerateKeysConfig::load(&context);
 
@@ -285,7 +281,6 @@ mod generate_network_key {
 	#[test]
 	fn generates_new_key_when_missing() {
 		let context = MockIOContext::new().with_expected_io(vec![
-			MockIO::file_read(&network_key_file()),
 			MockIO::eprint("⚙️ Generating network key"),
 			MockIO::run_command(
 				&format!("<mock executable> key generate-node-key --base-path {DATA_PATH}"),
@@ -305,7 +300,6 @@ mod generate_network_key {
 
 		let context =
 			MockIOContext::new().with_file(&network_key_file(), key).with_expected_io(vec![
-				MockIO::file_read(&network_key_file()),
 				MockIO::eprint("🔑 A valid network key is already present in the keystore, skipping generation")
 			]);
 
@@ -321,7 +315,6 @@ mod generate_network_key {
 
 		let context =
 			MockIOContext::new().with_file(&network_key_file(), key).with_expected_io(vec![
-				MockIO::file_read(&network_key_file()),
 				MockIO::eprint(
 					"⚠️ Network key in keystore is invalid (Invalid hex), wizard will regenerate it",
 				),

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -57,18 +57,15 @@ mod tests {
 			.with_json_file("payment.skey", payment_key_content())
 			.with_offchain_mocks(preprod_offchain_mocks())
 			.with_expected_io(vec![
-				MockIO::file_read(CARDANO_PAYMENT_SIGNING_KEY_FILE.config_file),
 				MockIO::prompt(
 					"path to the payment signing key file",
 					Some("payment.skey"),
 					"payment.skey",
 				),
-				MockIO::file_read(CARDANO_PAYMENT_SIGNING_KEY_FILE.config_file),
 				MockIO::file_write_json(
 					CARDANO_PAYMENT_SIGNING_KEY_FILE.config_file,
 					test_resources_config(),
 				),
-				MockIO::file_read("payment.skey"),
 			]);
 		run_init_governance(TEST_GENESIS_UTXO, &ogmios_config(), &mock_context)
 			.expect("should succeed");

--- a/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -213,14 +213,11 @@ pub mod tests {
 		}
 
 		pub fn read_config() -> MockIO {
-			MockIO::Group(vec![
-				prompt_with_default_and_save_to_existing_file(
-					SUBSTRATE_NODE_DATA_BASE_PATH,
-					SUBSTRATE_NODE_DATA_BASE_PATH.default,
-					DATA_PATH,
-				),
-				MockIO::file_read(&network_key_file()),
-			])
+			MockIO::Group(vec![prompt_with_default_and_save_to_existing_file(
+				SUBSTRATE_NODE_DATA_BASE_PATH,
+				SUBSTRATE_NODE_DATA_BASE_PATH.default,
+				DATA_PATH,
+			)])
 		}
 
 		pub fn pick_ip_protocol_with_defaults() -> MockIO {
@@ -357,13 +354,11 @@ pub mod tests {
 			.with_expected_io(vec![
 				scenarios::show_intro(),
 				scenarios::read_config(),
-				MockIO::file_read(BOOTNODES.config_file),
 				scenarios::pick_dns_protocol(
 					vec![Ipv4.into(), Dns.into()],
 					3034,
 					Dns.default_address().to_string(),
 				),
-				MockIO::file_read(BOOTNODES.config_file),
 				scenarios::save_dns_bootnode(KEY, 3034),
 				MockIO::eprint(&outro()),
 			]);
@@ -385,13 +380,11 @@ pub mod tests {
 			.with_expected_io(vec![
 				scenarios::show_intro(),
 				scenarios::read_config(),
-				MockIO::file_read(BOOTNODES.config_file),
 				scenarios::pick_ip_protocol(
 					vec![Ipv4.into(), Dns.into()],
 					3034,
 					"ip_address".to_string(),
 				),
-				MockIO::file_read(BOOTNODES.config_file),
 				scenarios::save_ip_bootnode(KEY, 3034),
 				MockIO::eprint(&outro()),
 			]);
@@ -424,7 +417,6 @@ pub mod tests {
 					DATA_PATH,
 				),
 				save_to_new_file(SUBSTRATE_NODE_DATA_BASE_PATH, DATA_PATH),
-				MockIO::file_read(&network_key_file()),
 				scenarios::pick_ip_protocol_with_defaults(),
 				scenarios::save_ip_bootnode(KEY, DEFAULT_PORT),
 				MockIO::eprint(&outro()),
@@ -458,14 +450,11 @@ pub mod tests {
 		field_definition: ConfigFieldDefinition<'_, T>,
 		value: &str,
 	) -> MockIO {
-		MockIO::Group(vec![
-			MockIO::file_read(field_definition.config_file),
-			MockIO::file_write_json_contains(
-				field_definition.config_file,
-				&field_definition.json_pointer(),
-				value,
-			),
-		])
+		MockIO::Group(vec![MockIO::file_write_json_contains(
+			field_definition.config_file,
+			&field_definition.json_pointer(),
+			value,
+		)])
 	}
 
 	pub fn save_to_new_file<T>(
@@ -493,7 +482,6 @@ pub mod tests {
 		value: &str,
 	) -> MockIO {
 		MockIO::Group(vec![
-			MockIO::file_read(field_definition.config_file),
 			MockIO::prompt(field_definition.name, default, value),
 			save_to_existing_file(field_definition, value),
 		])
@@ -505,7 +493,6 @@ pub mod tests {
 		value: &str,
 	) -> MockIO {
 		MockIO::Group(vec![
-			MockIO::file_read(field_definition.config_file),
 			MockIO::prompt_multi_option(
 				field_definition.name,
 				T::select_options_with_default(default),

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -172,21 +172,17 @@ mod tests {
 							true,
 							true,
 						),
-						MockIO::file_read(NATIVE_TOKEN_POLICY.config_file),
 						MockIO::prompt(
 							NATIVE_TOKEN_POLICY.name,
 							None,
 							"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 						),
-						MockIO::file_read(NATIVE_TOKEN_POLICY.config_file),
 						MockIO::file_write_json_contains(
 							NATIVE_TOKEN_POLICY.config_file,
 							&NATIVE_TOKEN_POLICY.json_pointer(),
 							"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 						),
-						MockIO::file_read(NATIVE_TOKEN_ASSET_NAME.config_file),
 						MockIO::prompt(NATIVE_TOKEN_ASSET_NAME.name, None, "5043546f6b656e44656d6f"),
-						MockIO::file_read(NATIVE_TOKEN_ASSET_NAME.config_file),
 						MockIO::file_write_json_contains(
 							NATIVE_TOKEN_ASSET_NAME.config_file,
 							&NATIVE_TOKEN_ASSET_NAME.json_pointer(),
@@ -234,8 +230,6 @@ mod tests {
 				),
 				save_to_existing_file(ILLIQUID_SUPPLY_ADDRESS, TEST_ILLIQUID_SUPPLY_ADDRESS),
 				print_addresses_io(),
-				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
-				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
 				MockIO::file_write_json(
 					INITIAL_PERMISSIONED_CANDIDATES.config_file,
 					test_chain_config(),
@@ -292,7 +286,6 @@ mod tests {
 				),
 				save_to_existing_file(ILLIQUID_SUPPLY_ADDRESS, TEST_ILLIQUID_SUPPLY_ADDRESS),
 				print_addresses_io(),
-				MockIO::file_read(INITIAL_PERMISSIONED_CANDIDATES.config_file),
 				scenarios::prompt_and_save_native_asset_scripts(),
 				MockIO::eprint(OUTRO),
 			]);

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -125,19 +125,16 @@ mod tests {
 
 	fn prompt_payment_vkey_and_read_it_to_derive_address() -> MockIO {
 		MockIO::Group(vec![
-			MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 			MockIO::prompt(
 				"path to the payment verification file",
 				Some("payment.vkey"),
 				"payment.vkey",
 			),
-			MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
 			MockIO::file_write_json_contains(
 				RESOURCES_CONFIG_FILE_PATH,
 				"/cardano_payment_verification_key_file",
 				"payment.vkey",
 			),
-			MockIO::file_read("payment.vkey"),
 		])
 	}
 }

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -95,7 +95,6 @@ mod tests {
 				Some("cold.skey"),
 				"/invalid/cold.skey",
 			),
-			MockIO::file_read("/invalid/cold.skey"),
 			MockIO::eprint("Unable to read mainchain signing key file"),
 		]);
 
@@ -111,14 +110,11 @@ mod tests {
 	}
 
 	fn prompt_mc_cold_key_path_io() -> Vec<MockIO> {
-		vec![
-			MockIO::prompt(
-				"Path to mainchain signing key file",
-				Some("cold.skey"),
-				"/path/to/cold.skey",
-			),
-			MockIO::file_read("/path/to/cold.skey"),
-		]
+		vec![MockIO::prompt(
+			"Path to mainchain signing key file",
+			Some("cold.skey"),
+			"/path/to/cold.skey",
+		)]
 	}
 
 	fn output_result_io() -> Vec<MockIO> {

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -180,7 +180,6 @@ mod tests {
 				vec![
 					intro_msg_io(),
 					prompt_mc_payment_key_path_io(),
-					read_payment_skey(),
 					get_ogmios_config(),
 					prompt_for_registration_status_y(),
 					show_registration_status_io(),
@@ -211,15 +210,10 @@ mod tests {
 				offchain_mock,
 			))
 			.with_expected_io(
-				vec![
-					intro_msg_io(),
-					prompt_mc_payment_key_path_io(),
-					read_payment_skey(),
-					get_ogmios_config(),
-				]
-				.into_iter()
-				.flatten()
-				.collect::<Vec<MockIO>>(),
+				vec![intro_msg_io(), prompt_mc_payment_key_path_io(), get_ogmios_config()]
+					.into_iter()
+					.flatten()
+					.collect::<Vec<MockIO>>(),
 			);
 
 		let result = mock_register3_cmd().run(&mock_context);
@@ -246,7 +240,6 @@ mod tests {
 				vec![
 					intro_msg_io(),
 					prompt_mc_payment_key_path_io(),
-					read_payment_skey(),
 					get_ogmios_config(),
 					prompt_for_registration_status_n(),
 				]
@@ -263,7 +256,6 @@ mod tests {
 		vec![
             MockIO::print("⚙️ Register as a committee candidate (step 3/3)"),
 			MockIO::print("This command will submit the registration message to the mainchain."),
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH), // check if the chain config file exists
 			MockIO::print("To proceed with the next command, a payment signing key is required. Please note that this key will not be stored or communicated over the network."),
         ]
 	}
@@ -293,13 +285,9 @@ mod tests {
 	fn show_registration_status_io() -> Vec<MockIO> {
 		vec![
         MockIO::print("The registration status will be queried from a db-sync instance for which a valid connection string is required. Please note that this db-sync instance needs to be up and synced with the main chain."),
-        MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
         MockIO::current_timestamp(mock_timestamp()),
-        MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
         MockIO::prompt("DB-Sync Postgres connection string",POSTGRES_CONNECTION_STRING.default,POSTGRES_CONNECTION_STRING.default.unwrap()),
-        MockIO::file_read(RESOURCES_CONFIG_FILE_PATH),
         MockIO::file_write_json_contains(RESOURCES_CONFIG_FILE_PATH, &POSTGRES_CONNECTION_STRING.json_pointer(), POSTGRES_CONNECTION_STRING.default.unwrap()),
-        MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
         MockIO::set_env_var(
 			  "DB_SYNC_POSTGRES_CONNECTION_STRING",  POSTGRES_CONNECTION_STRING.default.unwrap(),
 	  	),
@@ -316,10 +304,6 @@ mod tests {
         MockIO::print("Registration status:"),
         MockIO::print("{\"epoch\":1,\"validators\":[{\"public_key\":\"cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7\",\"status\":\"Registered\"}]}"),
 		]
-	}
-
-	fn read_payment_skey() -> Vec<MockIO> {
-		vec![MockIO::file_read("/path/to/payment.skey")]
 	}
 
 	fn mock_register3_cmd() -> Register3Cmd {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -21,9 +21,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_not_found_response()),
 			print_ariadne_parameters_not_found_io(),
 			prompt_permissioned_candidates_update_io(false),
@@ -56,9 +54,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_not_found_response()),
 			print_ariadne_parameters_not_found_io(),
 			prompt_permissioned_candidates_update_io(true),
@@ -77,9 +73,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_found_response()),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(false),
@@ -112,9 +106,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_found_response()),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(true),
@@ -141,9 +133,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_found_response()),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(true),
@@ -159,9 +149,7 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			read_chain_config_io(),
 			print_info_io(),
-			read_initial_permissioned_candidates_io(),
 			get_ariadne_parameters_io(ariadne_parameters_same_as_in_config_response()),
 			print_main_chain_and_configuration_candidates_are_equal_io(),
 			print_d_param_from_main_chain_io(),
@@ -170,14 +158,6 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
-}
-
-fn read_chain_config_io() -> MockIO {
-	MockIO::file_read(CHAIN_CONFIG_FILE_PATH)
-}
-
-fn read_initial_permissioned_candidates_io() -> MockIO {
-	MockIO::file_read(CHAIN_CONFIG_FILE_PATH)
 }
 
 fn print_info_io() -> MockIO {
@@ -241,7 +221,6 @@ fn upsert_permissioned_candidates_io() -> MockIO {
 			Some("payment.skey"),
 			"payment.skey",
 		),
-		MockIO::file_read("payment.skey"),
 		MockIO::print(
 			"Permissioned candidates updated. The change will be effective in two main chain epochs.",
 		)])
@@ -258,7 +237,6 @@ fn upsert_permissioned_candidates_failed_io() -> MockIO {
 			Some("payment.skey"),
 			"payment.skey",
 		),
-		MockIO::file_read("payment.skey"),
 	])
 }
 
@@ -287,7 +265,6 @@ fn insert_d_parameter_io() -> MockIO {
 			Some("payment.skey"),
 			"payment.skey",
 		),
-		MockIO::file_read("payment.skey"),
 		MockIO::print(
 			"D-parameter updated to (4, 7). The change will be effective in two main chain epochs.",
 		),
@@ -315,7 +292,6 @@ fn update_d_parameter_io() -> MockIO {
 			Some("payment.skey"),
 			"payment.skey",
 		),
-		MockIO::file_read("payment.skey"),
 		MockIO::print(
 			"D-parameter updated to (4, 7). The change will be effective in two main chain epochs.",
 		),

--- a/toolkit/partner-chains-cli/src/start_node/tests.rs
+++ b/toolkit/partner-chains-cli/src/start_node/tests.rs
@@ -107,23 +107,16 @@ fn happy_path() {
         .with_json_file(CHAIN_CONFIG_FILE_PATH, default_chain_config())
 		.with_file(CHAIN_SPEC_FILE, "irrelevant")
 		.with_expected_io(vec![
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
 			MockIO::eprint(&format!(
 				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_PATH}): {DATA_PATH}"
 			)),
 			MockIO::list_dir(&keystore_path(), Some(keystore_files.clone())),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
 			MockIO::eprint(&format!(
 				"🛠️ Loaded DB-Sync Postgres connection string from config ({RESOURCES_CONFIG_PATH}): {DB_CONNECTION_STRING}"
 			)),
-			MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
 			MockIO::list_dir(&keystore_path(), Some(keystore_files.clone())),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
 			MockIO::file_write_json_contains(RESOURCES_CONFIG_PATH, &SIDECHAIN_BLOCK_BENEFICIARY.json_pointer(), SIDECHAIN_BLOCK_BENEFICIARY_STRING),
 			value_check_prompt(),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
-			MockIO::file_read(RESOURCES_CONFIG_PATH),
 			MockIO::file_write_json_contains(RESOURCES_CONFIG_PATH, &NODE_P2P_PORT.json_pointer(), NODE_P2P_PORT.default.unwrap()),
 			MockIO::run_command(&default_chain_config_run_command(), "irrelevant")
 		]);
@@ -210,9 +203,8 @@ mod load_chain_config {
 
 	#[test]
 	fn accepts_a_correct_config() {
-		let context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_FILE_PATH, default_chain_config())
-			.with_expected_io(vec![MockIO::file_read(CHAIN_CONFIG_FILE_PATH)]);
+		let context =
+			MockIOContext::new().with_json_file(CHAIN_CONFIG_FILE_PATH, default_chain_config());
 
 		let result = load_chain_config(&context);
 
@@ -223,7 +215,6 @@ mod load_chain_config {
 	fn aborts_when_missing() {
 		let context =
 			MockIOContext::new().with_expected_io(vec![
-                MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
                 MockIO::eprint(&format!(
                     "⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} does not exists. Run prepare-configuration wizard first."
                 ))
@@ -242,7 +233,6 @@ mod load_chain_config {
 		let context = MockIOContext::new()
 			.with_json_file(CHAIN_CONFIG_FILE_PATH, incorrect)
 			.with_expected_io(vec![
-                MockIO::file_read(CHAIN_CONFIG_FILE_PATH),
                 MockIO::eprint(&format!(
                     "⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} is invalid: missing field `cardano` at line 8 column 1. Run prepare-configuration wizard or fix errors manually."
                 ))

--- a/toolkit/partner-chains-cli/src/tests/config.rs
+++ b/toolkit/partner-chains-cli/src/tests/config.rs
@@ -69,10 +69,10 @@ mod config_field {
 
 		let mock_context = MockIOContext::new()
 			.with_json_file(config_file_path, existing_content)
-			.with_expected_io(vec![
-				MockIO::file_read(config_file_path),
-				MockIO::file_write_json(config_file_path, expected_file_content),
-			]);
+			.with_expected_io(vec![MockIO::file_write_json(
+				config_file_path,
+				expected_file_content,
+			)]);
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
 	}
@@ -97,9 +97,8 @@ mod config_field {
 			_marker: Default::default(),
 		};
 
-		let mock_context = MockIOContext::new()
-			.with_json_file(config_file_path, json_content.clone())
-			.with_expected_io(vec![MockIO::file_read(config_file_path)]);
+		let mock_context =
+			MockIOContext::new().with_json_file(config_file_path, json_content.clone());
 
 		let read_content = config_field.load_file(&mock_context);
 


### PR DESCRIPTION
# Description

Step 1 of files operations overspecification clean-up. It is simple, because this is about reads only. We should not care about when something is read or how many times. Mock files are setup in tests and updated by write operations. Nothing else matters.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

