### PR TITLE
feat: make 'reserve release' --amount parameter the amount to release by this execution command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -13,13 +13,12 @@ WARNING: Benchmarking command has been removed, because `frame-benchmarking-cli`
 
 ## Fixed
 
-* Overflow error in `smart-contracts reserve release` if amount is not higher than already released amount.
-
 ## Added
 
 # v1.5.0
 
 ## Changed
+* `smart-contracts reserve release` command parameter `--amount` semantic has changed, it now represent the amount of tokens to release in this command execution
 * Replaced custom weights with default substrate weights for few pallets
 * Updated to polkadot-stable2409-4 (aka v1.16.4).
 * `setup-main-chain-state` command now uses native Rust to upsert the D-Parameter and upsert permissioned candidates

--- a/docs/developer-guides/native-token-reserve-management.md
+++ b/docs/developer-guides/native-token-reserve-management.md
@@ -224,7 +224,6 @@ Objective: Release available reserve tokens (defined by the `VFunction`).
   --ogmios-url ws://localhost:1337 \
   --payment-key-file <PAYMENT_KEY_FILE> \
   --reference-utxo 156803a18a4dbde48dc83a21b8b1007b693cdf096b73596252745fdef1de6414#0 \
-  --token <TOKEN> \
   --amount <AMOUNT>
 ```
 
@@ -236,17 +235,11 @@ Objective: Release available reserve tokens (defined by the `VFunction`).
 
 * `--reference-utxo`: UTXO where the `VFunction` script is attached as a reference.
 
-* `--token`: Reserve token asset id encoded in form `<policy_id_hex>.<asset_name_hex>`.
-
 * `--amount`: amount of tokens to release
 
-   - The number should be calculated as `number of tokens release up to this time + amount of tokens to release`
+   - Command will fail if amount is greater than the number of tokens in the reserve.
 
-   - If 10 tokens have already been released and you want to release 10 more, then the total accrued until now should be defined as 20.
-
-   - If `--amount` passed by the user is lower than the factual number, then nothing will be released.
-
-   - Ensure you have enough tokens to release in this time frame (the `VFunction` defines release logic).
+   - Command will fail if the `VFunction` refuses to relase given amount.
 
 #### Steps
 

--- a/toolkit/cli/smart-contracts-commands/src/reserve.rs
+++ b/toolkit/cli/smart-contracts-commands/src/reserve.rs
@@ -12,6 +12,7 @@ use partner_chains_cardano_offchain::{
 	},
 };
 use sidechain_domain::{AssetId, ScriptHash, UtxoId};
+use std::num::NonZero;
 
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
@@ -207,12 +208,9 @@ pub struct ReleaseReserveCmd {
 	/// Reference UTXO containing the V-Function script
 	#[arg(long, short('r'))]
 	reference_utxo: UtxoId,
-	/// Encoded asset id in form <policy_id_hex>.<asset_name_hex>.
+	/// Amount of reserve tokens to be released to the illiquid supply.
 	#[arg(long)]
-	token: AssetId,
-	/// Current value of the V-Function
-	#[arg(long)]
-	amount: u64,
+	amount: NonZero<u64>,
 }
 
 impl ReleaseReserveCmd {
@@ -220,7 +218,7 @@ impl ReleaseReserveCmd {
 		let payment_key = self.payment_key_file.read_key()?;
 		let client = self.common_arguments.get_ogmios_client().await?;
 		let _ = release_reserve_funds(
-			TokenAmount { token: self.token, amount: self.amount },
+			self.amount,
 			self.genesis_utxo,
 			self.reference_utxo,
 			&payment_key,

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -149,6 +149,14 @@ async fn reserve_management_scenario() {
 	)
 	.await;
 	assert_illiquid_supply(genesis_utxo, RELEASE_AMOUNT, &client).await;
+	run_release_reserve_funds(genesis_utxo, RELEASE_AMOUNT, V_FUNCTION_UTXO, &client).await;
+	assert_reserve_deposited(
+		genesis_utxo,
+		INITIAL_DEPOSIT_AMOUNT + DEPOSIT_AMOUNT - 2 * RELEASE_AMOUNT,
+		&client,
+	)
+	.await;
+	assert_illiquid_supply(genesis_utxo, 2 * RELEASE_AMOUNT, &client).await;
 	run_update_reserve_settings_management(
 		genesis_utxo,
 		UPDATED_TOTAL_ACCRUED_FUNCTION_SCRIPT_HASH,
@@ -421,13 +429,7 @@ async fn run_release_reserve_funds<
 	client: &T,
 ) {
 	release_reserve_funds(
-		TokenAmount {
-			token: AssetId {
-				policy_id: REWARDS_TOKEN_POLICY_ID,
-				asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
-			},
-			amount: release_amount,
-		},
+		release_amount.try_into().unwrap(),
 		genesis_utxo,
 		reference_utxo,
 		&governance_authority_payment_key(),


### PR DESCRIPTION
# Description

Changes `--amount` to the amount that should be released from reserve during this execution of command, not the total amount from the creation of the reserve.

Additionally, `--token` parameter is removed as it was not used by the present code. I don't know if it should or rather it should be removed from `deposit` for example. For sure users would be surprised if they given some asset id but something else was released.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

