### PR TITLE
bugfix: fix reserve release panicking with overflow error

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,8 @@ WARNING: Benchmarking command has been removed, because `frame-benchmarking-cli`
 
 ## Fixed
 
+* Overflow error in `smart-contracts reserve release` if amount is not higher than already released amount.
+
 ## Added
 
 # v1.5.0

--- a/toolkit/offchain/src/csl.rs
+++ b/toolkit/offchain/src/csl.rs
@@ -306,7 +306,7 @@ pub(crate) trait OgmiosUtxoExt {
 
 	fn to_domain(&self) -> sidechain_domain::UtxoId;
 
-	fn get_asset_amount(&self, asset: &AssetId) -> i128;
+	fn get_asset_amount(&self, asset: &AssetId) -> u64;
 
 	fn get_plutus_data(&self) -> Option<PlutusData>;
 }
@@ -336,7 +336,7 @@ impl OgmiosUtxoExt for OgmiosUtxo {
 		}
 	}
 
-	fn get_asset_amount(&self, asset_id: &AssetId) -> i128 {
+	fn get_asset_amount(&self, asset_id: &AssetId) -> u64 {
 		self.value
 			.native_tokens
 			.get(&asset_id.policy_id.0)

--- a/toolkit/offchain/src/reserve/mod.rs
+++ b/toolkit/offchain/src/reserve/mod.rs
@@ -97,7 +97,7 @@ impl ReserveData {
 		let (reserve_utxo, reserve_settings) = validator_utxos
 			.into_iter()
 			.find_map(|utxo| {
-				if utxo.get_asset_amount(&auth_token_asset_id) != 1i128 {
+				if utxo.get_asset_amount(&auth_token_asset_id) != 1u64 {
 					return None;
 				}
 				utxo.get_plutus_data()

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -544,9 +544,9 @@ async fn get_reserve_datum<
 			let reserve_auth_asset_name: Vec<u8> = Vec::new();
 			let auth_token =
 				utxo.value.native_tokens.get(&reserve_auth_policy_id).and_then(|assets| {
-					assets.iter().find(|asset| {
-						asset.name == reserve_auth_asset_name && asset.amount == 1i128
-					})
+					assets
+						.iter()
+						.find(|asset| asset.name == reserve_auth_asset_name && asset.amount == 1u64)
 				});
 			auth_token?;
 			utxo.clone()

--- a/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
+++ b/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
@@ -257,10 +257,7 @@ async fn query_utxos() {
 					let mut map = std::collections::HashMap::new();
 					map.insert(
 						hex!("e0d4479b3dbb53b1aecd48f7ef524a9cf166585923d91d9c72ed02cb"),
-						vec![Asset {
-							name: hex!("707070").to_vec(),
-							amount: 18446744073709551615i128,
-						}],
+						vec![Asset { name: hex!("707070").to_vec(), amount: 18446744073709551615 }],
 					);
 					map
 				},
@@ -319,10 +316,7 @@ async fn query_utxos_by_tx_hash() {
 					let mut map = std::collections::HashMap::new();
 					map.insert(
 						hex!("e0d4479b3dbb53b1aecd48f7ef524a9cf166585923d91d9c72ed02cb"),
-						vec![Asset {
-							name: hex!("707070").to_vec(),
-							amount: 18446744073709551615i128,
-						}],
+						vec![Asset { name: hex!("707070").to_vec(), amount: 18446744073709551615 }],
 					);
 					map
 				},


### PR DESCRIPTION
# Description

Fixes the overflow error when user passes `--amount` lower than total of already release amount.

Before:
```
thread 'main' panicked at toolkit/offchain/src/reserve/release.rs:109:30:
attempt to subtract with overflow
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

After:
```
Error: Application(The requested total amount: 2 is not greater than the amount already transferred to illiquid supply: 10!)
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff



