### PR TITLE
test: fix upsert permissioned candidates e2e tests

### DIFF
--- a/e2e-tests/src/blockchain_api.py
+++ b/e2e-tests/src/blockchain_api.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from src.partner_chain_rpc import PartnerChainRpcResponse, DParam
+from config.api_config import Node
 
 
 class Transaction:
@@ -159,7 +160,7 @@ class BlockchainApi(ABC):
         pass
 
     @abstractmethod
-    def upsert_permissioned_candidates(self, new_candidates_list: list) -> (bool, int):
+    def upsert_permissioned_candidates(self, new_candidates_list: dict[str, Node]) -> (bool, int):
         pass
 
     @abstractmethod

--- a/e2e-tests/src/partner_chains_node.py
+++ b/e2e-tests/src/partner_chains_node.py
@@ -1,5 +1,5 @@
 from .run_command import RunnerFactory
-from config.api_config import ApiConfig
+from config.api_config import ApiConfig, Node
 import json
 import re
 import logging as logger
@@ -137,15 +137,11 @@ class PartnerChainsNode:
             logger.error(f"Wrong response format from deregister command: {response}")
             return None
 
-    def upsert_permissioned_candidates(self, governance_key, new_candidates_list):
+    def upsert_permissioned_candidates(self, governance_key, new_candidates_list: dict[str, Node]):
         # Create permissioned candidates file to be used in CLI command
-        permissioned_candidates = []
-        for candidate in new_candidates_list:
-            permissioned_candidates.append(self.config.nodes_config.nodes[candidate.name])
-
         candidates_file_content = "\n".join(
             f"{candidate.public_key}:{candidate.aura_public_key}:{candidate.grandpa_public_key}"
-            for candidate in permissioned_candidates
+            for candidate in new_candidates_list.values()
         )
         permissioned_candidates_file = "/tmp/permissioned_candidates.csv"
         save_file_cmd = f"echo '{candidates_file_content}' > {permissioned_candidates_file}"

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -206,7 +206,7 @@ class SubstrateApi(BlockchainApi):
 
     @long_running_function
     def submit_transaction(self, tx: Transaction, wait_for_finalization):
-        tx._receipt = self.substrate.submit_extrinsic(tx._signed, wait_for_finalization)
+        tx._receipt = self.substrate.submit_extrinsic(tx._signed, wait_for_finalization=wait_for_finalization)
         logger.debug(f"Transaction sent {tx._receipt.extrinsic}")
         tx.hash = tx._receipt.extrinsic_hash
         tx.total_fee_amount = tx._receipt.total_fee_amount


### PR DESCRIPTION
fixes:
- fixture `permissioned_candidates` now gets the latest active candidates from RPC instead of db to avoid setting the same candidates error
- test_transaction now waits for finalization
- fixture `permissioned_rotation_candidates` now gets the latest status of candidates based on id column