### PR TITLE
change: ETCM-8437 make cardano slot length configurable

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,9 @@ files accordingly if migrating from prior versions.
 setting the permissioned candidates exactly as provided, overriding previous candidates. That means you can no longer remove a single candidate, you need
 to provide a whole list if you only want to remove one candidate. Set `"permissioned_candidate": true` in your config for every permissioned candidate on your network
 to achieve this.
+* Made Cardano slot duration configurable with default of 1000ms. If your partner chain's main chain is Cardano
+mainnet or one of the official testnets, you don't need to change anything. Otherwise, the duration can
+be set through `MC__SLOT_DURATION_MILLIS` environment variable.
 
 ## Removed
 

--- a/dev/envs/devnet/.envrc
+++ b/dev/envs/devnet/.envrc
@@ -27,6 +27,7 @@ export BLOCK_STABILITY_MARGIN=0
 # Timestamp for the MC_FIRST_EPOCH_NUMBER
 # Genesis should not have a timestamp before this one, this should be divisible by both sidechain slot and epoch durations
 export MC__FIRST_EPOCH_TIMESTAMP_MILLIS=1666656000000
+export MC__SLOT_DURATION_MILLIS=1000
 # First Shelley epoch number on Cardano
 export MC__FIRST_EPOCH_NUMBER=0
 # Should be divisible by Sidechain epoch duration (which is SlotDuration * SlotsPerEpoch and those params can be found in runtime/src/lib.rs)

--- a/docs/user-guides/chain-builder.md
+++ b/docs/user-guides/chain-builder.md
@@ -274,6 +274,7 @@ A sample file:
     "first_epoch_number": 208,
     "first_epoch_timestamp_millis": 1596059091000,
     "first_slot_number": 4492800,
+    "main_chain_slot_duration_millis": 1000,
     "network": 0,
     "security_parameter": 2160
   },

--- a/node/node/src/tests/mock.rs
+++ b/node/node/src/tests/mock.rs
@@ -35,6 +35,7 @@ pub fn test_epoch_config() -> MainchainEpochConfig {
 				* 10,
 		),
 		first_slot_number: 0,
+		slot_duration_millis: Duration::from_millis(1000),
 	}
 }
 

--- a/toolkit/mainchain-follower/db-sync-follower/src/block/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/block/mod.rs
@@ -107,14 +107,15 @@ impl BlockDataSourceImpl {
 		mc_epoch_config: &MainchainEpochConfig,
 	) -> BlockDataSourceImpl {
 		let k: f64 = cardano_security_parameter.into();
-		let min_slot_boundary = (k / cardano_active_slots_coeff).round() as i64;
+		let slot_duration: f64 = mc_epoch_config.slot_duration_millis.millis() as f64;
+		let min_slot_boundary = (slot_duration * k / cardano_active_slots_coeff).round() as i64;
 		let max_slot_boundary = 3 * min_slot_boundary;
 		let cache_size = 100;
 		BlockDataSourceImpl::new(
 			pool,
 			cardano_security_parameter,
-			TimeDelta::seconds(min_slot_boundary),
-			TimeDelta::seconds(max_slot_boundary),
+			TimeDelta::milliseconds(min_slot_boundary),
+			TimeDelta::milliseconds(max_slot_boundary),
 			mc_epoch_config.clone(),
 			block_stability_margin,
 			cache_size,

--- a/toolkit/mainchain-follower/db-sync-follower/src/block/tests.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/block/tests.rs
@@ -274,6 +274,7 @@ fn mainchain_epoch_config() -> MainchainEpochConfig {
 		epoch_duration_millis: Duration::from_millis(1000 * 1000),
 		first_epoch_number: 189,
 		first_slot_number: 189000,
+		slot_duration_millis: Duration::from_millis(1000),
 	}
 }
 

--- a/toolkit/pallets/sidechain/rpc/src/tests/mod.rs
+++ b/toolkit/pallets/sidechain/rpc/src/tests/mod.rs
@@ -24,6 +24,7 @@ mod get_status_tests {
 			epoch_duration_millis: Duration::from_millis(120_000),
 			first_epoch_number: 50,
 			first_slot_number: 501,
+			slot_duration_millis: Duration::from_millis(1000),
 		};
 		let mainchain_block = MainchainBlock {
 			epoch: McEpochNumber(99),
@@ -84,6 +85,7 @@ mod get_status_tests {
 			epoch_duration_millis: Duration::from_millis(120_000),
 			first_epoch_number: 50,
 			first_slot_number: 501,
+			slot_duration_millis: Duration::from_millis(1000),
 		};
 		let mainchain_block = MainchainBlock {
 			epoch: McEpochNumber(99),

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -4,6 +4,7 @@ use crate::config::config_fields::{
 };
 use crate::io::IOContext;
 use clap::{arg, Parser};
+use config_fields::CARDANO_SLOT_DURATION_MILLIS;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use sidechain_domain::UtxoId;
 use sp_core::offchain::{Duration, Timestamp};
@@ -271,6 +272,7 @@ pub struct CardanoParameters {
 	pub first_slot_number: u64,
 	pub epoch_duration_millis: u64,
 	pub first_epoch_timestamp_millis: u64,
+	pub main_chain_slot_duration_millis: u64,
 }
 
 impl CardanoParameters {
@@ -282,6 +284,7 @@ impl CardanoParameters {
 		CARDANO_EPOCH_DURATION_MILLIS.save_to_file(&self.epoch_duration_millis, context);
 		CARDANO_FIRST_EPOCH_TIMESTAMP_MILLIS
 			.save_to_file(&self.first_epoch_timestamp_millis, context);
+		CARDANO_SLOT_DURATION_MILLIS.save_to_file(&self.main_chain_slot_duration_millis, context);
 	}
 
 	pub fn read(context: &impl IOContext) -> Option<Self> {
@@ -292,6 +295,8 @@ impl CardanoParameters {
 			first_slot_number: CARDANO_FIRST_SLOT_NUMBER.load_from_file(context)?,
 			epoch_duration_millis: CARDANO_EPOCH_DURATION_MILLIS.load_from_file(context)?,
 			first_epoch_timestamp_millis: CARDANO_FIRST_EPOCH_TIMESTAMP_MILLIS
+				.load_from_file(context)?,
+			main_chain_slot_duration_millis: CARDANO_SLOT_DURATION_MILLIS
 				.load_from_file(context)?,
 		})
 	}
@@ -306,6 +311,7 @@ impl From<CardanoParameters> for sidechain_domain::mainchain_epoch::MainchainEpo
 			epoch_duration_millis: Duration::from_millis(value.epoch_duration_millis),
 			first_epoch_number: value.first_epoch_number,
 			first_slot_number: value.first_slot_number,
+			slot_duration_millis: Duration::from_millis(value.main_chain_slot_duration_millis),
 		}
 	}
 }
@@ -561,6 +567,15 @@ pub mod config_fields {
 			path: &["cardano", "first_epoch_timestamp_millis"],
 			name: "cardano first shelley epoch timestamp in millis",
 			default: None,
+			_marker: PhantomData,
+		};
+
+	pub const CARDANO_SLOT_DURATION_MILLIS: ConfigFieldDefinition<'static, u64> =
+		ConfigFieldDefinition {
+			config_file: CHAIN_CONFIG_FILE_PATH,
+			path: &["cardano", "slot_duration_millis"],
+			name: "cardano slot duration in millis",
+			default: Some("1000"),
 			_marker: PhantomData,
 		};
 

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -152,6 +152,7 @@ fn test_chain_config_content() -> serde_json::Value {
 			"epoch_duration_millis": 86400000,
 			"first_epoch_number": 1,
 			"first_slot_number": 4320,
+			"main_chain_slot_duration_millis": 1000,
 			"network": "testnet"
 		},
 		"cardano_addresses": {

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -42,28 +42,19 @@ fn caradano_parameters(
 			.checked_add(first_epoch_era.start.time_seconds)
 			.and_then(|seconds| seconds.checked_mul(1000))
 			.ok_or_else(|| anyhow::anyhow!("First epoch timestamp overflow"))?,
+		main_chain_slot_duration_millis: shelley_config.slot_length_millis,
 	})
 }
 
-// Partner Chains Main Chain follower supports only eras with 1 second slots.
-// This functions gets the first era with 1 second slots,
+// This functions gets the first era
 // such that all following eras have the same slot length and epoch length.
 fn get_first_epoch_era(eras_summaries: Vec<EraSummary>) -> Result<EraSummary, anyhow::Error> {
-	let latest_era_parameters = eras_summaries
-		.last()
-		.ok_or_else(|| anyhow::anyhow!("No eras found"))?
-		.parameters
-		.clone();
-	if latest_era_parameters.slot_length_millis != 1000 {
-		return Err(anyhow::anyhow!(
-			"Unexpected slot length in latest era, Partner Chains support only 1 second slots"
-		));
-	}
+	let latest_era = eras_summaries.last().ok_or_else(|| anyhow::anyhow!("No eras found"))?;
 	let first_epoch_era = eras_summaries
-		.into_iter()
-		.find(|era| era.parameters == latest_era_parameters)
+		.iter()
+		.find(|era| era.parameters == latest_era.parameters)
 		.ok_or_else(|| anyhow::anyhow!("No eras found"))?;
-	Ok(first_epoch_era)
+	Ok(first_epoch_era.clone())
 }
 
 #[cfg(test)]
@@ -86,6 +77,7 @@ pub mod tests {
 		first_slot_number: 86400,
 		epoch_duration_millis: 432000000,
 		first_epoch_timestamp_millis: 1655769600000,
+		main_chain_slot_duration_millis: 1000,
 	};
 
 	pub(crate) const PREVIEW_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
@@ -95,6 +87,7 @@ pub mod tests {
 		first_slot_number: 0,
 		epoch_duration_millis: 86400000,
 		first_epoch_timestamp_millis: 1666656000000,
+		main_chain_slot_duration_millis: 1000,
 	};
 
 	#[test]

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -276,7 +276,8 @@ mod tests {
 				"first_epoch_number": PREPROD_CARDANO_PARAMS.first_epoch_number,
 				"first_slot_number": PREPROD_CARDANO_PARAMS.first_slot_number,
 				"epoch_duration_millis": PREPROD_CARDANO_PARAMS.epoch_duration_millis,
-				"first_epoch_timestamp_millis": PREPROD_CARDANO_PARAMS.first_epoch_timestamp_millis
+				"first_epoch_timestamp_millis": PREPROD_CARDANO_PARAMS.first_epoch_timestamp_millis,
+				"slot_duration_millis": PREPROD_CARDANO_PARAMS.main_chain_slot_duration_millis
 			},
 			"cardano_addresses": {
 				"committee_candidates_address": TEST_COMMITTEE_CANDIDATES_ADDRESS,

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -351,6 +351,7 @@ mod tests {
 				"epoch_duration_millis": 86400000,
 				"first_epoch_number": 1,
 				"first_slot_number": 4320,
+				"main_chain_slot_duration_millis": 1000,
 				"network": "mainnet"
 			},
 			"cardano_addresses": {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -324,6 +324,7 @@ fn test_chain_config_content() -> serde_json::Value {
 			"epoch_duration_millis": 86400000,
 			"first_epoch_number": 1,
 			"first_slot_number": 4320,
+			"main_chain_slot_duration_millis": 1000,
 			"network": "testnet"
 		},
 		"cardano_addresses": {

--- a/toolkit/partner-chains-cli/src/start_node/mod.rs
+++ b/toolkit/partner-chains-cli/src/start_node/mod.rs
@@ -181,6 +181,7 @@ pub fn start_node<C: IOContext>(
 				first_slot_number,
 				epoch_duration_millis,
 				first_epoch_timestamp_millis,
+				main_chain_slot_duration_millis,
 			},
 		bootnodes,
 	}: StartNodeChainConfig,
@@ -195,6 +196,7 @@ pub fn start_node<C: IOContext>(
          DB_SYNC_POSTGRES_CONNECTION_STRING='{db_connection_string}' \\
          MC__FIRST_EPOCH_TIMESTAMP_MILLIS='{first_epoch_timestamp_millis}' \\
          MC__EPOCH_DURATION_MILLIS='{epoch_duration_millis}' \\
+         MC__SLOT_DURATION_MILLIS='{main_chain_slot_duration_millis}' \\
          MC__FIRST_EPOCH_NUMBER='{first_epoch_number}' \\
          MC__FIRST_SLOT_NUMBER='{first_slot_number}' \\
          BLOCK_STABILITY_MARGIN='0' \\

--- a/toolkit/partner-chains-cli/src/start_node/tests.rs
+++ b/toolkit/partner-chains-cli/src/start_node/tests.rs
@@ -44,6 +44,7 @@ const FIRST_EPOCH_NUMBER: u64 = 5;
 const FIRST_SLOT_NUMBER: u64 = 42000;
 const EPOCH_DURATION_MILLIS: u64 = 43200;
 const FIRST_EPOCH_TIMESTAMP_MILLIS: u64 = 1590000000000;
+const SLOT_DURATION_MILLIS: u64 = 1000;
 
 fn default_chain_config() -> serde_json::Value {
 	serde_json::json!({
@@ -57,7 +58,8 @@ fn default_chain_config() -> serde_json::Value {
 			"first_epoch_number": FIRST_EPOCH_NUMBER,
 			"first_slot_number": FIRST_SLOT_NUMBER,
 			"epoch_duration_millis": EPOCH_DURATION_MILLIS,
-			"first_epoch_timestamp_millis": FIRST_EPOCH_TIMESTAMP_MILLIS
+			"first_epoch_timestamp_millis": FIRST_EPOCH_TIMESTAMP_MILLIS,
+			"main_chain_slot_duration_millis": SLOT_DURATION_MILLIS
 		},
 		"chain_parameters": {
 			"genesis_utxo": "0000000000000000000000000000000000000000000000000000000000000000#0",
@@ -73,6 +75,7 @@ fn default_chain_config_run_command() -> String {
          DB_SYNC_POSTGRES_CONNECTION_STRING='{DB_CONNECTION_STRING}' \\
          MC__FIRST_EPOCH_TIMESTAMP_MILLIS='{FIRST_EPOCH_TIMESTAMP_MILLIS}' \\
          MC__EPOCH_DURATION_MILLIS='{EPOCH_DURATION_MILLIS}' \\
+         MC__SLOT_DURATION_MILLIS='{SLOT_DURATION_MILLIS}' \\
          MC__FIRST_EPOCH_NUMBER='{FIRST_EPOCH_NUMBER}' \\
          MC__FIRST_SLOT_NUMBER='{FIRST_SLOT_NUMBER}' \\
          BLOCK_STABILITY_MARGIN='0' \\

--- a/toolkit/primitives/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
@@ -221,6 +221,7 @@ mod tests {
 					* 10,
 			),
 			first_slot_number: 0,
+			slot_duration_millis: Duration::from_millis(1000),
 		};
 		let mc_reference_epoch = McEpochNumber(1);
 		let empty_ariadne_idp = AriadneInherentDataProvider::new(

--- a/toolkit/primitives/domain/src/mainchain_epoch.rs
+++ b/toolkit/primitives/domain/src/mainchain_epoch.rs
@@ -13,6 +13,12 @@ pub struct MainchainEpochConfig {
 	/// Number of the Cardano Epoch started at `first_epoch_timestamp_millis`
 	pub first_epoch_number: u32,
 	pub first_slot_number: u64,
+	#[cfg_attr(feature = "std", serde(default = "default_slot_duration"))]
+	pub slot_duration_millis: Duration,
+}
+
+fn default_slot_duration() -> Duration {
+	Duration::from_millis(1000)
 }
 
 #[derive(Encode, PartialEq, Eq)]
@@ -96,8 +102,7 @@ impl MainchainEpochDerivation for MainchainEpochConfig {
 			.unix_millis()
 			.checked_sub(self.first_epoch_timestamp_millis.unix_millis())
 			.ok_or(EpochDerivationError::TimestampTooSmall)?;
-		let mainchain_slot_duration = 1000;
-		Ok(self.first_slot_number + time_elapsed / mainchain_slot_duration)
+		Ok(self.first_slot_number + time_elapsed / self.slot_duration_millis.millis())
 	}
 
 	fn mainchain_epoch_to_timestamp(&self, epoch: McEpochNumber) -> Timestamp {
@@ -144,6 +149,7 @@ mod tests {
 					first_epoch_number: 100,
 					epoch_duration_millis: Duration::from_millis(1000),
 					first_slot_number: 42,
+					slot_duration_millis: Duration::from_millis(1000)
 				}
 			);
 			Ok(())
@@ -163,6 +169,7 @@ mod tests {
 			epoch_duration_millis: Duration::from_millis(1),
 			first_epoch_number: 0,
 			first_slot_number: 0,
+			slot_duration_millis: Duration::from_millis(1000),
 		}
 	}
 
@@ -172,6 +179,7 @@ mod tests {
 			epoch_duration_millis: Duration::from_millis(5 * 24 * 60 * 60 * 1000),
 			first_epoch_number: 75,
 			first_slot_number: 0,
+			slot_duration_millis: Duration::from_millis(1000),
 		}
 	}
 
@@ -181,6 +189,7 @@ mod tests {
 			epoch_duration_millis: Duration::from_millis(5 * 24 * 60 * 60 * 1000),
 			first_epoch_number: 4,
 			first_slot_number: 86400,
+			slot_duration_millis: Duration::from_millis(1000),
 		}
 	}
 


### PR DESCRIPTION
# Description

Cardano slot length was hard-coded to 1000ms. This PR makes it configurable via environment variable, while defaulting back to the original value.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

