### PR TITLE
change: ETCM-9277 rename wizard config files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,9 @@ The only other change is that "node executable path" configuration is not presen
 Code will always invoke "self" executable instead.
 Since this change, all functionality of Partner Chains is available in the one executable of the node.
 * Added support for extended payment signing and verification keys.
+* Renamed file names of the configs used by wizard commands. `partner-chains-cli-resources-config.json` is now
+`pc-resources-config.json`, `partner-chains-cli-chain-config.json` is now `pc-chain-config.json`. Rename your
+files accordingly if migrating from prior versions.
 
 ## Removed
 

--- a/docs/user-guides/chain-builder.md
+++ b/docs/user-guides/chain-builder.md
@@ -251,7 +251,7 @@ The generate-keys wizard will generate necessary keys and save them to your node
 If these keys already exist in the node’s keystore, you will be asked to overwrite existing keys. The wizard will also generate a network key for your node if needed.
 
 1. Start the wizard: `./partner-chains-node wizards generate-keys`
-2. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`.
+2. Input the node base path. It is saved in `pc-resources-config.json`.
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys:
 
@@ -273,7 +273,7 @@ Before running this wizard, be sure that `ogmios` is available by host and port.
 4. Configure initial native token supply address (optional)
 5. Store the main chain configuration
 
-This wizard will submit a governance initialization transaction, that spends the genesis utxo. It will also result in a `partner-chains-cli-chain-config.json` file. The wizard also adds required cardano addresses and policy ids to the configuration file.
+This wizard will submit a governance initialization transaction, that spends the genesis utxo. It will also result in a `pc-chain-config.json` file. The wizard also adds required cardano addresses and policy ids to the configuration file.
 
 After chain-config file has been generated, it should be updated with your keys and the keys of other *permissioned* candidates in the `initial_permissioned_candidates` array.
 
@@ -302,7 +302,7 @@ The wizard asks for the genesis utxo that identifies a partner chain.
 
 ##### Storing the main chain configuration
 
-The wizard completes by reporting that the `partner-chains-cli-chain-config.json` file is ready for distribution to network participants and also that the `create-chain-spec` wizard should be executed when keys of permissioned candidates are gathered.
+The wizard completes by reporting that the `pc-chain-config.json` file is ready for distribution to network participants and also that the `create-chain-spec` wizard should be executed when keys of permissioned candidates are gathered.
 
 A sample file:
 
@@ -352,11 +352,11 @@ A sample file:
 
 ### 4. Run the create-chain-spec wizard
 
-The wizard reads the file `partner-chains-cli-chain-config.json`. This file should be present and identical for every node participating in the chain.
+The wizard reads the file `pc-chain-config.json`. This file should be present and identical for every node participating in the chain.
 
 1. Start the wizard: `./partner-chains-node wizards create-chain-spec`
 
-The wizard displays the contents of `chain_parameters` and `initial_permissioned_candidates` from the `partner-chains-cli-chain-config.json` file. You can manually modify these values before running this wizard.
+The wizard displays the contents of `chain_parameters` and `initial_permissioned_candidates` from the `pc-chain-config.json` file. You can manually modify these values before running this wizard.
 
 The wizard creates the chain specification file `chain-spec.json` using these values.
 
@@ -366,7 +366,7 @@ The wizard informs you of the full path to the `chain-spec.json` file. You can n
 
 1. Start the wizard: `./partner-chains-node wizards setup-main-chain-state`
 
-The wizard reads the permissioned candidates list from the chain config file and Cardano. If it finds any discrepancy, it allows you to update the list. To update the list, add to the `initial_permissioned_candidates` array in `partner-chains-cli-chain-config.json` and re-run the setup-main-chain-state wizard.
+The wizard reads the permissioned candidates list from the chain config file and Cardano. If it finds any discrepancy, it allows you to update the list. To update the list, add to the `initial_permissioned_candidates` array in `pc-chain-config.json` and re-run the setup-main-chain-state wizard.
 
 Next, the wizard deals with the D parameter. If it is present on the main chain, the wizard displays its value and allows you to update it.
 
@@ -377,7 +377,7 @@ The D parameter has two values:
 
 The default value of R is zero, and the default value of P is the number of entries in the list of permissioned candidates.
 
-The configuration of the chain is stored in the file `partner-chains-cli-chain-config.json`. This file should be present and identical for every node participating in the network.
+The configuration of the chain is stored in the file `pc-chain-config.json`. This file should be present and identical for every node participating in the network.
 
 Information about the resources used by each node is stored in the file `partner-chain-cli-resources-config.json`. This file should be present for every node participating in the chain, but its contents are specific to each node.
 
@@ -390,12 +390,12 @@ Be sure two main chain (Cardano) epochs have passed since the registration of a 
 1. Start the wizard: `./partner-chains-node wizards start-node`
 2. The wizard checks if all required keys are present. If not, it reminds you to run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, it should be generated with the create-chain-spec wizard.
-4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, it should be generated with the prepare-configuration wizard.
+4. The wizard checks the `pc-chain-config.json` file. If it is missing or invalid, it should be generated with the prepare-configuration wizard.
 5. If the `db_sync_postgres_connection_string` is missing from the `partner-chain-cli-resources-config.json` file, the wizard prompts for it, using the default value `postgresql://postgres-user:postgres-password@localhost:5432/cexplorer`.
-6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `partner-chains-cli-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
+6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `pc-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
 
 ### 7. Distribute chain files to participants
 
 The partner chain is now ready to start accepting registered validator nodes. [Permissioned candidates](./docs/user-guides/permissioned.md) and [Registered candidates](./docs/user-guides/registered.md) have different onboarding processes. Please follow the respective steps for the corresponding type of user.
 
-Be prepared to share `chain-spec.json` and `partner-chains-cli-chain-config.json` files to both types of users.
+Be prepared to share `chain-spec.json` and `pc-chain-config.json` files to both types of users.

--- a/docs/user-guides/permissioned.md
+++ b/docs/user-guides/permissioned.md
@@ -151,7 +151,7 @@ The generate-keys wizard will generate necessary keys and save them to your node
 If these keys already exist in the node’s keystore, you will be asked to overwrite existing keys. The wizard will also generate a network key for your node if needed.
 
 1. Start the wizard: `./partner-chains-node wizards generate-keys`
-2. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`.
+2. Input the node base path. It is saved in `pc-resources-config.json`.
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys.
 ``` javascript
@@ -172,7 +172,7 @@ Contact the chain builder and provide the `partner-chains-cli-public-keys.json` 
 
 Obtaining these files is as simple as getting the file from the chain builder.
 
-Contact the chain builder and request the `chain-spec.json` and `partner-chains-cli-chain-config.json` files.
+Contact the chain builder and request the `chain-spec.json` and `pc-chain-config.json` files.
 
 ### 6. Run the partner chain node
 
@@ -181,16 +181,16 @@ The start-node wizard is used to start a partner chain node. Make sure that `car
 1. Start the wizard: `./partner-chains-node start-node`
 2. The wizard checks if all required keys are present. If not, it reminds you to run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, you should obtain it from the chain builder.
-4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, you should obtain it from the chain builder.
+4. The wizard checks the `pc-chain-config.json` file. If it is missing or invalid, you should obtain it from the chain builder.
 5. If the `db_sync_postgres_connection_string` is missing from the `partner-chain-cli-resources-config.json` file, the wizard prompts for it, using the default value `postgresql://postgres-user:postgres-password@localhost:5432/cexplorer`.
-6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `partner-chains-cli-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
+6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `pc-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
 
 The wizard sets the required environment variables and starts the node.
 
 ---
 **NOTE**
 
-The configuration of the chain is stored in the file `partner-chains-cli-chain-config.json`. This file needs to remain idential with other nodes in the network.
+The configuration of the chain is stored in the file `pc-chain-config.json`. This file needs to remain idential with other nodes in the network.
 
 ---
 

--- a/docs/user-guides/registered.md
+++ b/docs/user-guides/registered.md
@@ -256,7 +256,7 @@ If these keys already exist in the node’s keystore, you will be asked to overw
 
 1. To start the wizard, run the following command in the node repository:
 `./partner-chains-node wizards generate-keys`
-3. Input the node base path. It is saved in `partner-chains-cli-resources-config.json`
+3. Input the node base path. It is saved in `pc-resources-config.json`
 
 Now the wizard will output `partner-chains-public-keys.json` containing three keys:
 
@@ -272,7 +272,7 @@ Now the wizard will output `partner-chains-public-keys.json` containing three ke
 
 Obtaining the chain parameters needs to be done manually.
 
-Contact the chain builder and request the `chain-spec.json` file and the `partner-chains-cli-chain-config.json` file.
+Contact the chain builder and request the `chain-spec.json` file and the `pc-chain-config.json` file.
 
 ### 5. Register for the partner chain
 
@@ -320,9 +320,9 @@ The start-node wizard is used to start a partner chain node. Make sure that `car
 1. Start the wizard: `./partner-chains-node wizards start-node`.
 2. The wizard checks if all required keys are present. If not, it reminds you to the run the generate-keys wizard first, and exits.
 3. If the `chain-spec` file is not present, you should obtain it from the governance authority.
-4. The wizard checks the `partner-chains-cli-chain-config.json` file. If it is missing or invalid, you should obtain it from the governance authority.
+4. The wizard checks the `pc-chain-config.json` file. If it is missing or invalid, you should obtain it from the governance authority.
 5. If the `db_sync_postgres_connection_string` is missing from the `partner-chain-cli-resources-config.json` file, the wizard prompts for it using the default value `postgresql://postgres-user:postgres-password@localhost:5432/cexplorer`.
-6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `partner-chains-cli-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
+6. The wizard outputs all relevant parameters and asks if they are correct. If not, you should edit the `pc-chain-config.json` and/or `partner-chain-cli-resources-config.json` files and run the wizard again.
 
 The wizard sets the required environment variables and starts the node.
 
@@ -333,7 +333,7 @@ Registration is effective after 1-2 Cardano epochs. After the waiting period, th
 To deregister from the list of block producer candidates, you need to run the deregister wizard.
 
 1. Start the wizard: `./partner-chains-node wizards deregister`.
-2. The wizard checks the `partner-chains-cli-chain-config.json` file.
+2. The wizard checks the `pc-chain-config.json` file.
 3. The wizard prompts for the payment verification key file used during registration.
 4. The wizard prompts for the cold verification key matching the cold signing key used during registration.
 5. The wizard prompts for ogmios and kupo addresses.
@@ -342,7 +342,7 @@ To deregister from the list of block producer candidates, you need to run the de
 ---
 **NOTE**
 
-The configuration of the chain is stored in the file `partner-chains-cli-chain-config.json`. This file needs to remain identical with other nodes in the network.
+The configuration of the chain is stored in the file `pc-chain-config.json`. This file needs to remain identical with other nodes in the network.
 
 
 ---

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -343,8 +343,8 @@ pub struct ChainConfig {
 }
 
 pub const KEYS_FILE_PATH: &str = "partner-chains-public-keys.json";
-pub const CHAIN_CONFIG_FILE_PATH: &str = "partner-chains-cli-chain-config.json";
-pub const RESOURCES_CONFIG_FILE_PATH: &str = "partner-chains-cli-resources-config.json";
+pub const CHAIN_CONFIG_FILE_PATH: &str = "pc-chain-config.json";
+pub const RESOURCES_CONFIG_FILE_PATH: &str = "pc-resources-config.json";
 pub const CHAIN_SPEC_PATH: &str = "chain-spec.json";
 
 pub fn load_chain_config(context: &impl IOContext) -> anyhow::Result<ChainConfig> {

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -31,7 +31,7 @@ fn shows_warning_when_initial_candidates_are_empty() {
 			show_intro(),
 			show_chain_parameters(),
 			MockIO::print(&"WARNING: The list of initial permissioned candidates is empty. Generated chain spec will not allow the chain to start.".red().to_string()),
-			MockIO::print(&"Update 'initial_permissioned_candidates' field of partner-chains-cli-chain-config.json file with keys of initial committee.".red().to_string()),
+			MockIO::print(&"Update 'initial_permissioned_candidates' field of pc-chain-config.json file with keys of initial committee.".red().to_string()),
 			MockIO::print(&INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE.yellow().to_string()),
 			MockIO::prompt_yes_no("Do you want to continue?", true, false),
 			MockIO::print("Aborted."),
@@ -46,7 +46,7 @@ fn instruct_user_when_config_file_is_invalid() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_without_initial_permissioned_candidates())
 		.with_expected_io(vec![
-			MockIO::eprint("The 'partner-chains-cli-chain-config.json' configuration file is missing or invalid.
+			MockIO::eprint("The 'pc-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
@@ -59,7 +59,7 @@ fn instruct_user_when_config_file_has_a_field_in_wrong_format() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_with_a_field_in_wrong_format())
 		.with_expected_io(vec![
-			MockIO::eprint("The 'partner-chains-cli-chain-config.json' configuration file is missing or invalid.
+			MockIO::eprint("The 'pc-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -73,7 +73,7 @@ fn fails_when_chain_config_is_not_valid() {
 	let result = DeregisterCmd.run(&mock_context);
 	assert_eq!(
 	    result.err().unwrap().to_string(),
-		"Couldn't parse chain configuration file partner-chains-cli-chain-config.json. The chain configuration file that was used for registration is required in the working directory."
+		"Couldn't parse chain configuration file pc-chain-config.json. The chain configuration file that was used for registration is required in the working directory."
 	);
 }
 

--- a/toolkit/partner-chains-cli/src/generate_keys/tests.rs
+++ b/toolkit/partner-chains-cli/src/generate_keys/tests.rs
@@ -5,7 +5,7 @@ use scenarios::key_file_content;
 use scenarios::resources_file_content;
 
 const DATA_PATH: &str = "/path/to/data";
-const RESOURCES_CONFIG_PATH: &str = "partner-chains-cli-resources-config.json";
+const RESOURCES_CONFIG_PATH: &str = "pc-resources-config.json";
 const KEYS_FILE: &str = "partner-chains-public-keys.json";
 const CHAIN_NAME: &str = "partner_chains_template";
 

--- a/toolkit/partner-chains-cli/src/generate_keys/tests.rs
+++ b/toolkit/partner-chains-cli/src/generate_keys/tests.rs
@@ -1,28 +1,29 @@
 use super::*;
+use crate::config::RESOURCES_CONFIG_FILE_PATH;
 use crate::tests::*;
 use crate::CmdRun;
 use scenarios::key_file_content;
 use scenarios::resources_file_content;
 
 const DATA_PATH: &str = "/path/to/data";
-const RESOURCES_CONFIG_PATH: &str = "pc-resources-config.json";
-const KEYS_FILE: &str = "partner-chains-public-keys.json";
-const CHAIN_NAME: &str = "partner_chains_template";
 
 const GRANDPA_PREFIX: &str = "6772616e"; // "gran" in hex
 const CROSS_CHAIN_PREFIX: &str = "63726368"; // "crch" in hex
 const AURA_PREFIX: &str = "61757261"; // "aura" in hex
 
 fn default_config() -> GenerateKeysConfig {
-	GenerateKeysConfig { chain_name: CHAIN_NAME.into(), substrate_node_base_path: DATA_PATH.into() }
+	GenerateKeysConfig {
+		chain_name: DEFAULT_CHAIN_NAME.into(),
+		substrate_node_base_path: DATA_PATH.into(),
+	}
 }
 
 fn network_key_file() -> String {
-	format!("{DATA_PATH}/chains/{CHAIN_NAME}/network/secret_ed25519")
+	format!("{DATA_PATH}/chains/{DEFAULT_CHAIN_NAME}/network/secret_ed25519")
 }
 
 fn keystore_path() -> String {
-	format!("{DATA_PATH}/chains/{CHAIN_NAME}/keystore")
+	format!("{DATA_PATH}/chains/{DEFAULT_CHAIN_NAME}/keystore")
 }
 
 pub mod scenarios {
@@ -167,7 +168,7 @@ fn happy_path() {
 		"partner-chains-public-keys.json",
 		key_file_content("aura-pub-key", "grandpa-pub-key", "cross-chain-pub-key")
 	);
-	verify_json!(mock_context, RESOURCES_CONFIG_PATH, resources_file_content());
+	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, resources_file_content());
 }
 
 mod config_read {
@@ -181,7 +182,7 @@ mod config_read {
 
 		let result = GenerateKeysConfig::load(&context);
 
-		assert_eq!(result.chain_name, CHAIN_NAME);
+		assert_eq!(result.chain_name, DEFAULT_CHAIN_NAME);
 		assert_eq!(result.substrate_node_base_path, DATA_PATH);
 	}
 
@@ -189,18 +190,18 @@ mod config_read {
 	fn reads_all_when_present() {
 		let context = MockIOContext::new()
 			.with_json_file(
-				RESOURCES_CONFIG_PATH,
+				RESOURCES_CONFIG_FILE_PATH,
 				serde_json::json!({
 					"substrate_node_base_path": DATA_PATH,
 				}),
 			)
 			.with_expected_io(vec![MockIO::eprint(&format!(
-				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_PATH}): {DATA_PATH}"
+				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_FILE_PATH}): {DATA_PATH}"
 			))]);
 
 		let result = GenerateKeysConfig::load(&context);
 
-		assert_eq!(result.chain_name, CHAIN_NAME);
+		assert_eq!(result.chain_name, DEFAULT_CHAIN_NAME);
 		assert_eq!(result.substrate_node_base_path, DATA_PATH);
 	}
 }
@@ -217,7 +218,7 @@ mod generate_spo_keys {
 		];
 		let mock_context = MockIOContext::new()
 			.with_json_file(
-				RESOURCES_CONFIG_PATH,
+				RESOURCES_CONFIG_FILE_PATH,
 				serde_json::json!({
 					"substrate_node_base_path": DATA_PATH,
 				}),
@@ -260,16 +261,16 @@ mod generate_spo_keys {
 	#[test]
 	fn skips_the_step_if_user_declines_keys_file_overwrite() {
 		let mock_context = MockIOContext::new()
-			.with_file(KEYS_FILE, "irrelevant")
+			.with_file(KEYS_FILE_PATH, "irrelevant")
 			.with_json_file(
-				RESOURCES_CONFIG_PATH,
+				RESOURCES_CONFIG_FILE_PATH,
 				serde_json::json!({
 					"substrate_node_base_path": DATA_PATH,
 				}),
 			)
 			.with_expected_io(vec![
 				MockIO::prompt_yes_no(
-					&format! {"keys file {KEYS_FILE} exists - overwrite it?"},
+					&format! {"keys file {KEYS_FILE_PATH} exists - overwrite it?"},
 					false,
 					false,
 				),

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -94,7 +94,7 @@ const HELP_EXAMPLES: &str = r#"
 ║   6. deregister            : cancel registration                               ║
 ║                                                                                ║
 ║   Note: This sequence assumes that the chain-spec.json and                     ║
-║         pc-chain-config.json files have been obtained from     ║
+║         pc-chain-config.json files have been obtained from                     ║
 ║         the Governance Authority and are present in the working directory.     ║
 ╟────────────────────────────────────────────────────────────────────────────────╢
 ║ Permissioned Validator:                                                        ║
@@ -105,7 +105,7 @@ const HELP_EXAMPLES: &str = r#"
 ║         with the Governance Authority. The 'start-node' command can only be    ║
 ║         executed after the Governance Authority has established the partner    ║
 ║         chain on the main network. This sequence assumes that the              ║
-║         chain-spec.json and pc-chain-config.json files have    ║
+║         chain-spec.json and pc-chain-config.json files have                    ║
 ║         been obtained from the Governance Authority and are present in the     ║
 ║         working directory.                                                     ║
 ╚════════════════════════════════════════════════════════════════════════════════╝

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -94,7 +94,7 @@ const HELP_EXAMPLES: &str = r#"
 ║   6. deregister            : cancel registration                               ║
 ║                                                                                ║
 ║   Note: This sequence assumes that the chain-spec.json and                     ║
-║         partner-chains-cli-chain-config.json files have been obtained from     ║
+║         pc-chain-config.json files have been obtained from     ║
 ║         the Governance Authority and are present in the working directory.     ║
 ╟────────────────────────────────────────────────────────────────────────────────╢
 ║ Permissioned Validator:                                                        ║
@@ -105,7 +105,7 @@ const HELP_EXAMPLES: &str = r#"
 ║         with the Governance Authority. The 'start-node' command can only be    ║
 ║         executed after the Governance Authority has established the partner    ║
 ║         chain on the main network. This sequence assumes that the              ║
-║         chain-spec.json and partner-chains-cli-chain-config.json files have    ║
+║         chain-spec.json and pc-chain-config.json files have    ║
 ║         been obtained from the Governance Authority and are present in the     ║
 ║         working directory.                                                     ║
 ╚════════════════════════════════════════════════════════════════════════════════╝

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -73,9 +73,9 @@ fn prepare_native_token<C: IOContext>(context: &C) -> anyhow::Result<()> {
 	Ok(())
 }
 
-const OUTRO: &str = r#"Chain configuration (partner-chains-cli-chain-config.json) is now ready for distribution to network participants.
+const OUTRO: &str = r#"Chain configuration (pc-chain-config.json) is now ready for distribution to network participants.
 
-If you intend to run a chain with permissioned candidates, you must manually set their keys in the partner-chains-cli-chain-config.json file before proceeding. Here's an example of how to add permissioned candidates:
+If you intend to run a chain with permissioned candidates, you must manually set their keys in the pc-chain-config.json file before proceeding. Here's an example of how to add permissioned candidates:
 
 {
   ...

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -164,6 +164,7 @@ fn derive_address<C: IOContext>(
 mod tests {
 	use super::*;
 	use crate::tests::{MockIO, MockIOContext};
+	use config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
 	use ogmios::{
 		config::tests::{
 			default_ogmios_config_json, default_ogmios_service_config,
@@ -184,8 +185,8 @@ mod tests {
 		});
 
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_without_cardano_fields)
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_without_cardano_fields)
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_file(ECDSA_KEY_PATH, ECDSA_KEY_FILE_CONTENT)
 			.with_file(PAYMENT_VKEY_PATH, PAYMENT_VKEY_CONTENT)
@@ -206,7 +207,7 @@ mod tests {
 		result.expect("should succeed");
 		verify_json!(
 			mock_context,
-			RESOURCE_CONFIG_PATH,
+			RESOURCES_CONFIG_FILE_PATH,
 			json!({
 				"substrate_node_base_path": "/path/to/data",
 				"cardano_payment_verification_key_file": PAYMENT_VKEY_PATH,
@@ -246,8 +247,8 @@ mod tests {
 	#[test]
 	fn saved_prompt_fields_are_loaded_without_prompting() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_file(PAYMENT_VKEY_PATH, PAYMENT_VKEY_CONTENT)
 			.with_file(ECDSA_KEY_PATH, ECDSA_KEY_FILE_CONTENT)
@@ -271,8 +272,8 @@ mod tests {
 	#[test]
 	fn report_error_if_payment_file_is_invalid() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_file(PAYMENT_VKEY_PATH, "invalid content")
 			.with_expected_io(
@@ -293,8 +294,8 @@ mod tests {
 	#[test]
 	fn utxo_query_error() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_file(PAYMENT_VKEY_PATH, PAYMENT_VKEY_CONTENT)
 			.with_expected_io(
@@ -327,8 +328,8 @@ mod tests {
 	#[test]
 	fn should_error_with_missing_public_keys_file() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_expected_io(
 				vec![
 					intro_msg_io(),
@@ -346,8 +347,8 @@ mod tests {
 	#[test]
 	fn should_error_with_missing_private_keys_in_storage() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_file(PAYMENT_VKEY_PATH, PAYMENT_VKEY_CONTENT)
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_expected_io(
@@ -372,8 +373,8 @@ mod tests {
 	#[test]
 	fn should_error_on_invalid_seed_phrase() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(CHAIN_CONFIG_PATH, chain_config_content())
-			.with_json_file(RESOURCE_CONFIG_PATH, resource_config_content())
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, chain_config_content())
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, resource_config_content())
 			.with_json_file(KEYS_FILE_PATH, generated_keys_file_content())
 			.with_file(PAYMENT_VKEY_PATH, PAYMENT_VKEY_CONTENT)
 			.with_file(ECDSA_KEY_PATH, "invalid seed phrase")
@@ -395,9 +396,6 @@ mod tests {
 		let result = Register1Cmd {}.run(&mock_context);
 		assert!(result.is_err());
 	}
-
-	const CHAIN_CONFIG_PATH: &str = "pc-chain-config.json";
-	const RESOURCE_CONFIG_PATH: &str = "pc-resources-config.json";
 
 	fn chain_config_content() -> serde_json::Value {
 		serde_json::json!({

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -138,7 +138,7 @@ where
 	T: DeserializeOwned,
 {
 	field.load_from_file(context).ok_or_else(|| {
-		context.eprint("⚠️ The chain configuration file `partner-chains-cli-chain-config.json` is missing or invalid.\n If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\n If you are a validator, you can obtain the chain configuration file from the governance authority.");
+		context.eprint("⚠️ The chain configuration file `pc-chain-config.json` is missing or invalid.\n If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\n If you are a validator, you can obtain the chain configuration file from the governance authority.");
 		anyhow::anyhow!("failed to read {}", field.path.join("."))
 	})
 }
@@ -231,7 +231,7 @@ mod tests {
 	#[test]
 	fn report_error_if_chain_config_fields_are_missing() {
 		let mock_context = MockIOContext::new()
-			.with_json_file("partner-chains-cli-chain-config.json", serde_json::json!({}))
+			.with_json_file("pc-chain-config.json", serde_json::json!({}))
 			.with_expected_io(
 				vec![intro_msg_io(), invalid_chain_config_io()]
 					.into_iter()
@@ -396,8 +396,8 @@ mod tests {
 		assert!(result.is_err());
 	}
 
-	const CHAIN_CONFIG_PATH: &str = "partner-chains-cli-chain-config.json";
-	const RESOURCE_CONFIG_PATH: &str = "partner-chains-cli-resources-config.json";
+	const CHAIN_CONFIG_PATH: &str = "pc-chain-config.json";
+	const RESOURCE_CONFIG_PATH: &str = "pc-resources-config.json";
 
 	fn chain_config_content() -> serde_json::Value {
 		serde_json::json!({
@@ -500,6 +500,6 @@ mod tests {
 	const ECDSA_KEY_PATH: &str = "/path/to/data/chains/partner_chains_template/keystore/63726368031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6";
 
 	fn invalid_chain_config_io() -> Vec<MockIO> {
-		vec![MockIO::eprint("⚠️ The chain configuration file `partner-chains-cli-chain-config.json` is missing or invalid.\n If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\n If you are a validator, you can obtain the chain configuration file from the governance authority.")]
+		vec![MockIO::eprint("⚠️ The chain configuration file `pc-chain-config.json` is missing or invalid.\n If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\n If you are a validator, you can obtain the chain configuration file from the governance authority.")]
 	}
 }

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -290,7 +290,7 @@ fn update_d_parameter_io() -> MockIO {
 
 fn print_main_chain_and_configuration_candidates_difference_io() -> MockIO {
 	MockIO::Group(vec![
-		MockIO::print("Permissioned candidates in the partner-chains-cli-chain-config.json file does not match the most recent on-chain initial permissioned candidates."),
+		MockIO::print("Permissioned candidates in the pc-chain-config.json file does not match the most recent on-chain initial permissioned candidates."),
 		MockIO::print("The most recent on-chain initial permissioned candidates are:"),
 		MockIO::print("Partner Chains Key: 0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1, AURA: 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d, GRANDPA: 0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee"),
 		MockIO::print("Partner Chains Key: 0x0263c9cdabbef76829fe5b35f0bbf3051bd1c41b80f58b5d07c271d0dd04de2a4e, AURA: 0x9cedc9f7b926191f64d68ee77dd90c834f0e73c0f53855d77d3b0517041d5640, GRANDPA: 0xde21d8171821fc29a43a1ed90ee75623edc3794012010f165b6afc3483a569aa"),
@@ -302,7 +302,7 @@ fn print_main_chain_and_configuration_candidates_difference_io() -> MockIO {
 
 fn print_main_chain_and_configuration_candidates_are_equal_io() -> MockIO {
 	MockIO::Group(vec![
-		MockIO::print("Permissioned candidates in the partner-chains-cli-chain-config.json file match the most recent on-chain initial permissioned candidates."),
+		MockIO::print("Permissioned candidates in the pc-chain-config.json file match the most recent on-chain initial permissioned candidates."),
 	])
 }
 

--- a/toolkit/partner-chains-cli/src/start_node/tests.rs
+++ b/toolkit/partner-chains-cli/src/start_node/tests.rs
@@ -2,7 +2,7 @@ use crate::tests::{MockIO, MockIOContext};
 
 use super::*;
 
-const RESOURCES_CONFIG_PATH: &str = "partner-chains-cli-resources-config.json";
+const RESOURCES_CONFIG_PATH: &str = "pc-resources-config.json";
 const DATA_PATH: &str = "/path/to/data";
 const CHAIN_SPEC_FILE: &str = "chain-spec.json";
 const DB_CONNECTION_STRING: &str =


### PR DESCRIPTION
# Description

Changes the names of the config files used by wizard commands to be shorter.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

