### PR TITLE
test-refactor: do not over-specify file write interactions

### DIFF
--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,7 +1,7 @@
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
 use crate::tests::{MockIO, MockIOContext};
-use crate::CmdRun;
+use crate::{verify_json, CmdRun};
 use anyhow::anyhow;
 use colored::Colorize;
 
@@ -16,11 +16,11 @@ fn happy_path() {
 			show_initial_permissioned_candidates(),
 			MockIO::prompt_yes_no("Do you want to continue?", true, true),
 			run_build_spec_io(Ok("ok".to_string())),
-			write_updated_chain_spec_io(),
 			show_outro(),
 		]);
 	let result = CreateChainSpecCmd.run(&mock_context);
 	result.expect("should succeed");
+	verify_json!(mock_context, "chain-spec.json", updated_chain_spec())
 }
 
 #[test]
@@ -259,61 +259,58 @@ fn run_build_spec_io(output: Result<String, anyhow::Error>) -> MockIO {
 	])
 }
 
-fn write_updated_chain_spec_io() -> MockIO {
-	MockIO::file_write_json(
-		"chain-spec.json",
-		serde_json::json!(
-			{
-				"genesis": {
-					"runtimeGenesis": {
-						"config": {
-							"session": {
-								"initialValidators": [
-									[
-										  "5C7C2Z5sWbytvHpuLTvzKunnnRwQxft1jiqrLD5rhucQ5S9X",
-										  {
-											"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-											"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
-										}
-									],
-									[
-										"5DVskgSC9ncWQpxFMeUn45NU43RUq93ByEge6ApbnLk6BR9N",
-										{
-											"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-											"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
-										}
-									]
-								]
-							},
-							"sessionCommitteeManagement": {
-								"initialAuthorities": [
-									[
-										"KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
-										{
-											"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-											"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
-										}
-									],
-									[
-										"KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
-										{
-											"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-											"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
-										}
-									]
+fn updated_chain_spec() -> serde_json::Value {
+	serde_json::json!(
+		{
+			"genesis": {
+				"runtimeGenesis": {
+					"config": {
+						"session": {
+							"initialValidators": [
+								[
+									  "5C7C2Z5sWbytvHpuLTvzKunnnRwQxft1jiqrLD5rhucQ5S9X",
+									  {
+										"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+										"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
+									}
 								],
-								"main_chain_scripts": {
-									"committee_candidate_address": "0x002244",
-									"d_parameter_policy_id": "0x1234",
-									"permissioned_candidates_policy_id": "0x5678"
-								}
-							},
-						}
+								[
+									"5DVskgSC9ncWQpxFMeUn45NU43RUq93ByEge6ApbnLk6BR9N",
+									{
+										"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+										"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
+									}
+								]
+							]
+						},
+						"sessionCommitteeManagement": {
+							"initialAuthorities": [
+								[
+									"KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
+									{
+										"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+										"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
+									}
+								],
+								[
+									"KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
+									{
+										"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+										"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
+									}
+								]
+							],
+							"main_chain_scripts": {
+								"committee_candidate_address": "0x002244",
+								"d_parameter_policy_id": "0x1234",
+								"permissioned_candidates_policy_id": "0x5678"
+							}
+						},
 					}
-				},
-				"some_other_field": "irrelevant"
-			}
-		),
+				}
+			},
+			"some_other_field": "irrelevant"
+		}
 	)
 }
 

--- a/toolkit/partner-chains-cli/src/ogmios/config.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/config.rs
@@ -28,10 +28,10 @@ pub(crate) mod tests {
 	use super::*;
 	use crate::config::NetworkProtocol;
 	use crate::prepare_configuration::tests::{
-		prompt_multi_option_with_default_and_save_to_existing_file,
-		prompt_with_default_and_save_to_existing_file,
+		prompt_multi_option_with_default, prompt_with_default,
 	};
 	use crate::tests::MockIO;
+	use serde_json::{json, Value};
 	use std::str::FromStr;
 
 	pub(crate) fn default_ogmios_service_config() -> ServiceConfig {
@@ -43,6 +43,14 @@ pub(crate) mod tests {
 			hostname: OGMIOS_HOSTNAME.default.unwrap_or("localhost").to_string(),
 			port: OGMIOS_PORT.default.unwrap_or("1337").parse().unwrap(),
 		}
+	}
+
+	pub(crate) fn default_ogmios_config_json() -> Value {
+		json!({
+			"protocol": "http",
+			"hostname": "localhost",
+			"port": 1337,
+		})
 	}
 
 	/// Assumption for this function is that resources config file exists, so tests context should have it.
@@ -62,17 +70,17 @@ pub(crate) mod tests {
 		config_to_set: &ServiceConfig,
 	) -> MockIO {
 		MockIO::Group(vec![
-			prompt_multi_option_with_default_and_save_to_existing_file(
+			prompt_multi_option_with_default(
 				OGMIOS_PROTOCOL,
 				Some(&default_config.protocol.to_string()),
 				&config_to_set.protocol.to_string(),
 			),
-			prompt_with_default_and_save_to_existing_file(
+			prompt_with_default(
 				OGMIOS_HOSTNAME,
 				Some(&default_config.hostname),
 				&config_to_set.hostname,
 			),
-			prompt_with_default_and_save_to_existing_file(
+			prompt_with_default(
 				OGMIOS_PORT,
 				Some(&default_config.port.to_string()),
 				&config_to_set.port.to_string(),

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -39,10 +39,11 @@ mod tests {
 	use super::run_init_governance;
 	use crate::{
 		config::{
-			config_fields::{CARDANO_PAYMENT_SIGNING_KEY_FILE, GENESIS_UTXO, OGMIOS_PROTOCOL},
-			NetworkProtocol, ServiceConfig,
+			config_fields::{GENESIS_UTXO, OGMIOS_PROTOCOL},
+			NetworkProtocol, ServiceConfig, RESOURCES_CONFIG_FILE_PATH,
 		},
 		tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks},
+		verify_json,
 	};
 	use hex_literal::hex;
 	use ogmios_client::types::OgmiosTx;
@@ -56,19 +57,14 @@ mod tests {
 			.with_json_file(OGMIOS_PROTOCOL.config_file, serde_json::json!({}))
 			.with_json_file("payment.skey", payment_key_content())
 			.with_offchain_mocks(preprod_offchain_mocks())
-			.with_expected_io(vec![
-				MockIO::prompt(
-					"path to the payment signing key file",
-					Some("payment.skey"),
-					"payment.skey",
-				),
-				MockIO::file_write_json(
-					CARDANO_PAYMENT_SIGNING_KEY_FILE.config_file,
-					test_resources_config(),
-				),
-			]);
+			.with_expected_io(vec![MockIO::prompt(
+				"path to the payment signing key file",
+				Some("payment.skey"),
+				"payment.skey",
+			)]);
 		run_init_governance(TEST_GENESIS_UTXO, &ogmios_config(), &mock_context)
 			.expect("should succeed");
+		verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, test_resources_config());
 	}
 
 	fn payment_key_content() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -99,12 +99,12 @@ After setting up the permissioned candidates, execute the 'create-chain-spec' co
 mod tests {
 	use super::*;
 	use crate::config::config_fields::{GENESIS_UTXO, OGMIOS_PROTOCOL};
-	use crate::config::NetworkProtocol;
+	use crate::config::{NetworkProtocol, CHAIN_CONFIG_FILE_PATH};
 	use crate::ogmios::test_values::{preprod_eras_summaries, preprod_shelley_config};
 	use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 	use crate::prepare_configuration::prepare_cardano_params::tests::PREPROD_CARDANO_PARAMS;
-	use crate::prepare_configuration::tests::save_to_existing_file;
 	use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
+	use crate::verify_json;
 	use partner_chains_cardano_offchain::scripts_data::{Addresses, PolicyIds, ScriptsData};
 	use serde_json::json;
 	use serde_json::Value;
@@ -132,38 +132,8 @@ mod tests {
 
 	pub mod scenarios {
 		use super::*;
-		use crate::config::config_fields::*;
 
-		pub fn save_cardano_params() -> MockIO {
-			MockIO::Group(vec![
-				save_to_existing_file(
-					CARDANO_SECURITY_PARAMETER,
-					&PREPROD_CARDANO_PARAMS.security_parameter.to_string(),
-				),
-				save_to_existing_file(
-					CARDANO_ACTIVE_SLOTS_COEFF,
-					&PREPROD_CARDANO_PARAMS.active_slots_coeff.to_string(),
-				),
-				save_to_existing_file(
-					CARDANO_FIRST_EPOCH_NUMBER,
-					&PREPROD_CARDANO_PARAMS.first_epoch_number.to_string(),
-				),
-				save_to_existing_file(
-					CARDANO_FIRST_SLOT_NUMBER,
-					&PREPROD_CARDANO_PARAMS.first_slot_number.to_string(),
-				),
-				save_to_existing_file(
-					CARDANO_EPOCH_DURATION_MILLIS,
-					&PREPROD_CARDANO_PARAMS.epoch_duration_millis.to_string(),
-				),
-				save_to_existing_file(
-					CARDANO_FIRST_EPOCH_TIMESTAMP_MILLIS,
-					&PREPROD_CARDANO_PARAMS.first_epoch_timestamp_millis.to_string(),
-				),
-			])
-		}
-
-		pub fn prompt_and_save_native_asset_scripts() -> MockIO {
+		pub fn prompt_native_asset_scripts() -> MockIO {
 			MockIO::Group(vec![
 						MockIO::print("Partner Chains can store their initial token supply on Cardano as Cardano native tokens."),
 						MockIO::print("Creation of the native token is not supported by this wizard and must be performed manually before this step."),
@@ -177,17 +147,7 @@ mod tests {
 							None,
 							"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 						),
-						MockIO::file_write_json_contains(
-							NATIVE_TOKEN_POLICY.config_file,
-							&NATIVE_TOKEN_POLICY.json_pointer(),
-							"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-						),
 						MockIO::prompt(NATIVE_TOKEN_ASSET_NAME.name, None, "5043546f6b656e44656d6f"),
-						MockIO::file_write_json_contains(
-							NATIVE_TOKEN_ASSET_NAME.config_file,
-							&NATIVE_TOKEN_ASSET_NAME.json_pointer(),
-							"5043546f6b656e44656d6f",
-						),
 					])
 		}
 	}
@@ -198,6 +158,14 @@ mod tests {
 			"description": "Payment Signing Key",
 			"cborHex": "5820d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386"
 		})
+	}
+
+	fn initial_permissioned_candidates_json() -> serde_json::Value {
+		json!([{
+		  "aura_pub_key": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
+		  "grandpa_pub_key": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee",
+		  "sidechain_pub_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1"
+		}])
 	}
 
 	#[test]
@@ -218,23 +186,8 @@ mod tests {
 					OgmiosRequest::QueryNetworkShelleyGenesis,
 					Ok(OgmiosResponse::QueryNetworkShelleyGenesis(preprod_shelley_config())),
 				),
-				scenarios::save_cardano_params(),
-				save_to_existing_file(
-					COMMITTEE_CANDIDATES_ADDRESS,
-					TEST_COMMITTEE_CANDIDATES_ADDRESS,
-				),
-				save_to_existing_file(D_PARAMETER_POLICY_ID, TEST_D_PARAMETER_POLICY_ID),
-				save_to_existing_file(
-					PERMISSIONED_CANDIDATES_POLICY_ID,
-					TEST_PERMISSIONED_CANDIDATES_POLICY_ID,
-				),
-				save_to_existing_file(ILLIQUID_SUPPLY_ADDRESS, TEST_ILLIQUID_SUPPLY_ADDRESS),
 				print_addresses_io(),
-				MockIO::file_write_json(
-					INITIAL_PERMISSIONED_CANDIDATES.config_file,
-					test_chain_config(),
-				),
-				scenarios::prompt_and_save_native_asset_scripts(),
+				scenarios::prompt_native_asset_scripts(),
 				MockIO::eprint(OUTRO),
 			]);
 		prepare_main_chain_config(
@@ -243,6 +196,7 @@ mod tests {
 			UtxoId::from_str(TEST_GENESIS_UTXO).unwrap(),
 		)
 		.expect("should succeed");
+		verify_json!(mock_context, CHAIN_CONFIG_FILE_PATH, expected_chain_config(json!([])));
 	}
 
 	#[test]
@@ -250,15 +204,7 @@ mod tests {
 		let mock_context = MockIOContext::new()
 			.with_json_file(
 				INITIAL_PERMISSIONED_CANDIDATES.config_file,
-				serde_json::json!({
-					"initial_permissioned_candidates": [
-						{
-						  "aura_pub_key": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
-						  "grandpa_pub_key": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee",
-						  "sidechain_pub_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1"
-						}
-					]
-				}),
+				json!({"initial_permissioned_candidates": initial_permissioned_candidates_json()}),
 			)
 			.with_json_file("payment.skey", payment_key_content())
 			.with_json_file(OGMIOS_PROTOCOL.config_file, serde_json::json!({}))
@@ -274,19 +220,8 @@ mod tests {
 					OgmiosRequest::QueryNetworkShelleyGenesis,
 					Ok(OgmiosResponse::QueryNetworkShelleyGenesis(preprod_shelley_config())),
 				),
-				scenarios::save_cardano_params(),
-				save_to_existing_file(
-					COMMITTEE_CANDIDATES_ADDRESS,
-					TEST_COMMITTEE_CANDIDATES_ADDRESS,
-				),
-				save_to_existing_file(D_PARAMETER_POLICY_ID, TEST_D_PARAMETER_POLICY_ID),
-				save_to_existing_file(
-					PERMISSIONED_CANDIDATES_POLICY_ID,
-					TEST_PERMISSIONED_CANDIDATES_POLICY_ID,
-				),
-				save_to_existing_file(ILLIQUID_SUPPLY_ADDRESS, TEST_ILLIQUID_SUPPLY_ADDRESS),
 				print_addresses_io(),
-				scenarios::prompt_and_save_native_asset_scripts(),
+				scenarios::prompt_native_asset_scripts(),
 				MockIO::eprint(OUTRO),
 			]);
 		prepare_main_chain_config(
@@ -295,6 +230,11 @@ mod tests {
 			UtxoId::from_str(TEST_GENESIS_UTXO).unwrap(),
 		)
 		.expect("should succeed");
+		verify_json!(
+			mock_context,
+			CHAIN_CONFIG_FILE_PATH,
+			expected_chain_config(initial_permissioned_candidates_json())
+		);
 	}
 
 	fn print_addresses_io() -> MockIO {
@@ -328,7 +268,7 @@ mod tests {
 		OffchainMocks::new_with_mock("http://localhost:1337", mock)
 	}
 
-	fn test_chain_config() -> Value {
+	fn expected_chain_config(initial_permissioned_candidates: Value) -> Value {
 		serde_json::json!({
 			"cardano": {
 				"security_parameter": PREPROD_CARDANO_PARAMS.security_parameter,
@@ -344,9 +284,13 @@ mod tests {
 				"permissioned_candidates_policy_id": TEST_PERMISSIONED_CANDIDATES_POLICY_ID,
 				"native_token": {
 					"illiquid_supply_address": TEST_ILLIQUID_SUPPLY_ADDRESS,
+					"asset": {
+						"policy_id":"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+						"asset_name":"5043546f6b656e44656d6f"
+					}
 				}
 			},
-			"initial_permissioned_candidates": []
+			"initial_permissioned_candidates": initial_permissioned_candidates
 		})
 	}
 }

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -62,13 +62,14 @@ mod tests {
 	use crate::config::config_fields::GENESIS_UTXO;
 	use crate::config::RESOURCES_CONFIG_FILE_PATH;
 	use crate::ogmios::config::tests::{
-		default_ogmios_service_config, prompt_ogmios_configuration_io,
+		default_ogmios_config_json, default_ogmios_service_config, prompt_ogmios_configuration_io,
 	};
 	use crate::ogmios::test_values::preview_shelley_config;
 	use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 	use crate::prepare_configuration::select_genesis_utxo::{select_genesis_utxo, INTRO};
 	use crate::select_utxo::tests::{mock_7_valid_utxos_rows, mock_result_7_valid, query_utxos_io};
 	use crate::tests::{MockIO, MockIOContext};
+	use crate::verify_json;
 
 	fn test_vkey_file_json() -> serde_json::Value {
 		serde_json::json!({
@@ -97,16 +98,21 @@ mod tests {
 				 	mock_7_valid_utxos_rows(),
 					 "4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93 (1100000 lovelace)"
 				),
-				MockIO::file_write_json_contains(
-					GENESIS_UTXO.config_file,
-					&GENESIS_UTXO.json_pointer(),
-					"4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93",
-				),
 			]);
 
 		let result = select_genesis_utxo(&mock_context);
 
 		result.expect("should succeed");
+		verify_json!(
+			mock_context,
+			GENESIS_UTXO.config_file,
+			serde_json::json!({"chain_parameters": {"genesis_utxo": "4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93"}})
+		);
+		verify_json!(
+			mock_context,
+			RESOURCES_CONFIG_FILE_PATH,
+			serde_json::json!({"cardano_payment_verification_key_file": "payment.vkey", "ogmios": default_ogmios_config_json()})
+		);
 	}
 
 	fn read_shelly_config_to_get_network() -> MockIO {
@@ -124,17 +130,10 @@ mod tests {
 	}
 
 	fn prompt_payment_vkey_and_read_it_to_derive_address() -> MockIO {
-		MockIO::Group(vec![
-			MockIO::prompt(
-				"path to the payment verification file",
-				Some("payment.vkey"),
-				"payment.vkey",
-			),
-			MockIO::file_write_json_contains(
-				RESOURCES_CONFIG_FILE_PATH,
-				"/cardano_payment_verification_key_file",
-				"payment.vkey",
-			),
-		])
+		MockIO::prompt(
+			"path to the payment verification file",
+			Some("payment.vkey"),
+			"payment.vkey",
+		)
 	}
 }

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -151,8 +151,12 @@ mod tests {
 			config_fields::POSTGRES_CONNECTION_STRING, CHAIN_CONFIG_FILE_PATH,
 			RESOURCES_CONFIG_FILE_PATH,
 		},
-		ogmios::config::tests::{default_ogmios_service_config, establish_ogmios_configuration_io},
+		ogmios::config::tests::{
+			default_ogmios_config_json, default_ogmios_service_config,
+			establish_ogmios_configuration_io,
+		},
 		tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks},
+		verify_json,
 	};
 	use hex_literal::hex;
 	use partner_chains_cardano_offchain::OffchainError;
@@ -191,6 +195,7 @@ mod tests {
 
 		let result = mock_register3_cmd().run(&mock_context);
 		result.expect("should succeed");
+		verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, final_resources_config_json());
 	}
 
 	#[test]
@@ -287,7 +292,6 @@ mod tests {
         MockIO::print("The registration status will be queried from a db-sync instance for which a valid connection string is required. Please note that this db-sync instance needs to be up and synced with the main chain."),
         MockIO::current_timestamp(mock_timestamp()),
         MockIO::prompt("DB-Sync Postgres connection string",POSTGRES_CONNECTION_STRING.default,POSTGRES_CONNECTION_STRING.default.unwrap()),
-        MockIO::file_write_json_contains(RESOURCES_CONFIG_FILE_PATH, &POSTGRES_CONNECTION_STRING.json_pointer(), POSTGRES_CONNECTION_STRING.default.unwrap()),
         MockIO::set_env_var(
 			  "DB_SYNC_POSTGRES_CONNECTION_STRING",  POSTGRES_CONNECTION_STRING.default.unwrap(),
 	  	),
@@ -373,6 +377,16 @@ mod tests {
 				  "partner_chain_pub_key": "0x0390084fdbf27d2b79d26a4f13f0ccd982cb755a661969143c37cbc49ef5b91f27"
 				}
 			],
+		})
+	}
+
+	fn final_resources_config_json() -> serde_json::Value {
+		json!({
+			"cardano_payment_verification_key_file": "payment.vkey",
+			"db_sync_postgres_connection_string": "postgresql://postgres-user:postgres-password@localhost:5432/cexplorer",
+			"ogmios": default_ogmios_config_json(),
+			"substrate_node_base_path": "/path/to/data",
+			"substrate_node_executable_path": "/path/to/node"
 		})
 	}
 

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,13 +1,13 @@
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::config::{config_fields, RESOURCES_CONFIG_FILE_PATH};
-use crate::ogmios::config::tests::{default_ogmios_service_config, prompt_ogmios_configuration_io};
-use crate::prepare_configuration::tests::{
-	prompt_and_save_to_existing_file, prompt_with_default_and_save_to_existing_file,
+use crate::ogmios::config::tests::{
+	default_ogmios_config_json, default_ogmios_service_config, prompt_ogmios_configuration_io,
 };
+use crate::prepare_configuration::tests::{prompt, prompt_with_default};
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
 use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
-use crate::CmdRun;
+use crate::{verify_json, CmdRun};
 use hex_literal::hex;
 use serde_json::json;
 use sidechain_domain::{
@@ -31,6 +31,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 	let result = SetupMainChainStateCmd.run(&mock_context);
 
 	result.expect("should succeed");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
 }
 
 #[test]
@@ -65,6 +66,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
 
 #[test]
@@ -83,6 +85,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
 }
 
 #[test]
@@ -118,6 +121,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
 
 #[test]
@@ -141,6 +145,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect_err("should return error");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
 
 #[test]
@@ -158,6 +163,7 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 		]);
 	let result = SetupMainChainStateCmd.run(&mock_context);
 	result.expect("should succeed");
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
 }
 
 fn print_info_io() -> MockIO {
@@ -185,7 +191,7 @@ fn get_ariadne_parameters_io(result: serde_json::Value) -> MockIO {
 	let timestamp_for_preview_epoch_605 = Timestamp::from_unix_millis(1_718_972_296_000u64);
 	MockIO::Group(vec![
 		MockIO::print("Will read the current D-Parameter and Permissioned Candidates from the main chain, using 'partner-chains-node ariadne-parameters' command."),
-		prompt_and_save_to_existing_file(config_fields::POSTGRES_CONNECTION_STRING, "postgres://postgres:password123@localhost:5432/cexplorer"),
+		prompt(config_fields::POSTGRES_CONNECTION_STRING, "postgres://postgres:password123@localhost:5432/cexplorer"),
 		set_env_for_node_io(),
 		MockIO::current_timestamp(timestamp_for_preview_epoch_605),
 		MockIO::new_tmp_dir(),
@@ -216,11 +222,7 @@ fn upsert_permissioned_candidates_io() -> MockIO {
 			&default_ogmios_service_config(),
 			&default_ogmios_service_config(),
 		),
-		prompt_with_default_and_save_to_existing_file(
-			CARDANO_PAYMENT_SIGNING_KEY_FILE,
-			Some("payment.skey"),
-			"payment.skey",
-		),
+		prompt(CARDANO_PAYMENT_SIGNING_KEY_FILE, "payment.skey"),
 		MockIO::print(
 			"Permissioned candidates updated. The change will be effective in two main chain epochs.",
 		)])
@@ -232,11 +234,7 @@ fn upsert_permissioned_candidates_failed_io() -> MockIO {
 			&default_ogmios_service_config(),
 			&default_ogmios_service_config(),
 		),
-		prompt_with_default_and_save_to_existing_file(
-			CARDANO_PAYMENT_SIGNING_KEY_FILE,
-			Some("payment.skey"),
-			"payment.skey",
-		),
+		prompt(CARDANO_PAYMENT_SIGNING_KEY_FILE, "payment.skey"),
 	])
 }
 
@@ -260,11 +258,7 @@ fn insert_d_parameter_io() -> MockIO {
 			Some("0"),
 			"7",
 		),
-		prompt_with_default_and_save_to_existing_file(
-			CARDANO_PAYMENT_SIGNING_KEY_FILE,
-			Some("payment.skey"),
-			"payment.skey",
-		),
+		prompt(CARDANO_PAYMENT_SIGNING_KEY_FILE, "payment.skey"),
 		MockIO::print(
 			"D-parameter updated to (4, 7). The change will be effective in two main chain epochs.",
 		),
@@ -287,11 +281,7 @@ fn update_d_parameter_io() -> MockIO {
 			Some("4"),
 			"7",
 		),
-		prompt_with_default_and_save_to_existing_file(
-			CARDANO_PAYMENT_SIGNING_KEY_FILE,
-			Some("payment.skey"),
-			"payment.skey",
-		),
+		prompt_with_default(CARDANO_PAYMENT_SIGNING_KEY_FILE, Some("payment.skey"), "payment.skey"),
 		MockIO::print(
 			"D-parameter updated to (4, 7). The change will be effective in two main chain epochs.",
 		),
@@ -361,6 +351,18 @@ fn test_chain_config_content() -> serde_json::Value {
 			}
 		],
 	})
+}
+
+fn post_updates_resources_json() -> serde_json::Value {
+	json!({
+		"cardano_payment_signing_key_file": "payment.skey",
+		"db_sync_postgres_connection_string": "postgres://postgres:password123@localhost:5432/cexplorer",
+		"ogmios": default_ogmios_config_json()
+	})
+}
+
+fn no_updates_resources_json() -> serde_json::Value {
+	json!({"db_sync_postgres_connection_string": "postgres://postgres:password123@localhost:5432/cexplorer"})
 }
 
 fn initial_permissioned_candidates() -> Vec<sidechain_domain::PermissionedCandidateData> {

--- a/toolkit/partner-chains-cli/src/tests/config.rs
+++ b/toolkit/partner-chains-cli/src/tests/config.rs
@@ -2,7 +2,7 @@ use crate::config::*;
 
 mod config_field {
 
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::{tests::MockIOContext, verify_json};
 
 	use super::*;
 
@@ -26,12 +26,10 @@ mod config_field {
 			}
 		});
 
-		let mock_context = MockIOContext::new().with_expected_io(vec![MockIO::file_write_json(
-			config_file_path,
-			expected_file_content,
-		)]);
+		let mock_context = MockIOContext::new();
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
+		verify_json!(mock_context, config_file_path, expected_file_content);
 	}
 
 	#[test]
@@ -67,14 +65,10 @@ mod config_field {
 			}
 		});
 
-		let mock_context = MockIOContext::new()
-			.with_json_file(config_file_path, existing_content)
-			.with_expected_io(vec![MockIO::file_write_json(
-				config_file_path,
-				expected_file_content,
-			)]);
+		let mock_context = MockIOContext::new().with_json_file(config_file_path, existing_content);
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
+		verify_json!(mock_context, config_file_path, expected_file_content);
 	}
 
 	#[test]


### PR DESCRIPTION
# Description

Replaces verification for each JSON field write operation with assertions on the final shape of given file.

`pretty_assertions` are used to diff serde_json::Value, in so error message pretty.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff


