### PR TITLE
ETCM-9199: better error when connecting to ogmios fails

### DIFF
--- a/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
+++ b/toolkit/cli/smart-contracts-commands/src/d_parameter.rs
@@ -1,5 +1,4 @@
 use crate::PaymentFilePath;
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::d_param::upsert_d_param;
 use sidechain_domain::DParameter;
@@ -26,7 +25,7 @@ impl UpsertDParameterCmd {
 			num_permissioned_candidates: self.permissioned_candidates_count,
 			num_registered_candidates: self.registered_candidates_count,
 		};
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 
 		upsert_d_param(
 			self.genesis_utxo,

--- a/toolkit/cli/smart-contracts-commands/src/get_scripts.rs
+++ b/toolkit/cli/smart-contracts-commands/src/get_scripts.rs
@@ -1,4 +1,3 @@
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::scripts_data::get_scripts_data_with_ogmios;
 use sidechain_domain::UtxoId;
 
@@ -13,7 +12,7 @@ pub struct GetScripts {
 
 impl GetScripts {
 	pub async fn execute(self) -> crate::CmdResult<()> {
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let scripts_data = get_scripts_data_with_ogmios(self.genesis_utxo, &client).await?;
 
 		let json = serde_json::to_string_pretty(&scripts_data)?;

--- a/toolkit/cli/smart-contracts-commands/src/governance.rs
+++ b/toolkit/cli/smart-contracts-commands/src/governance.rs
@@ -1,5 +1,4 @@
 use crate::PaymentFilePath;
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries, init_governance::run_init_governance,
 	update_governance::run_update_governance,
@@ -41,7 +40,7 @@ pub struct InitGovernanceCmd {
 impl InitGovernanceCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 
 		run_init_governance(
 			self.governance_authority,
@@ -72,7 +71,7 @@ pub struct UpdateGovernanceCmd {
 impl UpdateGovernanceCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 
 		run_update_governance(
 			self.new_governance_authority,

--- a/toolkit/cli/smart-contracts-commands/src/lib.rs
+++ b/toolkit/cli/smart-contracts-commands/src/lib.rs
@@ -1,3 +1,4 @@
+use ogmios_client::jsonrpsee::{client_for_url, OgmiosClients};
 use partner_chains_cardano_offchain::cardano_keys::{
 	CardanoKeyFileContent, CardanoPaymentSigningKey,
 };
@@ -36,6 +37,14 @@ pub enum SmartContractsCmd {
 pub struct CommonArguments {
 	#[arg(default_value = "ws://localhost:1337", long, short = 'O')]
 	ogmios_url: String,
+}
+
+impl CommonArguments {
+	pub async fn get_ogmios_client(&self) -> crate::CmdResult<OgmiosClients> {
+		Ok(client_for_url(&self.ogmios_url).await.map_err(|e| {
+			format!("Failed to connect to Ogmios at {} with: {}", &self.ogmios_url, e)
+		})?)
+	}
 }
 
 type CmdResult<T> = Result<T, Box<dyn std::error::Error + Send + Sync>>;

--- a/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
+++ b/toolkit/cli/smart-contracts-commands/src/permissioned_candidates.rs
@@ -1,6 +1,5 @@
 use crate::parse_partnerchain_public_keys;
 use crate::PaymentFilePath;
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::permissioned_candidates::upsert_permissioned_candidates;
 use sidechain_domain::UtxoId;
@@ -42,7 +41,7 @@ impl UpsertPermissionedCandidatesCmd {
 			permissioned_candidates.push(permissioned_candidate);
 		}
 
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 
 		upsert_permissioned_candidates(
 			self.genesis_utxo,

--- a/toolkit/cli/smart-contracts-commands/src/register.rs
+++ b/toolkit/cli/smart-contracts-commands/src/register.rs
@@ -1,5 +1,4 @@
 use crate::{parse_partnerchain_public_keys, PaymentFilePath};
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
 	register::{run_deregister, run_register},
@@ -43,7 +42,7 @@ pub struct RegisterCmd {
 impl RegisterCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let candidate_registration = CandidateRegistration {
 			stake_ownership: AdaBasedStaking {
 				pub_key: self.spo_public_key,
@@ -87,7 +86,7 @@ pub struct DeregisterCmd {
 impl DeregisterCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_signing_key = self.payment_key_file.read_key()?;
-		let client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 
 		run_deregister(
 			self.genesis_utxo,

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -1,5 +1,4 @@
 use crate::PaymentFilePath;
-use ogmios_client::jsonrpsee::client_for_url;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
 	reserve::{
@@ -55,11 +54,11 @@ pub struct InitReserveCmd {
 impl InitReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = init_reserve_management(
 			self.genesis_utxo,
 			&payment_key,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
@@ -90,7 +89,7 @@ pub struct CreateReserveCmd {
 impl CreateReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = create_reserve_utxo(
 			ReserveParameters {
 				total_accrued_function_script_hash: self.total_accrued_function_script_hash,
@@ -99,7 +98,7 @@ impl CreateReserveCmd {
 			},
 			self.genesis_utxo,
 			&payment_key,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
@@ -127,12 +126,12 @@ pub struct DepositReserveCmd {
 impl DepositReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = deposit_to_reserve(
 			TokenAmount { token: self.token, amount: self.amount },
 			self.genesis_utxo,
 			&payment_key,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
@@ -157,12 +156,12 @@ pub struct UpdateReserveSettingsCmd {
 impl UpdateReserveSettingsCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = update_reserve_settings(
 			self.genesis_utxo,
 			&payment_key,
 			self.total_accrued_function_script_hash,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
@@ -184,11 +183,11 @@ pub struct HandoverReserveCmd {
 impl HandoverReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = handover_reserve(
 			self.genesis_utxo,
 			&payment_key,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
@@ -219,13 +218,13 @@ pub struct ReleaseReserveCmd {
 impl ReleaseReserveCmd {
 	pub async fn execute(self) -> crate::CmdResult<()> {
 		let payment_key = self.payment_key_file.read_key()?;
-		let ogmios_client = client_for_url(&self.common_arguments.ogmios_url).await?;
+		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = release_reserve_funds(
 			TokenAmount { token: self.token, amount: self.amount },
 			self.genesis_utxo,
 			self.reference_utxo,
 			&payment_key,
-			&ogmios_client,
+			&client,
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;

--- a/toolkit/partner-chains-cli/src/ogmios/mod.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/mod.rs
@@ -71,7 +71,9 @@ pub struct UtxoValue {
 pub fn ogmios_request(addr: &str, req: OgmiosRequest) -> anyhow::Result<OgmiosResponse> {
 	let tokio_runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
 	tokio_runtime.block_on(async {
-		let client = client_for_url(addr).await.map_err(|e| anyhow::anyhow!(e))?;
+		let client = client_for_url(addr)
+			.await
+			.map_err(|e| anyhow::anyhow!("Failed to connect to Ogmios at {} with: {}", addr, e))?;
 		match req {
 			OgmiosRequest::QueryLedgerStateEraSummaries => {
 				let era_summaries = client.era_summaries().await.map_err(|e| anyhow::anyhow!(e))?;

--- a/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
+++ b/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
@@ -90,7 +90,7 @@ async fn era_summaries() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let era_summaries = client.era_summaries().await.unwrap();
 	assert_eq!(era_summaries.len(), 3);
 	assert_eq!(
@@ -167,7 +167,7 @@ async fn protocol_parameters() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let parameters = client.query_protocol_parameters().await.unwrap();
 
 	assert_eq!(
@@ -232,7 +232,7 @@ async fn query_utxos() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let utxos = client
 		.query_utxos(&[
 			"addr_test1vqezxrh24ts0775hulcg3ejcwj7hns8792vnn8met6z9gwsxt87zy".into(),
@@ -292,7 +292,7 @@ async fn query_utxos_by_tx_hash() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let utxo = client
 		.query_utxo_by_id(UtxoId::new(
 			hex!("106b0d7d1544c97941777041699412fb7c8b94855210987327199620c0599580"),

--- a/toolkit/utils/ogmios-client/tests/query_network.rs
+++ b/toolkit/utils/ogmios-client/tests/query_network.rs
@@ -43,7 +43,7 @@ async fn shelley_genesis_configuration() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let genesis_configuration = client.shelley_genesis_configuration().await.unwrap();
 	assert_eq!(
 		genesis_configuration,

--- a/toolkit/utils/ogmios-client/tests/transactions.rs
+++ b/toolkit/utils/ogmios-client/tests/transactions.rs
@@ -36,7 +36,7 @@ async fn evaluate_transaction() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let response = client.evaluate_transaction(&hex!("aabbccdd")).await.unwrap();
 	assert_eq!(
 		response[0],
@@ -60,7 +60,7 @@ async fn submit_transaction() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("http://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
 	let response = client.submit_transaction(&hex!("aabbccdd")).await.unwrap();
 	assert_eq!(
 		response,


### PR DESCRIPTION
# Description

Adds more descriptive error for when connecting to Ogmios client fails.

previously:
```
Error: Application("Couldn't create WebSockets client: Error when opening the TCP socket: Connection refused (os error 61)")
```
with the change:
```
Error: Application("Failed to connect to Ogmios at ws://localhost:1337 with: Couldn't create WebSockets client: Error when opening the TCP socket: Connection refused (os error 111)")
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

