### PR TITLE
fix: return error instead of panic when permission candidates file is missing

### DIFF
--- a/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
+++ b/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
@@ -26,10 +26,13 @@ impl UpsertPermissionedCandidatesCmd {
 
 		let mut permissioned_candidates = Vec::new();
 
-		for line in read_to_string(&self.permissioned_candidates_file)
-			.expect("Permissioned candidates file with each line representing one candidate")
-			.lines()
-		{
+		let file_content = read_to_string(&self.permissioned_candidates_file).map_err(|e| {
+			format!(
+				"Could not read permissioned candidates file '{}'. Cause: {e}",
+				&self.permissioned_candidates_file
+			)
+		})?;
+		for line in file_content.lines() {
 			if line.is_empty() {
 				continue;
 			}


### PR DESCRIPTION
# Description

Before:
```
STDERR: thread 'main' panicked at toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs:30:14:
Permissioned candidates file with each line representing one candidate: Os { code: 2, kind: NotFound, message: "No such file or directory" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```
After:
```
Error: Application("Could not read permissioned candidates file 'oneentry.cv'. Cause: No such file or directory (os error 2)")
```

