### PR TITLE
add: ETCM-8739 include input data hash in committee selection inherent

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -54,6 +54,7 @@ to achieve this.
 * Command `smart-contracts reserve init`, `create`, `deposit`, `release`, `handover` and `update-settings`
 * Command `smart-contracts governance update`
 * Ogmios client backed by jsonrpsee `WsClient`
+* Input data is now included in the `set` committee inherent in `pallet-session-validator-management`
 
 # v1.4.0
 

--- a/toolkit/pallets/session-validator-management/Cargo.toml
+++ b/toolkit/pallets/session-validator-management/Cargo.toml
@@ -36,7 +36,10 @@ std = [
     "sp-core/std",
     "sp-runtime/std",
     "sp-std/std",
-    "sp-session-validator-management/std"
+    "sp-session-validator-management/std",
+    "sp-session-validator-management/serde",
+    "sidechain-domain/std",
+    "sidechain-domain/serde",
 ]
 try-runtime = ["frame-support/try-runtime"]
 mock = [

--- a/toolkit/pallets/session-validator-management/benchmarking/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/benchmarking/src/lib.rs
@@ -74,7 +74,7 @@ pub mod benchmarks {
 		set_epoch_number::<T>(for_epoch_number.into());
 
 		#[extrinsic_call]
-		_(RawOrigin::None, validators.clone(), for_epoch_number);
+		_(RawOrigin::None, validators.clone(), for_epoch_number, Default::default());
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -214,7 +214,9 @@ pub mod pallet {
 
 			if *validators_param != validators {
 				if *call_selection_inputs_hash == computed_selection_inputs_hash {
-					return Err(InherentError::InvalidValidators(computed_selection_inputs_hash));
+					return Err(InherentError::InvalidValidatorsMatchingHash(
+						computed_selection_inputs_hash,
+					));
 				} else {
 					return Err(InherentError::InvalidValidatorsHashMismatch(
 						computed_selection_inputs_hash,

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -337,10 +337,7 @@ pub mod pallet {
 				.get_data::<T::AuthoritySelectionInputs>(&INHERENT_IDENTIFIER)
 				.expect("Validator inherent data not correctly encoded")
 				.expect("Validator inherent data must be provided");
-			let raw_data = decoded_data.encode();
-
-			let data_hash =
-				blake2_256(&raw_data).to_vec().try_into().expect("blake256 is always 32 bytes");
+			let data_hash = SizedByteString(blake2_256(&decoded_data.encode()));
 
 			(decoded_data, data_hash)
 		}

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -225,13 +225,6 @@ pub mod pallet {
 				}
 			}
 
-			if *call_selection_inputs_hash != computed_selection_inputs_hash {
-				log::warn!("⁉️️ Correct committee set via inherent in imported block, but different input data hash found. Expected: {}, got: {}",
-					computed_selection_inputs_hash.to_hex_string(),
-					call_selection_inputs_hash.to_hex_string(),
-				);
-			}
-
 			Ok(())
 		}
 

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -213,7 +213,14 @@ pub mod pallet {
 					});
 
 			if *validators_param != validators {
-				return Err(InherentError::InvalidValidators);
+				if *call_selection_inputs_hash == computed_selection_inputs_hash {
+					return Err(InherentError::InvalidValidators(computed_selection_inputs_hash));
+				} else {
+					return Err(InherentError::InvalidValidatorsHashMismatch(
+						computed_selection_inputs_hash,
+						call_selection_inputs_hash.clone(),
+					));
+				}
 			}
 
 			if *call_selection_inputs_hash != computed_selection_inputs_hash {

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -217,10 +217,10 @@ pub mod pallet {
 			}
 
 			if *call_selection_inputs_hash != computed_selection_inputs_hash {
-				return Err(InherentError::DataHashMismatch(
-					call_selection_inputs_hash.clone(),
-					computed_selection_inputs_hash,
-				));
+				log::warn!("⁉️️ Correct committee set via inherent in imported block, but different input data hash found. Expected: {}, got: {}",
+					computed_selection_inputs_hash.to_hex_string(),
+					call_selection_inputs_hash.to_hex_string(),
+				);
 			}
 
 			Ok(())

--- a/toolkit/pallets/session-validator-management/src/tests.rs
+++ b/toolkit/pallets/session-validator-management/src/tests.rs
@@ -5,7 +5,9 @@ mod inherent_tests {
 	use super::*;
 	use crate::{pallet, CommitteeInfo, Error};
 	use frame_support::assert_err;
+	use sidechain_domain::byte_string::SizedByteString;
 	use sp_runtime::DispatchError;
+	use sp_session_validator_management::InherentError;
 
 	#[test]
 	fn changes_validator_vec_based_on_inherent_data() {
@@ -111,6 +113,63 @@ mod inherent_tests {
 				&call,
 				&inherent_data_from_which_committee_cannot_be_selected
 			));
+		});
+	}
+
+	#[test]
+	fn check_inherent_error_includes_both_hashes_if_different() {
+		let mut genesis_validators = [ALICE, BOB];
+		new_test_ext_with_genesis_initial_authorities(&genesis_validators).execute_with(|| {
+			assert!(pallet::NextCommittee::<Test>::get().is_none());
+			let (inherent_data_from_which_committee_cannot_be_selected, selection_inputs_hash) =
+				create_inherent_data(&genesis_validators);
+			genesis_validators.reverse();
+			let call = pallet::Call::set {
+				validators: ids_and_keys_fn(&genesis_validators),
+				for_epoch_number: 43,
+				selection_inputs_hash: selection_inputs_hash.clone(),
+			};
+
+			let expected_err =
+				InherentError::InvalidValidatorsMatchingHash(selection_inputs_hash.clone());
+			assert_eq!(
+				<SessionCommitteeManagement as ProvideInherent>::check_inherent(
+					&call,
+					&inherent_data_from_which_committee_cannot_be_selected
+				),
+				Err(expected_err)
+			);
+		});
+	}
+
+	#[test]
+	fn check_inherent_error_includes_hash_if_correct() {
+		let mut genesis_validators = [ALICE, BOB];
+		new_test_ext_with_genesis_initial_authorities(&genesis_validators).execute_with(|| {
+			assert!(pallet::NextCommittee::<Test>::get().is_none());
+			let (
+				inherent_data_from_which_committee_cannot_be_selected,
+				correct_selection_inputs_hash,
+			) = create_inherent_data(&genesis_validators);
+			let incorrect_selection_inputs_hash = SizedByteString([9u8; 32]);
+			genesis_validators.reverse();
+			let call = pallet::Call::set {
+				validators: ids_and_keys_fn(&genesis_validators),
+				for_epoch_number: 43,
+				selection_inputs_hash: incorrect_selection_inputs_hash.clone(),
+			};
+
+			let expected_err = InherentError::InvalidValidatorsHashMismatch(
+				correct_selection_inputs_hash.clone(),
+				incorrect_selection_inputs_hash.clone(),
+			);
+			assert_eq!(
+				<SessionCommitteeManagement as ProvideInherent>::check_inherent(
+					&call,
+					&inherent_data_from_which_committee_cannot_be_selected
+				),
+				Err(expected_err)
+			);
 		});
 	}
 }

--- a/toolkit/pallets/session-validator-management/src/tests.rs
+++ b/toolkit/pallets/session-validator-management/src/tests.rs
@@ -56,7 +56,7 @@ mod inherent_tests {
 			);
 			assert_ok!(<SessionCommitteeManagement as ProvideInherent>::check_inherent(
 				&call,
-				&create_inherent_data(&validators)
+				&create_inherent_data(&validators).0
 			));
 		});
 	}
@@ -77,11 +77,13 @@ mod inherent_tests {
 				committee: ids_and_keys_fn(&[ALICE, BOB]),
 				epoch: 43,
 			});
+			let (inherent_data_from_which_committee_cannot_be_selected, selection_inputs_hash) =
+				create_inherent_data(&[]);
 			let set_call = pallet::Call::set {
 				validators: ids_and_keys_fn(&[ALICE, BOB]),
 				for_epoch_number: 43,
+				selection_inputs_hash,
 			};
-			let inherent_data_from_which_committee_cannot_be_selected = create_inherent_data(&[]);
 			assert_ok!(<SessionCommitteeManagement as ProvideInherent>::check_inherent(
 				&set_call,
 				&inherent_data_from_which_committee_cannot_be_selected
@@ -97,11 +99,13 @@ mod inherent_tests {
 		let genesis_validators = [ALICE, BOB];
 		new_test_ext_with_genesis_initial_authorities(&genesis_validators).execute_with(|| {
 			assert!(pallet::NextCommittee::<Test>::get().is_none());
+			let (inherent_data_from_which_committee_cannot_be_selected, selection_inputs_hash) =
+				create_inherent_data(&[]);
 			let call = pallet::Call::set {
 				validators: ids_and_keys_fn(&genesis_validators),
 				for_epoch_number: 43,
+				selection_inputs_hash,
 			};
-			let inherent_data_from_which_committee_cannot_be_selected = create_inherent_data(&[]);
 			// Should be Ok, because check_inherent should use CurrentCommittee value.
 			assert_ok!(<SessionCommitteeManagement as ProvideInherent>::check_inherent(
 				&call,

--- a/toolkit/pallets/session-validator-management/src/tests.rs
+++ b/toolkit/pallets/session-validator-management/src/tests.rs
@@ -117,7 +117,7 @@ mod inherent_tests {
 	}
 
 	#[test]
-	fn check_inherent_error_includes_both_hashes_if_different() {
+	fn check_inherent_error_includes_hash_if_correct() {
 		let mut genesis_validators = [ALICE, BOB];
 		new_test_ext_with_genesis_initial_authorities(&genesis_validators).execute_with(|| {
 			assert!(pallet::NextCommittee::<Test>::get().is_none());
@@ -143,7 +143,7 @@ mod inherent_tests {
 	}
 
 	#[test]
-	fn check_inherent_error_includes_hash_if_correct() {
+	fn check_inherent_error_includes_both_hashes_if_different() {
 		let mut genesis_validators = [ALICE, BOB];
 		new_test_ext_with_genesis_initial_authorities(&genesis_validators).execute_with(|| {
 			assert!(pallet::NextCommittee::<Test>::get().is_none());

--- a/toolkit/primitives/domain/src/byte_string.rs
+++ b/toolkit/primitives/domain/src/byte_string.rs
@@ -15,7 +15,8 @@ pub struct ByteString(pub Vec<u8>);
 // Constant size variant of `ByteString` that's usable as a runtime type
 #[derive(Eq, Clone, PartialEq, TypeInfo, MaxEncodedLen, Encode, Decode)]
 #[byte_string(debug)]
-#[cfg_attr(feature = "std", byte_string(to_hex_string, decode_hex))]
+#[byte_string(to_hex_string)]
+#[cfg_attr(feature = "std", byte_string(decode_hex))]
 #[cfg_attr(feature = "serde", byte_string(hex_serialize))]
 pub struct SizedByteString<const N: usize>(pub [u8; N]);
 
@@ -24,5 +25,11 @@ impl<const N: usize> TryFrom<Vec<u8>> for SizedByteString<N> {
 
 	fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
 		Ok(SizedByteString(value.try_into()?))
+	}
+}
+
+impl<const N: usize> Default for SizedByteString<N> {
+	fn default() -> Self {
+		Self([0; N])
 	}
 }

--- a/toolkit/primitives/session-validator-management/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/src/lib.rs
@@ -3,7 +3,7 @@
 use core::str::FromStr;
 
 use scale_info::TypeInfo;
-use sidechain_domain::{MainchainAddress, PolicyId};
+use sidechain_domain::{byte_string::SizedByteString, MainchainAddress, PolicyId};
 use sp_core::{Decode, Encode, MaxEncodedLen};
 use sp_inherents::{InherentIdentifier, IsFatalError};
 
@@ -22,6 +22,11 @@ pub enum InherentError {
 		error("Candidates inherent required: committee needs to be stored one epoch in advance")
 	)]
 	CommitteeNeedsToBeStoredOneEpochInAdvance,
+	#[cfg_attr(
+		feature = "std",
+		error("Inherent called with data hash {0:?} but {1:?} expected from inherent data")
+	)]
+	DataHashMismatch(SizedByteString<32>, SizedByteString<32>),
 }
 
 impl IsFatalError for InherentError {

--- a/toolkit/primitives/session-validator-management/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/src/lib.rs
@@ -14,19 +14,21 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"/ariadne";
 pub enum InherentError {
 	#[cfg_attr(
 		feature = "std",
-		error("The validators in the block do not match the calculated validators")
+		error("The validators in the block do not match the calculated validators. Input data hash ({}) is valid.", .0.to_hex_string())
 	)]
-	InvalidValidators,
+	InvalidValidators(SizedByteString<32>),
+	#[cfg_attr(
+		feature = "std",
+		error("The validators and input data hash in the block do not match the calculated values. Expected hash: {}, got: {}",
+			.0.to_hex_string(),
+			.1.to_hex_string())
+	)]
+	InvalidValidatorsHashMismatch(SizedByteString<32>, SizedByteString<32>),
 	#[cfg_attr(
 		feature = "std",
 		error("Candidates inherent required: committee needs to be stored one epoch in advance")
 	)]
 	CommitteeNeedsToBeStoredOneEpochInAdvance,
-	#[cfg_attr(
-		feature = "std",
-		error("Inherent called with data hash {0:?} but {1:?} expected from inherent data")
-	)]
-	DataHashMismatch(SizedByteString<32>, SizedByteString<32>),
 }
 
 impl IsFatalError for InherentError {

--- a/toolkit/primitives/session-validator-management/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/src/lib.rs
@@ -12,11 +12,25 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"/ariadne";
 #[derive(Encode, sp_runtime::RuntimeDebug, PartialEq, Eq)]
 #[cfg_attr(feature = "std", derive(Decode, thiserror::Error))]
 pub enum InherentError {
+	#[deprecated(
+		since = "1.5.0",
+		note = "Use InvalidValidatorsMatchingHash or InvalidValidatorsHashMismatch"
+	)]
+	#[cfg_attr(
+		feature = "std",
+		error("The validators in the block do not match the calculated validators")
+	)]
+	InvalidValidators,
+	#[cfg_attr(
+		feature = "std",
+		error("Candidates inherent required: committee needs to be stored one epoch in advance")
+	)]
+	CommitteeNeedsToBeStoredOneEpochInAdvance,
 	#[cfg_attr(
 		feature = "std",
 		error("The validators in the block do not match the calculated validators. Input data hash ({}) is valid.", .0.to_hex_string())
 	)]
-	InvalidValidators(SizedByteString<32>),
+	InvalidValidatorsMatchingHash(SizedByteString<32>),
 	#[cfg_attr(
 		feature = "std",
 		error("The validators and input data hash in the block do not match the calculated values. Expected hash: {}, got: {}",
@@ -24,11 +38,6 @@ pub enum InherentError {
 			.1.to_hex_string())
 	)]
 	InvalidValidatorsHashMismatch(SizedByteString<32>, SizedByteString<32>),
-	#[cfg_attr(
-		feature = "std",
-		error("Candidates inherent required: committee needs to be stored one epoch in advance")
-	)]
-	CommitteeNeedsToBeStoredOneEpochInAdvance,
 }
 
 impl IsFatalError for InherentError {

--- a/toolkit/utils/byte-string-derivation/src/lib.rs
+++ b/toolkit/utils/byte-string-derivation/src/lib.rs
@@ -242,7 +242,7 @@ fn gen_to_hex(name: &syn::Ident, generics: &Generics) -> impl ToTokens {
 
 	quote! {
 		impl #impl_generics #name #ty_generics #where_clause {
-			pub fn to_hex_string(&self) -> String {
+			pub fn to_hex_string(&self) -> alloc::string::String {
 				sp_core::bytes::to_hex(&self.0, false)
 			}
 		}


### PR DESCRIPTION
# Description

* Includes a Blake2 hash of the inherent data used in the `pallet-session-validator-management`'s `set` inherent.
* Includes hash information in the error if the committee doesn't match expected
* Logs a warning if correct committee is selected but a hash mismatch is detected

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

