### PR TITLE
Separate Stake and Stake Pool keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1280,7 +1280,6 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "ed25519",
  "ed25519-zebra",
  "hex",
  "hex-literal",

--- a/changelog.md
+++ b/changelog.md
@@ -315,7 +315,7 @@ types instead of raw byte arrays
 
 ## Changed
 
-* ETCM-6517 - `sidechain_getRegistrations` changed to return only active and invalid registrations in `mainchainEpoch` for `mainchainPublicKey`
+* ETCM-6517 - `sidechain_getRegistrations` changed to return only active and invalid registrations in `mainchainEpoch` for `StakePoolPublicKey`
 * ETCM-6517 - `sidechain_getAriadneParameters` extended with `candidateRegistrations` response field
 * ETCM-5756 (update) - increased granularity of errors when retrieving the parameters
 * ETCM-6629 - moved `sidechain_getStatus` json RPC method to `sidechain-pallet`

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* Split MainchainPublicKey to StakePoolPublicKey and StakePublicKey. Some parameters names has been changed as well, so potentially compiliation of downstream projects could be broken.
 * Update polkadot-sdk to polkadot-stable2412-1.
 WARNING: Benchmarking command has been removed, because `frame-benchmarking-cli` crate became GPLv3 without any exception.
 * Made Cardano slot duration configurable with default of 1000ms. If your partner chain's main chain is Cardano
@@ -315,7 +316,7 @@ types instead of raw byte arrays
 
 ## Changed
 
-* ETCM-6517 - `sidechain_getRegistrations` changed to return only active and invalid registrations in `mainchainEpoch` for `StakePoolPublicKey`
+* ETCM-6517 - `sidechain_getRegistrations` changed to return only active and invalid registrations in `mainchainEpoch` for `mainchainPublicKey`
 * ETCM-6517 - `sidechain_getAriadneParameters` extended with `candidateRegistrations` response field
 * ETCM-5756 (update) - increased granularity of errors when retrieving the parameters
 * ETCM-6629 - moved `sidechain_getStatus` json RPC method to `sidechain-pallet`

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -39,8 +39,8 @@ pub use pallet_timestamp::Call as TimestampCall;
 use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier};
 use session_manager::ValidatorManagementSessionManager;
 use sidechain_domain::{
-	MainchainPublicKey, NativeTokenAmount, PermissionedCandidateData, RegistrationData,
-	ScEpochNumber, ScSlotNumber, StakeDelegation, UtxoId,
+	NativeTokenAmount, PermissionedCandidateData, RegistrationData, ScEpochNumber, ScSlotNumber,
+	StakeDelegation, StakePoolPublicKey, UtxoId,
 };
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -850,7 +850,7 @@ impl_runtime_apis! {
 	}
 
 	impl authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi<Block> for Runtime {
-		fn validate_registered_candidate_data(mainchain_pub_key: &MainchainPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
+		fn validate_registered_candidate_data(mainchain_pub_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
 			authority_selection_inherents::filter_invalid_candidates::validate_registration_data(mainchain_pub_key, registration_data, Sidechain::genesis_utxo()).err()
 		}
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError> {

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -850,8 +850,8 @@ impl_runtime_apis! {
 	}
 
 	impl authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi<Block> for Runtime {
-		fn validate_registered_candidate_data(mainchain_pub_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
-			authority_selection_inherents::filter_invalid_candidates::validate_registration_data(mainchain_pub_key, registration_data, Sidechain::genesis_utxo()).err()
+		fn validate_registered_candidate_data(stake_pool_public_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
+			authority_selection_inherents::filter_invalid_candidates::validate_registration_data(stake_pool_public_key, registration_data, Sidechain::genesis_utxo()).err()
 		}
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError> {
 			authority_selection_inherents::filter_invalid_candidates::validate_stake(stake).err()

--- a/node/runtime/src/mock.rs
+++ b/node/runtime/src/mock.rs
@@ -350,7 +350,7 @@ pub fn create_inherent_data_struct(
 			};
 
 			CandidateRegistrations {
-				mainchain_pub_key: MainchainPublicKey(dummy_mainchain_pub_key.public().0),
+				mainchain_pub_key: StakePoolPublicKey(dummy_mainchain_pub_key.public().0),
 				registrations: vec![registration_data],
 				stake_delegation: Some(StakeDelegation(7)),
 			}

--- a/node/runtime/src/mock.rs
+++ b/node/runtime/src/mock.rs
@@ -350,7 +350,7 @@ pub fn create_inherent_data_struct(
 			};
 
 			CandidateRegistrations {
-				mainchain_pub_key: StakePoolPublicKey(dummy_mainchain_pub_key.public().0),
+				stake_pool_public_key: StakePoolPublicKey(dummy_mainchain_pub_key.public().0),
 				registrations: vec![registration_data],
 				stake_delegation: Some(StakeDelegation(7)),
 			}

--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true }
-ed25519 = { workspace = true, features = ["alloc"] }
 ed25519-zebra = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }
@@ -17,7 +16,7 @@ plutus = { workspace = true, default-features = true }
 plutus-datum-derive = { workspace = true, default-features = true }
 secp256k1 = { workspace = true, features = ["std", "global-context"] }
 sidechain-domain = { workspace = true, default-features = true, features = [
-    "std",
+	"std",
 ] }
 sp-io = { workspace = true, default-features = true }
 thiserror = { workspace = true }

--- a/toolkit/cli/commands/src/key_params.rs
+++ b/toolkit/cli/commands/src/key_params.rs
@@ -1,5 +1,5 @@
 use secp256k1::{PublicKey, SecretKey};
-use sidechain_domain::{MainchainPublicKey, SidechainPublicKey};
+use sidechain_domain::{SidechainPublicKey, StakePoolPublicKey, StakePublicKey};
 use std::convert::Infallible;
 use std::fmt::Display;
 use std::io;
@@ -62,40 +62,62 @@ impl FromStr for PlainPublicKeyParam {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum MainchainKeyError {
+pub enum Ed25519SigningKeyError {
 	#[error("{0}")]
 	HexError(#[from] hex::FromHexError),
 	#[error("{0}")]
 	Ed25519Error(#[from] ed25519_zebra::Error),
 }
 
-impl From<MainchainKeyError> for io::Error {
-	fn from(value: MainchainKeyError) -> Self {
+impl From<Ed25519SigningKeyError> for io::Error {
+	fn from(value: Ed25519SigningKeyError) -> Self {
 		io::Error::new(ErrorKind::InvalidInput, value)
 	}
 }
 
-#[derive(Clone, Debug)]
-pub struct MainchainSigningKeyParam(pub ed25519_zebra::SigningKey);
+pub(crate) fn parse_zebra_signing_key(
+	s: &str,
+) -> Result<ed25519_zebra::SigningKey, Ed25519SigningKeyError> {
+	let trimmed = s.trim_start_matches("0x");
+	Ok(ed25519_zebra::SigningKey::try_from(hex::decode(trimmed)?.as_slice())?)
+}
 
-impl FromStr for MainchainSigningKeyParam {
-	type Err = MainchainKeyError;
+#[derive(Clone, Debug)]
+pub struct StakePoolSigningKeyParam(pub ed25519_zebra::SigningKey);
+
+impl FromStr for StakePoolSigningKeyParam {
+	type Err = Ed25519SigningKeyError;
 
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let trimmed = s.trim_start_matches("0x");
-		let key = ed25519_zebra::SigningKey::try_from(hex::decode(trimmed)?.as_slice())?;
-		Ok(MainchainSigningKeyParam(key))
+		Ok(Self(parse_zebra_signing_key(s)?))
 	}
 }
 
-impl From<[u8; 32]> for MainchainSigningKeyParam {
+impl From<[u8; 32]> for StakePoolSigningKeyParam {
 	fn from(key: [u8; 32]) -> Self {
-		MainchainSigningKeyParam(ed25519_zebra::SigningKey::from(key))
+		Self(ed25519_zebra::SigningKey::from(key))
 	}
 }
 
-impl MainchainSigningKeyParam {
-	pub fn vkey(&self) -> MainchainPublicKey {
-		MainchainPublicKey(ed25519_zebra::VerificationKey::from(&self.0).into())
+impl StakePoolSigningKeyParam {
+	pub fn vkey(&self) -> StakePoolPublicKey {
+		StakePoolPublicKey(ed25519_zebra::VerificationKey::from(&self.0).into())
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct StakeSigningKeyParam(pub ed25519_zebra::SigningKey);
+
+impl FromStr for StakeSigningKeyParam {
+	type Err = Ed25519SigningKeyError;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(Self(parse_zebra_signing_key(s)?))
+	}
+}
+
+impl StakeSigningKeyParam {
+	pub fn vkey(&self) -> StakePublicKey {
+		StakePublicKey(ed25519_zebra::VerificationKey::from(&self.0).into())
 	}
 }

--- a/toolkit/cli/commands/src/signing.rs
+++ b/toolkit/cli/commands/src/signing.rs
@@ -1,7 +1,7 @@
-use ed25519_zebra::ed25519;
 use plutus::to_datum_cbor_bytes;
 use plutus::ToDatum;
 use secp256k1::{ecdsa::Signature, Message, PublicKey, SecretKey};
+use sidechain_domain::{MainchainSignature, StakePoolPublicKey};
 use sp_io::hashing::blake2_256;
 
 pub fn hash<T: ToDatum>(msg: T) -> [u8; 32] {
@@ -22,12 +22,12 @@ pub fn sc_public_key_and_signature_for_datum<T: ToDatum>(
 	sc_public_key_and_signature(key, hashed_msg)
 }
 
-pub fn mainchain_public_key_and_signature<T: ToDatum>(
+pub fn cardano_spo_public_key_and_signature<T: ToDatum>(
 	key: ed25519_zebra::SigningKey,
 	datum_msg: T,
-) -> (ed25519_zebra::VerificationKey, ed25519::Signature) {
+) -> (StakePoolPublicKey, MainchainSignature) {
 	let message = to_datum_cbor_bytes(datum_msg);
-	let signature = key.sign(&message);
-	let public = ed25519_zebra::VerificationKey::from(&key);
+	let signature = MainchainSignature(key.sign(&message).into());
+	let public = StakePoolPublicKey(ed25519_zebra::VerificationKey::from(&key).into());
 	(public, signature)
 }

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -10,7 +10,7 @@ use partner_chains_cli::io::DefaultCmdRunContext;
 use partner_chains_smart_contracts_commands::SmartContractsCmd;
 use sc_cli::{CliConfiguration, SharedParams, SubstrateCli};
 use sc_service::TaskManager;
-use sidechain_domain::{MainchainPublicKey, McEpochNumber, ScEpochNumber};
+use sidechain_domain::{McEpochNumber, ScEpochNumber, StakePoolPublicKey};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
@@ -54,7 +54,7 @@ impl CliConfiguration for SidechainParamsCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RegistrationStatusCmd {
 	#[arg(long)]
-	pub mainchain_pub_key: MainchainPublicKey,
+	pub mainchain_pub_key: StakePoolPublicKey,
 	#[arg(long)]
 	pub mc_epoch_number: McEpochNumber,
 	#[allow(missing_docs)]

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -54,7 +54,8 @@ impl CliConfiguration for SidechainParamsCmd {
 #[derive(Debug, Clone, Parser)]
 pub struct RegistrationStatusCmd {
 	#[arg(long)]
-	pub mainchain_pub_key: StakePoolPublicKey,
+	#[arg(long, alias = "mainchain-pub-key")]
+	pub stake_pool_pub_key: StakePoolPublicKey,
 	#[arg(long)]
 	pub mc_epoch_number: McEpochNumber,
 	#[allow(missing_docs)]
@@ -78,7 +79,7 @@ pub enum PartnerChainsSubcommand {
 	/// If registration has been included in Cardano block in epoch N, then it should be returned by this command if epoch greater than N+1 is provided.
 	/// If this command won't show your registration after a few minutes after it has been included in a cardano block, you can start debugging for unsuccessful registration.
 	#[clap(
-		after_help = "Example: partner-chains-node -- registration-status --mainchain-pub-key 0x702b81ab2e86cf73a87062af1eb0da666d451976d9d91c63a119ed94e6a33dc0 --mc-epoch-number 586"
+		after_help = "Example: partner-chains-node -- registration-status --stake-pool-pub-key 0x702b81ab2e86cf73a87062af1eb0da666d451976d9d91c63a119ed94e6a33dc0 --mc-epoch-number 586"
 	)]
 	RegistrationStatus(RegistrationStatusCmd),
 
@@ -145,7 +146,7 @@ where
 					print_result(cli_get_registration_status(
 						query,
 						cmd.mc_epoch_number,
-						cmd.mainchain_pub_key.clone(),
+						cmd.stake_pool_pub_key.clone(),
 					)),
 					task_manager,
 				))

--- a/toolkit/cli/smart-contracts-commands/src/register.rs
+++ b/toolkit/cli/smart-contracts-commands/src/register.rs
@@ -4,8 +4,8 @@ use partner_chains_cardano_offchain::{
 	register::{run_deregister, run_register},
 };
 use sidechain_domain::{
-	AdaBasedStaking, CandidateRegistration, MainchainPublicKey, MainchainSignature,
-	PermissionedCandidateData, SidechainSignature, UtxoId,
+	AdaBasedStaking, CandidateRegistration, MainchainSignature, PermissionedCandidateData,
+	SidechainSignature, StakePoolPublicKey, UtxoId,
 };
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -33,7 +33,7 @@ pub struct RegisterCmd {
 	partner_chain_signature: SidechainSignature,
 	/// Hex string representing bytes of the Stake Pool Verification Key
 	#[arg(long)]
-	spo_public_key: MainchainPublicKey,
+	spo_public_key: StakePoolPublicKey,
 	/// Hex string of bytes of the registration message signature by main chain key, obtained by 'registration-signatures' command
 	#[arg(long)]
 	spo_signature: MainchainSignature,
@@ -80,7 +80,7 @@ pub struct DeregisterCmd {
 	payment_key_file: PaymentFilePath,
 	/// Hex string representing bytes of the Stake Pool Verification Key
 	#[arg(long)]
-	spo_public_key: MainchainPublicKey,
+	spo_public_key: StakePoolPublicKey,
 }
 
 impl DeregisterCmd {

--- a/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -32,7 +32,7 @@ struct ParsedCandidate {
 
 #[derive(Debug)]
 struct RegisteredCandidate {
-	mainchain_pub_key: StakePoolPublicKey,
+	stake_pool_pub_key: StakePoolPublicKey,
 	registration_utxo: UtxoId,
 	tx_inputs: Vec<UtxoId>,
 	sidechain_signature: SidechainSignature,
@@ -101,7 +101,7 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 		let stake_map = Self::make_stake_map(db_model::get_stake_distribution(&self.pool, epoch).await?);
 		Ok(Self::group_candidates_by_mc_pub_key(candidates).into_iter().map(|(mainchain_pub_key, candidate_registrations)| {
 			CandidateRegistrations {
-				mainchain_pub_key: mainchain_pub_key.clone(),
+				stake_pool_public_key: mainchain_pub_key.clone(),
 				registrations: candidate_registrations.into_iter().map(Self::make_registration_data).collect(),
 				stake_delegation: Self::get_stake_delegation(&stake_map, &mainchain_pub_key),
 			}
@@ -161,7 +161,7 @@ impl CandidatesDataSourceImpl {
 	fn group_candidates_by_mc_pub_key(
 		candidates: Vec<RegisteredCandidate>,
 	) -> HashMap<StakePoolPublicKey, Vec<RegisteredCandidate>> {
-		candidates.into_iter().into_group_map_by(|c| c.mainchain_pub_key.clone())
+		candidates.into_iter().into_group_map_by(|c| c.stake_pool_pub_key.clone())
 	}
 
 	fn make_registration_data(c: RegisteredCandidate) -> RegistrationData {
@@ -190,14 +190,14 @@ impl CandidatesDataSourceImpl {
 
 	fn get_stake_delegation(
 		stake_map: &HashMap<MainchainKeyHash, StakeDelegation>,
-		mainchain_pub_key: &StakePoolPublicKey,
+		stake_pool_pub_key: &StakePoolPublicKey,
 	) -> Option<StakeDelegation> {
 		if stake_map.is_empty() {
 			None
 		} else {
 			Some(
 				stake_map
-					.get(&MainchainKeyHash::from_vkey(&mainchain_pub_key.0))
+					.get(&MainchainKeyHash::from_vkey(&stake_pool_pub_key.0))
 					.cloned()
 					.unwrap_or(StakeDelegation(0)),
 			)
@@ -222,7 +222,7 @@ impl CandidatesDataSourceImpl {
 					grandpa_pub_key,
 				} = c.datum;
 				Ok(RegisteredCandidate {
-					mainchain_pub_key: stake_ownership.pub_key,
+					stake_pool_pub_key: stake_ownership.pub_key,
 					mainchain_signature: stake_ownership.signature,
 					// For now we use the same key for both cross chain and sidechain actions
 					cross_chain_pub_key: CrossChainPublicKey(sidechain_pub_key.0.clone()),

--- a/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/candidates/mod.rs
@@ -32,7 +32,7 @@ struct ParsedCandidate {
 
 #[derive(Debug)]
 struct RegisteredCandidate {
-	mainchain_pub_key: MainchainPublicKey,
+	mainchain_pub_key: StakePoolPublicKey,
 	registration_utxo: UtxoId,
 	tx_inputs: Vec<UtxoId>,
 	sidechain_signature: SidechainSignature,
@@ -160,7 +160,7 @@ impl CandidatesDataSourceImpl {
 
 	fn group_candidates_by_mc_pub_key(
 		candidates: Vec<RegisteredCandidate>,
-	) -> HashMap<MainchainPublicKey, Vec<RegisteredCandidate>> {
+	) -> HashMap<StakePoolPublicKey, Vec<RegisteredCandidate>> {
 		candidates.into_iter().into_group_map_by(|c| c.mainchain_pub_key.clone())
 	}
 
@@ -190,7 +190,7 @@ impl CandidatesDataSourceImpl {
 
 	fn get_stake_delegation(
 		stake_map: &HashMap<MainchainKeyHash, StakeDelegation>,
-		mainchain_pub_key: &MainchainPublicKey,
+		mainchain_pub_key: &StakePoolPublicKey,
 	) -> Option<StakeDelegation> {
 		if stake_map.is_empty() {
 			None

--- a/toolkit/mainchain-follower/db-sync-follower/src/candidates/tests.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/candidates/tests.rs
@@ -295,7 +295,7 @@ fn latest_permissioned_candidates() -> Vec<RawPermissionedCandidateData> {
 
 fn leader_candidate_spo_a() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
+			stake_pool_public_key: StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 1),
@@ -325,7 +325,7 @@ fn leader_candidate_spo_a() -> CandidateRegistrations {
 
 fn leader_candidate_spo_b() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: StakePoolPublicKey(hex!("cfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
+			stake_pool_public_key: StakePoolPublicKey(hex!("cfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 1),
@@ -355,7 +355,7 @@ fn leader_candidate_spo_b() -> CandidateRegistrations {
 
 fn leader_candidate_spo_c() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: StakePoolPublicKey(hex!("3fd6618bfcb8d964f44beba4280bd91c6e87ac5bca4aa1c8f1cde9e85352660b")),
+			stake_pool_public_key: StakePoolPublicKey(hex!("3fd6618bfcb8d964f44beba4280bd91c6e87ac5bca4aa1c8f1cde9e85352660b")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 2),

--- a/toolkit/mainchain-follower/db-sync-follower/src/candidates/tests.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/candidates/tests.rs
@@ -295,7 +295,7 @@ fn latest_permissioned_candidates() -> Vec<RawPermissionedCandidateData> {
 
 fn leader_candidate_spo_a() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: MainchainPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
+			mainchain_pub_key: StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 1),
@@ -325,7 +325,7 @@ fn leader_candidate_spo_a() -> CandidateRegistrations {
 
 fn leader_candidate_spo_b() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: MainchainPublicKey(hex!("cfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
+			mainchain_pub_key: StakePoolPublicKey(hex!("cfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 1),
@@ -355,7 +355,7 @@ fn leader_candidate_spo_b() -> CandidateRegistrations {
 
 fn leader_candidate_spo_c() -> CandidateRegistrations {
 	CandidateRegistrations {
-			mainchain_pub_key: MainchainPublicKey(hex!("3fd6618bfcb8d964f44beba4280bd91c6e87ac5bca4aa1c8f1cde9e85352660b")),
+			mainchain_pub_key: StakePoolPublicKey(hex!("3fd6618bfcb8d964f44beba4280bd91c6e87ac5bca4aa1c8f1cde9e85352660b")),
 			registrations: vec![
 				RegistrationData {
 					registration_utxo: UtxoId::new(hex!("cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13"), 2),

--- a/toolkit/mainchain-follower/mock/src/candidate.rs
+++ b/toolkit/mainchain-follower/mock/src/candidate.rs
@@ -42,7 +42,7 @@ impl MockRegistration {
 
 impl From<MockRegistration> for CandidateRegistrations {
 	fn from(mock: MockRegistration) -> Self {
-		let mainchain_pub_key = MainchainPublicKey(mock.mainchain_pub_key.0.try_into().expect(
+		let mainchain_pub_key = StakePoolPublicKey(mock.mainchain_pub_key.0.try_into().expect(
 			"Invalid mock configuration. 'mainchain_pub_key' public key should be 32 bytes.",
 		));
 		let registrations = vec![RegistrationData {

--- a/toolkit/mainchain-follower/mock/src/candidate.rs
+++ b/toolkit/mainchain-follower/mock/src/candidate.rs
@@ -42,7 +42,7 @@ impl MockRegistration {
 
 impl From<MockRegistration> for CandidateRegistrations {
 	fn from(mock: MockRegistration) -> Self {
-		let mainchain_pub_key = StakePoolPublicKey(mock.mainchain_pub_key.0.try_into().expect(
+		let stake_pool_public_key = StakePoolPublicKey(mock.mainchain_pub_key.0.try_into().expect(
 			"Invalid mock configuration. 'mainchain_pub_key' public key should be 32 bytes.",
 		));
 		let registrations = vec![RegistrationData {
@@ -71,7 +71,7 @@ impl From<MockRegistration> for CandidateRegistrations {
 			grandpa_pub_key: GrandpaPublicKey(mock.grandpa_pub_key.0),
 		}];
 		let stake_delegation = Some(StakeDelegation(333));
-		CandidateRegistrations { mainchain_pub_key, registrations, stake_delegation }
+		CandidateRegistrations { stake_pool_public_key, registrations, stake_delegation }
 	}
 }
 

--- a/toolkit/offchain/src/register.rs
+++ b/toolkit/offchain/src/register.rs
@@ -329,7 +329,7 @@ mod tests {
 	fn candidate_registration(registration_utxo: UtxoId) -> CandidateRegistration {
 		CandidateRegistration {
 			stake_ownership: AdaBasedStaking {
-				pub_key: test_values::mainchain_pub_key(),
+				pub_key: test_values::stake_pool_pub_key(),
 				signature: MainchainSignature([0u8; 64]),
 			},
 			partner_chain_pub_key: SidechainPublicKey(Vec::new()),

--- a/toolkit/offchain/src/register.rs
+++ b/toolkit/offchain/src/register.rs
@@ -125,7 +125,7 @@ pub trait Deregister {
 		&self,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
-		stake_ownership_pub_key: MainchainPublicKey,
+		stake_ownership_pub_key: StakePoolPublicKey,
 	) -> Result<Option<McTxHash>, OffchainError>;
 }
 
@@ -137,7 +137,7 @@ where
 		&self,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
-		stake_ownership_pub_key: MainchainPublicKey,
+		stake_ownership_pub_key: StakePoolPublicKey,
 	) -> Result<Option<McTxHash>, OffchainError> {
 		run_deregister(
 			genesis_utxo,
@@ -157,7 +157,7 @@ pub async fn run_deregister<
 >(
 	genesis_utxo: UtxoId,
 	payment_signing_key: &CardanoPaymentSigningKey,
-	stake_ownership_pub_key: MainchainPublicKey,
+	stake_ownership_pub_key: StakePoolPublicKey,
 	client: &C,
 	await_tx: A,
 ) -> anyhow::Result<Option<McTxHash>> {
@@ -201,7 +201,7 @@ pub async fn run_deregister<
 
 fn get_own_registrations(
 	own_pkh: MainchainKeyHash,
-	spo_pub_key: MainchainPublicKey,
+	spo_pub_key: StakePoolPublicKey,
 	validator_utxos: &[OgmiosUtxo],
 ) -> Vec<(OgmiosUtxo, CandidateRegistration)> {
 	let mut own_registrations = Vec::new();

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -204,16 +204,13 @@ mod tests {
 		ReserveDatum, ReserveImmutableSettings, ReserveMutableSettings, ReserveStats,
 	};
 	use pretty_assertions::assert_eq;
-	use sidechain_domain::{AssetName, MainchainPrivateKey, PolicyId};
-
-	fn payment_key_domain() -> MainchainPrivateKey {
-		MainchainPrivateKey(hex!(
-			"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
-		))
-	}
+	use sidechain_domain::{AssetName, PolicyId};
 
 	fn payment_key() -> PrivateKey {
-		PrivateKey::from_normal_bytes(&payment_key_domain().0).unwrap()
+		PrivateKey::from_normal_bytes(&hex!(
+			"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
+		))
+		.unwrap()
 	}
 
 	fn test_address_bech32() -> String {

--- a/toolkit/offchain/src/test_values.rs
+++ b/toolkit/offchain/src/test_values.rs
@@ -23,7 +23,7 @@ pub(crate) fn payment_addr() -> Address {
 	Address::from_bech32(PAYMENT_ADDR).unwrap()
 }
 
-pub(crate) fn mainchain_pub_key() -> StakePoolPublicKey {
+pub(crate) fn stake_pool_pub_key() -> StakePoolPublicKey {
 	StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d"))
 }
 

--- a/toolkit/offchain/src/test_values.rs
+++ b/toolkit/offchain/src/test_values.rs
@@ -7,7 +7,7 @@ use ogmios_client::{
 	},
 	types::{OgmiosBytesSize, OgmiosTx, OgmiosUtxo, OgmiosValue},
 };
-use sidechain_domain::MainchainPublicKey;
+use sidechain_domain::StakePoolPublicKey;
 
 pub(crate) fn payment_key() -> PrivateKey {
 	PrivateKey::from_normal_bytes(&hex!(
@@ -23,8 +23,8 @@ pub(crate) fn payment_addr() -> Address {
 	Address::from_bech32(PAYMENT_ADDR).unwrap()
 }
 
-pub(crate) fn mainchain_pub_key() -> MainchainPublicKey {
-	MainchainPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d"))
+pub(crate) fn mainchain_pub_key() -> StakePoolPublicKey {
+	StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d"))
 }
 
 pub(crate) fn test_validator() -> PlutusScript {

--- a/toolkit/offchain/src/update_governance/test.rs
+++ b/toolkit/offchain/src/update_governance/test.rs
@@ -6,14 +6,13 @@ use cardano_serialization_lib::*;
 use hex_literal::hex;
 use ogmios_client::types::{Asset, Datum, OgmiosTx, OgmiosUtxo, OgmiosValue};
 use pretty_assertions::assert_eq;
-use sidechain_domain::{MainchainKeyHash, MainchainPrivateKey};
-
-fn payment_key_domain() -> MainchainPrivateKey {
-	MainchainPrivateKey(hex!("94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"))
-}
+use sidechain_domain::MainchainKeyHash;
 
 fn payment_key() -> PrivateKey {
-	PrivateKey::from_normal_bytes(&payment_key_domain().0).unwrap()
+	PrivateKey::from_normal_bytes(&hex!(
+		"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
+	))
+	.unwrap()
 }
 
 fn test_address_bech32() -> String {

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -25,8 +25,8 @@ use partner_chains_cardano_offchain::{
 use partner_chains_plutus_data::reserve::ReserveDatum;
 use sidechain_domain::{
 	AdaBasedStaking, AssetId, AssetName, AuraPublicKey, CandidateRegistration, DParameter,
-	GrandpaPublicKey, MainchainKeyHash, MainchainPublicKey, MainchainSignature, McTxHash,
-	PermissionedCandidateData, PolicyId, SidechainPublicKey, SidechainSignature, UtxoId, UtxoIndex,
+	GrandpaPublicKey, MainchainKeyHash, MainchainSignature, McTxHash, PermissionedCandidateData,
+	PolicyId, SidechainPublicKey, SidechainSignature, StakePoolPublicKey, UtxoId, UtxoIndex,
 };
 use std::time::Duration;
 use testcontainers::{clients::Cli, Container, GenericImage};
@@ -56,8 +56,8 @@ fn eve_payment_key() -> CardanoPaymentSigningKey {
 	.unwrap()
 }
 
-const EVE_PUBLIC_KEY: MainchainPublicKey =
-	MainchainPublicKey(hex!("a5ab6e82531cac3480cf7ff360f38a0beeea93cabfdd1ed0495e0423f7875c57"));
+const EVE_PUBLIC_KEY: StakePoolPublicKey =
+	StakePoolPublicKey(hex!("a5ab6e82531cac3480cf7ff360f38a0beeea93cabfdd1ed0495e0423f7875c57"));
 
 const EVE_PUBLIC_KEY_HASH: MainchainKeyHash =
 	MainchainKeyHash(hex!("84ba05c28879b299a8377e62128adc7a0e0df3ac438ff95efc7c8443"));

--- a/toolkit/pallets/address-associations/src/benchmarking.rs
+++ b/toolkit/pallets/address-associations/src/benchmarking.rs
@@ -19,7 +19,7 @@ mod benchmarks {
 	#[benchmark]
 	fn associate_address() {
 		// Alice
-		let mc_pub_key = MainchainPublicKey(hex!(
+		let mc_pub_key = StakePoolPublicKey(hex!(
 			"2bebcb7fbc74a6e0fd6e00a311698b047b7b659f0e047ff5349dbd984aefc52c"
 		));
 		// Alice

--- a/toolkit/pallets/address-associations/src/benchmarking.rs
+++ b/toolkit/pallets/address-associations/src/benchmarking.rs
@@ -19,7 +19,7 @@ mod benchmarks {
 	#[benchmark]
 	fn associate_address() {
 		// Alice
-		let mc_pub_key = StakePoolPublicKey(hex!(
+		let stake_public_key = StakePublicKey(hex!(
 			"2bebcb7fbc74a6e0fd6e00a311698b047b7b659f0e047ff5349dbd984aefc52c"
 		));
 		// Alice
@@ -27,10 +27,10 @@ mod benchmarks {
 			"5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
 		)
 		.unwrap();
-		let mc_signature = hex!("1aa8c1b363a207ddadf0c6242a0632f5a557690a327d0245f9d473b983b3d8e1c95a3dd804cab41123c36ddbcb7137b8261c35d5c8ef04ce9d0f8d5c4b3ca607");
+		let signature = StakeKeySignature(hex!("1aa8c1b363a207ddadf0c6242a0632f5a557690a327d0245f9d473b983b3d8e1c95a3dd804cab41123c36ddbcb7137b8261c35d5c8ef04ce9d0f8d5c4b3ca607"));
 
 		#[extrinsic_call]
-		_(RawOrigin::None, pc_address, mc_signature, mc_pub_key);
+		_(RawOrigin::None, pc_address, signature, stake_public_key);
 	}
 
 	impl_benchmark_test_suite!(AddressAssociations, crate::mock::new_test_ext(), crate::mock::Test);

--- a/toolkit/pallets/address-associations/src/tests.rs
+++ b/toolkit/pallets/address-associations/src/tests.rs
@@ -11,7 +11,7 @@ use sp_runtime::AccountId32;
 fn saves_new_address_association() {
 	new_test_ext().execute_with(|| {
 			// Alice
-			let mc_pub_key = StakePublicKey(hex!(
+			let stake_public_key = StakePublicKey(hex!(
 				"2bebcb7fbc74a6e0fd6e00a311698b047b7b659f0e047ff5349dbd984aefc52c"
 			));
 			let mc_signature = hex!("1aa8c1b363a207ddadf0c6242a0632f5a557690a327d0245f9d473b983b3d8e1c95a3dd804cab41123c36ddbcb7137b8261c35d5c8ef04ce9d0f8d5c4b3ca607");
@@ -25,12 +25,12 @@ fn saves_new_address_association() {
 					OriginFor::<Test>::signed(AccountId32::new([1; 32])),
 					pc_address.clone(),
 					mc_signature.into(),
-					mc_pub_key.clone(),
+					stake_public_key.clone(),
 				)
 			);
 
 			assert_eq!(
-				Pallet::<Test>::get_partner_chain_address_for(&mc_pub_key),
+				Pallet::<Test>::get_partner_chain_address_for(&stake_public_key),
 				Some(pc_address)
 			);
 		})

--- a/toolkit/pallets/address-associations/src/tests.rs
+++ b/toolkit/pallets/address-associations/src/tests.rs
@@ -11,7 +11,7 @@ use sp_runtime::AccountId32;
 fn saves_new_address_association() {
 	new_test_ext().execute_with(|| {
 			// Alice
-			let mc_pub_key = MainchainPublicKey(hex!(
+			let mc_pub_key = StakePublicKey(hex!(
 				"2bebcb7fbc74a6e0fd6e00a311698b047b7b659f0e047ff5349dbd984aefc52c"
 			));
 			let mc_signature = hex!("1aa8c1b363a207ddadf0c6242a0632f5a557690a327d0245f9d473b983b3d8e1c95a3dd804cab41123c36ddbcb7137b8261c35d5c8ef04ce9d0f8d5c4b3ca607");
@@ -24,7 +24,7 @@ fn saves_new_address_association() {
 				super::Pallet::<Test>::associate_address(
 					OriginFor::<Test>::signed(AccountId32::new([1; 32])),
 					pc_address.clone(),
-					mc_signature,
+					mc_signature.into(),
 					mc_pub_key.clone(),
 				)
 			);
@@ -39,20 +39,23 @@ fn saves_new_address_association() {
 #[test]
 fn rejects_duplicate_key_association() {
 	new_test_ext().execute_with(|| {
-		let mc_pub_key = MainchainPublicKey([1; 32]);
-		let mc_signarture = [1; 64];
+		let stake_public_key = StakePublicKey([1; 32]);
+		let signature = StakeKeySignature([1; 64]);
 
-		crate::AddressAssociations::<Test>::insert(&mc_pub_key.hash(), AccountId32::new([0; 32]));
+		crate::AddressAssociations::<Test>::insert(
+			&stake_public_key.hash(),
+			AccountId32::new([0; 32]),
+		);
 		assert_eq!(
-			Pallet::<Test>::get_partner_chain_address_for(&mc_pub_key),
+			Pallet::<Test>::get_partner_chain_address_for(&stake_public_key),
 			Some(AccountId32::new([0; 32]))
 		);
 		assert_eq!(
 			super::Pallet::<Test>::associate_address(
 				OriginFor::<Test>::signed(AccountId32::new([1; 32])),
 				AccountId32::new([0; 32]),
-				mc_signarture,
-				mc_pub_key,
+				signature,
+				stake_public_key,
 			)
 			.unwrap_err(),
 			Error::<Test>::MainchainKeyAlreadyAssociated.into()
@@ -63,17 +66,17 @@ fn rejects_duplicate_key_association() {
 #[test]
 fn rejects_invalid_mainchain_signature() {
 	new_test_ext().execute_with(|| {
-			let mc_pub_key = MainchainPublicKey(hex!(
+			let stake_public_key = StakePublicKey(hex!(
 				"fc014cb5f071f5d6a36cb5a7e5f168c86555989445a23d4abec33d280f71aca4"
 			));
-			let mc_signarture = hex!("c50828c31d1a61e05fdb943847efd42ce2eadda9c7d21dd2d035e8de66bc56de7f6b1297fba6cb7305f2aac97b5f9168894fb10295c503de6d5fb6ae70bd9a0d");
+			let signature = StakeKeySignature(hex!("c50828c31d1a61e05fdb943847efd42ce2eadda9c7d21dd2d035e8de66bc56de7f6b1297fba6cb7305f2aac97b5f9168894fb10295c503de6d5fb6ae70bd9a0d"));
 
 			assert_eq!(
 				super::Pallet::<Test>::associate_address(
 					OriginFor::<Test>::signed(AccountId32::new([1; 32])),
 					AccountId32::new([0; 32]),
-					mc_signarture,
-					mc_pub_key,
+					signature,
+					stake_public_key,
 				)
 				.unwrap_err(),
 				Error::<Test>::InvalidMainchainSignature.into()

--- a/toolkit/pallets/session-validator-management/rpc/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/rpc/src/lib.rs
@@ -24,7 +24,7 @@ pub trait SessionValidatorManagementRpcApi {
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: StakePoolPublicKey,
+		#[argument(rename = "mc_public_key")] stake_pool_public_key: StakePoolPublicKey,
 	) -> RpcResult<Vec<CandidateRegistrationEntry>>;
 
 	/// Regardless of `epoch_number` value, all the candidates data validation is done based on the validation api from the latest sidechain block.
@@ -52,10 +52,10 @@ where
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: StakePoolPublicKey,
+		stake_pool_public_key: StakePoolPublicKey,
 	) -> RpcResult<Vec<CandidateRegistrationEntry>> {
 		self.query_api
-			.get_registrations(mc_epoch_number, mc_public_key)
+			.get_registrations(mc_epoch_number, stake_pool_public_key)
 			.await
 			.map_err(error_object_from_str)
 	}

--- a/toolkit/pallets/session-validator-management/rpc/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/rpc/src/lib.rs
@@ -5,7 +5,7 @@ use jsonrpsee::{
 	proc_macros::rpc,
 	types::{ErrorObject, ErrorObjectOwned},
 };
-use sidechain_domain::{MainchainPublicKey, McEpochNumber};
+use sidechain_domain::{McEpochNumber, StakePoolPublicKey};
 use sp_session_validator_management_query::types::*;
 use sp_session_validator_management_query::SessionValidatorManagementQueryApi;
 use std::sync::Arc;
@@ -24,7 +24,7 @@ pub trait SessionValidatorManagementRpcApi {
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: MainchainPublicKey,
+		mc_public_key: StakePoolPublicKey,
 	) -> RpcResult<Vec<CandidateRegistrationEntry>>;
 
 	/// Regardless of `epoch_number` value, all the candidates data validation is done based on the validation api from the latest sidechain block.
@@ -52,7 +52,7 @@ where
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: MainchainPublicKey,
+		mc_public_key: StakePoolPublicKey,
 	) -> RpcResult<Vec<CandidateRegistrationEntry>> {
 		self.query_api
 			.get_registrations(mc_epoch_number, mc_public_key)

--- a/toolkit/partner-chains-cli/src/cardano_key.rs
+++ b/toolkit/partner-chains-cli/src/cardano_key.rs
@@ -3,7 +3,7 @@ use anyhow::anyhow;
 use partner_chains_cardano_offchain::cardano_keys::{
 	CardanoKeyFileContent, CardanoPaymentSigningKey,
 };
-use sidechain_domain::MainchainPublicKey;
+use sidechain_domain::StakePoolPublicKey;
 
 fn parse_json_key_file(
 	path: &str,
@@ -28,7 +28,7 @@ pub(crate) fn get_mc_payment_signing_key_from_file(
 pub(crate) fn get_mc_payment_verification_key_from_file(
 	path: &str,
 	context: &impl IOContext,
-) -> anyhow::Result<MainchainPublicKey> {
+) -> anyhow::Result<StakePoolPublicKey> {
 	let key_file = parse_json_key_file(path, context)?;
 	let key_type = key_file.r#type.clone();
 	if key_type == "PaymentExtendedVerificationKeyShelley_ed25519_bip32" {
@@ -36,12 +36,12 @@ pub(crate) fn get_mc_payment_verification_key_from_file(
 			.raw_key_bytes::<64>()
 			.map_err(|e| anyhow!("Failed to parse key bytes in {path}. {e}"))?;
 		let prefix: [u8; 32] = key_bytes[0..32].try_into().unwrap();
-		Ok(MainchainPublicKey(prefix))
+		Ok(StakePoolPublicKey(prefix))
 	} else if key_type == "PaymentVerificationKeyShelley_ed25519" {
 		let key_bytes = key_file
 			.raw_key_bytes()
 			.map_err(|e| anyhow!("Failed to parse key bytes in {path}. {e}"))?;
-		Ok(MainchainPublicKey(key_bytes))
+		Ok(StakePoolPublicKey(key_bytes))
 	} else {
 		Err(anyhow!(
 			"Unexpected key type '{key_type}' in {path}. Expected a Payment Verification Key."
@@ -67,11 +67,11 @@ pub(crate) fn get_mc_staking_signing_key_from_file(
 pub(crate) fn get_mc_staking_verification_key_from_file(
 	path: &str,
 	context: &impl IOContext,
-) -> anyhow::Result<MainchainPublicKey> {
+) -> anyhow::Result<StakePoolPublicKey> {
 	let key_file = parse_json_key_file(path, context)?;
 	let key_type = key_file.r#type.clone();
 	if key_type == "StakePoolVerificationKey_ed25519" {
-		Ok(MainchainPublicKey(
+		Ok(StakePoolPublicKey(
 			key_file.raw_key_bytes().map_err(|e| anyhow!("Failed to parse {path}: '{e}'"))?,
 		))
 	} else {

--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -2,7 +2,7 @@
 mod tests;
 
 use crate::cardano_key::{
-	get_mc_payment_signing_key_from_file, get_mc_staking_verification_key_from_file,
+	get_mc_payment_signing_key_from_file, get_stake_pool_verification_key_from_file,
 };
 use crate::config::config_fields::{
 	CARDANO_COLD_VERIFICATION_KEY_FILE, CARDANO_PAYMENT_SIGNING_KEY_FILE,
@@ -33,7 +33,7 @@ impl CmdRun for DeregisterCmd {
 		let cold_vkey_path =
 			CARDANO_COLD_VERIFICATION_KEY_FILE.prompt_with_default_from_file_and_save(context);
 		let stake_ownership_pub_key =
-			get_mc_staking_verification_key_from_file(&cold_vkey_path, context)?;
+			get_stake_pool_verification_key_from_file(&cold_vkey_path, context)?;
 		let ogmios_config = establish_ogmios_configuration(context)?;
 		let offchain = context.offchain_impl(&ogmios_config)?;
 

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -233,6 +233,6 @@ fn payment_signing_key() -> Vec<u8> {
 	hex!("0000000000000000000000000000000000000000000000000000000000000001").to_vec()
 }
 
-fn stake_ownership_pub_key() -> MainchainPublicKey {
-	MainchainPublicKey(hex!("1111111111111111111111111111111111111111111111111111111111111111"))
+fn stake_ownership_pub_key() -> StakePoolPublicKey {
+	StakePoolPublicKey(hex!("1111111111111111111111111111111111111111111111111111111111111111"))
 }

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -45,11 +45,10 @@ fn derive_address<C: IOContext>(
 	let cardano_payment_verification_key_file =
 		config_fields::CARDANO_PAYMENT_VERIFICATION_KEY_FILE
 			.prompt_with_default_from_file_and_save(context);
-	let key_bytes: [u8; 32] = cardano_key::get_mc_payment_verification_key_from_file(
+	let key_bytes: [u8; 32] = cardano_key::get_payment_verification_key_bytes_from_file(
 		&cardano_payment_verification_key_file,
 		context,
-	)?
-	.0;
+	)?;
 	let address =
 		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.to_csl());
 	address.to_bech32(None).map_err(|e| anyhow!(e.to_string()))

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -150,11 +150,10 @@ fn derive_address<C: IOContext>(
 	let cardano_payment_verification_key_file =
 		config_fields::CARDANO_PAYMENT_VERIFICATION_KEY_FILE
 			.prompt_with_default_from_file_and_save(context);
-	let key_bytes: [u8; 32] = cardano_key::get_mc_payment_verification_key_from_file(
+	let key_bytes: [u8; 32] = cardano_key::get_payment_verification_key_bytes_from_file(
 		&cardano_payment_verification_key_file,
 		context,
-	)?
-	.0;
+	)?;
 	let address =
 		partner_chains_cardano_offchain::csl::payment_address(&key_bytes, cardano_network.to_csl());
 	address.to_bech32(None).map_err(|e| anyhow!(e.to_string()))

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -33,11 +33,10 @@ impl CmdRun for Register2Cmd {
 			"  This command will use SPO cold signing key for signing the registration message.",
 		);
 
-		let mainchain_signing_key_path =
-			context.prompt("Path to mainchain signing key file", Some("cold.skey"));
-		let mainchain_signing_key =
-			get_mainchain_cold_skey(context, &mainchain_signing_key_path)
-				.inspect_err(|_| context.eprint("Unable to read mainchain signing key file"))?;
+		let stake_pool_signing_key_path =
+			context.prompt("Path to Stake Pool signing key file", Some("cold.skey"));
+		let mainchain_signing_key = get_stake_pool_cold_skey(context, &stake_pool_signing_key_path)
+			.inspect_err(|_| context.eprint("Unable to read Stake Pool signing key file"))?;
 
 		let registration_message = RegisterValidatorMessage {
 			genesis_utxo: self.genesis_utxo,
@@ -59,7 +58,7 @@ impl CmdRun for Register2Cmd {
 	}
 }
 
-fn get_mainchain_cold_skey<C: IOContext>(
+fn get_stake_pool_cold_skey<C: IOContext>(
 	context: &C,
 	keys_path: &str,
 ) -> Result<StakePoolSigningKeyParam, anyhow::Error> {
@@ -87,15 +86,15 @@ mod tests {
 	}
 
 	#[test]
-	fn invalid_mc_signing_key() {
+	fn invalid_stake_pool_signing_key() {
 		let mock_context = MockIOContext::new().with_expected_io(vec![
 			MockIO::Group(intro_msg_io()),
 			MockIO::prompt(
-				"Path to mainchain signing key file",
+				"Path to Stake Pool signing key file",
 				Some("cold.skey"),
 				"/invalid/cold.skey",
 			),
-			MockIO::eprint("Unable to read mainchain signing key file"),
+			MockIO::eprint("Unable to read Stake Pool signing key file"),
 		]);
 
 		let result = mock_register2_cmd().run(&mock_context);
@@ -111,7 +110,7 @@ mod tests {
 
 	fn prompt_mc_cold_key_path_io() -> Vec<MockIO> {
 		vec![MockIO::prompt(
-			"Path to mainchain signing key file",
+			"Path to Stake Pool signing key file",
 			Some("cold.skey"),
 			"/path/to/cold.skey",
 		)]

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -45,11 +45,11 @@ impl CmdRun for Register2Cmd {
 			registration_utxo: self.registration_utxo,
 		};
 
-		let (verification_key, mc_signature) =
+		let (verification_key, spo_signature) =
 			cardano_spo_public_key_and_signature(mainchain_signing_key.0, registration_message);
 
 		let spo_public_key = verification_key.to_hex_string();
-		let spo_signature = mc_signature.to_hex_string();
+		let spo_signature = spo_signature.to_hex_string();
 		let executable = context.current_executable()?;
 		context.print("To finish the registration process, run the following command on the machine with the partner chain dependencies running:\n");
 		context.print(&format!(

--- a/toolkit/partner-chains-cli/src/register/register2.rs
+++ b/toolkit/partner-chains-cli/src/register/register2.rs
@@ -3,10 +3,10 @@ use crate::io::IOContext;
 use crate::CmdRun;
 use clap::Parser;
 use cli_commands::key_params::{
-	MainchainSigningKeyParam, PlainPublicKeyParam, SidechainPublicKeyParam,
+	PlainPublicKeyParam, SidechainPublicKeyParam, StakePoolSigningKeyParam,
 };
 use cli_commands::registration_signatures::RegisterValidatorMessage;
-use cli_commands::signing::mainchain_public_key_and_signature;
+use cli_commands::signing::cardano_spo_public_key_and_signature;
 use sidechain_domain::UtxoId;
 
 #[derive(Clone, Debug, Parser)]
@@ -46,10 +46,10 @@ impl CmdRun for Register2Cmd {
 		};
 
 		let (verification_key, mc_signature) =
-			mainchain_public_key_and_signature(mainchain_signing_key.0, registration_message);
+			cardano_spo_public_key_and_signature(mainchain_signing_key.0, registration_message);
 
-		let spo_public_key = hex::encode(verification_key);
-		let spo_signature = hex::encode(mc_signature.to_vec());
+		let spo_public_key = verification_key.to_hex_string();
+		let spo_signature = mc_signature.to_hex_string();
 		let executable = context.current_executable()?;
 		context.print("To finish the registration process, run the following command on the machine with the partner chain dependencies running:\n");
 		context.print(&format!(
@@ -62,8 +62,8 @@ impl CmdRun for Register2Cmd {
 fn get_mainchain_cold_skey<C: IOContext>(
 	context: &C,
 	keys_path: &str,
-) -> Result<MainchainSigningKeyParam, anyhow::Error> {
-	Ok(MainchainSigningKeyParam::from(get_mc_staking_signing_key_from_file(keys_path, context)?))
+) -> Result<StakePoolSigningKeyParam, anyhow::Error> {
+	Ok(StakePoolSigningKeyParam::from(get_mc_staking_signing_key_from_file(keys_path, context)?))
 }
 
 #[cfg(test)]
@@ -120,7 +120,7 @@ mod tests {
 	fn output_result_io() -> Vec<MockIO> {
 		vec![
             MockIO::print("To finish the registration process, run the following command on the machine with the partner chain dependencies running:\n"),
-            MockIO::print("<mock executable> wizards register3 \\\n--genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n--registration-utxo 7e9ebd0950ae1bec5606f0cd7ac88b3c60b1103d7feb6ffa36402edae4d1b617#0 \\\n--aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n--grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n--partner-chain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n--partner-chain-signature 7a7e3e585a5dc248d4a2772814e1b58c90313443dd99369f994e960ecc4931442a08305743db7ab42ab9b8672e00250e1cc7c08bc018b0630a8197c4f95528a301 \\\n--spo-public-key cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 \\\n--spo-signature aaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801"),
+            MockIO::print("<mock executable> wizards register3 \\\n--genesis-utxo 0000000000000000000000000000000000000000000000000000000000000001#0 \\\n--registration-utxo 7e9ebd0950ae1bec5606f0cd7ac88b3c60b1103d7feb6ffa36402edae4d1b617#0 \\\n--aura-pub-key 0xdf883ee0648f33b6103017b61be702017742d501b8fe73b1d69ca0157460b777 \\\n--grandpa-pub-key 0x5a091a06abd64f245db11d2987b03218c6bd83d64c262fe10e3a2a1230e90327 \\\n--partner-chain-pub-key 0x031e75acbf45ef8df98bbe24b19b28fff807be32bf88838c30c0564d7bec5301f6 \\\n--partner-chain-signature 7a7e3e585a5dc248d4a2772814e1b58c90313443dd99369f994e960ecc4931442a08305743db7ab42ab9b8672e00250e1cc7c08bc018b0630a8197c4f95528a301 \\\n--spo-public-key 0xcef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7 \\\n--spo-signature 0xaaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801"),
         ]
 	}
 	// non 0 genesis utxo 8ea10040249ad3033ae7c4d4b69e0b2e2b50a90741b783491cb5ddf8ced0d861

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -27,7 +27,7 @@ pub struct Register3Cmd {
 	#[arg(long)]
 	pub partner_chain_signature: SidechainSignature,
 	#[arg(long)]
-	pub spo_public_key: MainchainPublicKey,
+	pub spo_public_key: StakePoolPublicKey,
 	#[arg(long)]
 	pub spo_signature: MainchainSignature,
 }
@@ -106,7 +106,7 @@ fn prepare_mc_follower_env<C: IOContext>(context: &C) -> anyhow::Result<()> {
 fn show_registration_status(
 	context: &impl IOContext,
 	mc_epoch_number: McEpochNumber,
-	mc_public_key: MainchainPublicKey,
+	mc_public_key: StakePoolPublicKey,
 ) -> Result<(), anyhow::Error> {
 	let temp_dir = context.new_tmp_dir();
 	let temp_dir_path = temp_dir
@@ -318,7 +318,7 @@ mod tests {
             aura_pub_key: "79c3b7fc0b7697b9414cb87adcb37317d1cab32818ae18c0e97ad76395d1fdcf".parse().unwrap(),
             grandpa_pub_key: "1a55db596380bc63f5ee964565359b5ea8e0096c798c3281692df097abbd9aa4b657f887915ad2a52fc85c674ef4044baeaf7149546af93a2744c379b9798f07".parse().unwrap(),
             partner_chain_signature: SidechainSignature(hex_literal::hex!("cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854").to_vec()),
-			spo_public_key: MainchainPublicKey(hex_literal::hex!("cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7")),
+			spo_public_key: StakePoolPublicKey(hex_literal::hex!("cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7")),
 			spo_signature: MainchainSignature(hex_literal::hex!("aaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801")),
         }
 	}
@@ -412,7 +412,7 @@ mod tests {
 	fn new_candidate_registration() -> CandidateRegistration {
 		CandidateRegistration {
 			stake_ownership: AdaBasedStaking {
-				pub_key: MainchainPublicKey(hex!("cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7")),
+				pub_key: StakePoolPublicKey(hex!("cef2d1630c034d3b9034eb7903d61f419a3074a1ad01d4550cc72f2b733de6e7")),
 				signature: MainchainSignature(hex!("aaa39fbf163ed77c69820536f5dc22854e7e13f964f1e077efde0844a09bde64c1aab4d2b401e0fe39b43c91aa931cad26fa55c8766378462c06d86c85134801"))
 			},
 			partner_chain_pub_key: SidechainPublicKey(hex!("020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1").to_vec()),

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -106,7 +106,7 @@ fn prepare_mc_follower_env<C: IOContext>(context: &C) -> anyhow::Result<()> {
 fn show_registration_status(
 	context: &impl IOContext,
 	mc_epoch_number: McEpochNumber,
-	mc_public_key: StakePoolPublicKey,
+	stake_pool_public_key: StakePoolPublicKey,
 ) -> Result<(), anyhow::Error> {
 	let temp_dir = context.new_tmp_dir();
 	let temp_dir_path = temp_dir
@@ -116,7 +116,7 @@ fn show_registration_status(
 	let node_executable = context.current_executable()?;
 	let command = format!(
 		"{} registration-status --mainchain-pub-key {} --mc-epoch-number {} --chain chain-spec.json --base-path {temp_dir_path}",
-		node_executable, mc_public_key.to_hex_string(), mc_epoch_number
+		node_executable, stake_pool_public_key.to_hex_string(), mc_epoch_number
 	);
 	let output = context.run_command(&command)?;
 	context.print("Registration status:");

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -10,7 +10,7 @@ use partner_chains_cardano_offchain::scripts_data::{GetScriptsData, ScriptsData}
 use partner_chains_cardano_offchain::{cardano_keys::CardanoPaymentSigningKey, OffchainError};
 use pretty_assertions::assert_eq;
 use sidechain_domain::{
-	CandidateRegistration, DParameter, MainchainKeyHash, MainchainPublicKey, McTxHash, UtxoId,
+	CandidateRegistration, DParameter, MainchainKeyHash, McTxHash, StakePoolPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 use std::collections::HashMap;
@@ -245,7 +245,7 @@ pub struct OffchainMock {
 		Result<Option<McTxHash>, OffchainError>,
 	>,
 	pub deregister: HashMap<
-		(UtxoId, PrivateKeyBytes, MainchainPublicKey),
+		(UtxoId, PrivateKeyBytes, StakePoolPublicKey),
 		Result<Option<McTxHash>, OffchainError>,
 	>,
 }
@@ -307,7 +307,7 @@ impl OffchainMock {
 		self,
 		genesis_utxo: UtxoId,
 		payment_signing_key: PrivateKeyBytes,
-		stake_ownership_pub_key: MainchainPublicKey,
+		stake_ownership_pub_key: StakePoolPublicKey,
 		result: Result<Option<McTxHash>, OffchainError>,
 	) -> Self {
 		Self {
@@ -403,7 +403,7 @@ impl Deregister for OffchainMock {
 		&self,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
-		stake_ownership_pub_key: MainchainPublicKey,
+		stake_ownership_pub_key: StakePoolPublicKey,
 	) -> Result<Option<McTxHash>, OffchainError> {
 		self.deregister
 			.get(&(genesis_utxo, payment_signing_key.to_bytes(), stake_ownership_pub_key.clone()))

--- a/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
@@ -167,7 +167,7 @@ pub fn validate_permissioned_candidate_data<AccountId: TryFrom<SidechainPublicKe
 
 /// Is the registration data provided by the authority candidate valid?
 pub fn validate_registration_data(
-	mainchain_pub_key: &MainchainPublicKey,
+	mainchain_pub_key: &StakePoolPublicKey,
 	registration_data: &RegistrationData,
 	genesis_utxo: UtxoId,
 ) -> Result<Candidate<ecdsa::Public, (sr25519::Public, ed25519::Public)>, RegistrationDataError> {
@@ -220,7 +220,7 @@ pub fn validate_stake(stake: Option<StakeDelegation>) -> Result<StakeDelegation,
 }
 
 fn verify_mainchain_signature(
-	mainchain_pub_key: &MainchainPublicKey,
+	mainchain_pub_key: &StakePoolPublicKey,
 	registration_data: &RegistrationData,
 	signed_message_encoded: &[u8],
 ) -> Result<(), RegistrationDataError> {
@@ -276,7 +276,7 @@ fn verify_tx_inputs(registration_data: &RegistrationData) -> Result<(), Registra
 // When implementing, make sure that the same validation is used here and in the committee selection logic
 sp_api::decl_runtime_apis! {
 	pub trait CandidateValidationApi {
-		fn validate_registered_candidate_data(mainchain_pub_key: &MainchainPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError>;
+		fn validate_registered_candidate_data(mainchain_pub_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError>;
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError>;
 		fn validate_permissioned_candidate_data(candidate: PermissionedCandidateData) -> Option<PermissionedCandidateDataError>;
 	}
@@ -290,7 +290,7 @@ mod tests {
 	use sp_core::Pair;
 
 	/// Get Valid Parameters of the `is_registration_data_valid()` function
-	fn create_valid_parameters() -> (MainchainPublicKey, RegistrationData, UtxoId) {
+	fn create_valid_parameters() -> (StakePoolPublicKey, RegistrationData, UtxoId) {
 		let registration_utxo = UtxoId {
 			tx_hash: McTxHash(hex!(
 				"d260a76b267e27fdf79c217ec61b776d6436dc78eefeac8f3c615486a71f38eb"
@@ -342,7 +342,7 @@ mod tests {
 		};
 
 		(
-			MainchainPublicKey(hex!(
+			StakePoolPublicKey(hex!(
 				"fb335cabe7d3dd77d0177cd332e9a44998d9d5085b811650853b7bb0752a8bef"
 			)),
 			registration_data,
@@ -361,7 +361,7 @@ mod tests {
 		fn create_parameters(
 			signing_sidechain_account: ecdsa::Pair,
 			sidechain_pub_key: Vec<u8>,
-		) -> (MainchainPublicKey, RegistrationData, UtxoId) {
+		) -> (StakePoolPublicKey, RegistrationData, UtxoId) {
 			let mainchain_account = ed25519::Pair::from_seed_slice(&[7u8; 32]).unwrap();
 			let genesis_utxo =
 				UtxoId { tx_hash: McTxHash([7u8; TX_HASH_SIZE]), index: UtxoIndex(0) };
@@ -397,7 +397,7 @@ mod tests {
 				tx_inputs: vec![signed_message.registration_utxo],
 			};
 
-			(MainchainPublicKey(mainchain_account.public().0), registration_data, genesis_utxo)
+			(StakePoolPublicKey(mainchain_account.public().0), registration_data, genesis_utxo)
 		}
 
 		#[test]
@@ -415,7 +415,7 @@ mod tests {
 		fn should_not_work_if_mainchain_pub_key_is_different() {
 			let (mainchain_pub_key, registration_data, genesis_utxo) = create_valid_parameters();
 			let different_mainchain_pub_key =
-				MainchainPublicKey(ed25519::Pair::from_seed_slice(&[0u8; 32]).unwrap().public().0);
+				StakePoolPublicKey(ed25519::Pair::from_seed_slice(&[0u8; 32]).unwrap().public().0);
 			assert_ne!(mainchain_pub_key, different_mainchain_pub_key);
 			assert_eq!(
 				validate_registration_data(

--- a/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
@@ -78,7 +78,7 @@ where
 	TAccountKeys: From<(sr25519::Public, ed25519::Public)>,
 {
 	let stake_delegation = validate_stake(candidate_registrations.stake_delegation).ok()?;
-	let mainchain_pub_key = candidate_registrations.mainchain_pub_key;
+	let mainchain_pub_key = candidate_registrations.stake_pool_public_key;
 
 	let (candidate_data, _) = candidate_registrations
 		.registrations
@@ -167,7 +167,7 @@ pub fn validate_permissioned_candidate_data<AccountId: TryFrom<SidechainPublicKe
 
 /// Is the registration data provided by the authority candidate valid?
 pub fn validate_registration_data(
-	mainchain_pub_key: &StakePoolPublicKey,
+	stake_pool_pub_key: &StakePoolPublicKey,
 	registration_data: &RegistrationData,
 	genesis_utxo: UtxoId,
 ) -> Result<Candidate<ecdsa::Public, (sr25519::Public, ed25519::Public)>, RegistrationDataError> {
@@ -193,7 +193,7 @@ pub fn validate_registration_data(
 	let signed_message_encoded = minicbor::to_vec(signed_message.to_datum())
 		.expect("`RegisterValidatorSignedMessage` should always be encodable");
 
-	verify_mainchain_signature(mainchain_pub_key, registration_data, &signed_message_encoded)?;
+	verify_stake_pool_signature(stake_pool_pub_key, registration_data, &signed_message_encoded)?;
 	verify_sidechain_signature(
 		sidechain_pub_key,
 		&registration_data.sidechain_signature,
@@ -219,21 +219,19 @@ pub fn validate_stake(stake: Option<StakeDelegation>) -> Result<StakeDelegation,
 	}
 }
 
-fn verify_mainchain_signature(
-	mainchain_pub_key: &StakePoolPublicKey,
+fn verify_stake_pool_signature(
+	stake_pool_pub_key: &StakePoolPublicKey,
 	registration_data: &RegistrationData,
 	signed_message_encoded: &[u8],
 ) -> Result<(), RegistrationDataError> {
-	let mainchain_signature: [u8; 64] = registration_data
+	let spo_signature: [u8; 64] = registration_data
 		.mainchain_signature
 		.0
 		.clone()
 		.try_into()
 		.map_err(|_| RegistrationDataError::InvalidMainchainSignature)?;
-	let mainchain_signature = ed25519::Signature::from(mainchain_signature);
-	if mainchain_signature
-		.verify(signed_message_encoded, &ed25519::Public::from(mainchain_pub_key.0))
-	{
+	let spo_signature = ed25519::Signature::from(spo_signature);
+	if spo_signature.verify(signed_message_encoded, &ed25519::Public::from(stake_pool_pub_key.0)) {
 		Ok(())
 	} else {
 		Err(RegistrationDataError::InvalidMainchainSignature)
@@ -501,22 +499,22 @@ mod tests {
 		let (mc_pub_key, registration_data, genesis_utxo) = create_valid_parameters();
 		let candidate_registrations = vec![
 			CandidateRegistrations {
-				mainchain_pub_key: mc_pub_key.clone(),
+				stake_pool_public_key: mc_pub_key.clone(),
 				registrations: vec![registration_data.clone()],
 				stake_delegation: Some(StakeDelegation(0)),
 			},
 			CandidateRegistrations {
-				mainchain_pub_key: mc_pub_key.clone(),
+				stake_pool_public_key: mc_pub_key.clone(),
 				registrations: vec![registration_data.clone()],
 				stake_delegation: Some(StakeDelegation(1)),
 			},
 			CandidateRegistrations {
-				mainchain_pub_key: mc_pub_key.clone(),
+				stake_pool_public_key: mc_pub_key.clone(),
 				registrations: vec![registration_data.clone()],
 				stake_delegation: None,
 			},
 			CandidateRegistrations {
-				mainchain_pub_key: mc_pub_key,
+				stake_pool_public_key: mc_pub_key,
 				registrations: vec![registration_data],
 				stake_delegation: Some(StakeDelegation(2)),
 			},

--- a/toolkit/primitives/authority-selection-inherents/src/tests.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/tests.rs
@@ -412,7 +412,7 @@ fn create_epoch_candidates_idp(validators: &[MockValidator]) -> Vec<CandidateReg
 			};
 
 			CandidateRegistrations {
-				mainchain_pub_key: StakePoolPublicKey(mainchain_key_pair.public().0),
+				stake_pool_public_key: StakePoolPublicKey(mainchain_key_pair.public().0),
 				registrations: vec![registration_data],
 				stake_delegation: Some(StakeDelegation(validator.stake)),
 			}

--- a/toolkit/primitives/authority-selection-inherents/src/tests.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/tests.rs
@@ -412,7 +412,7 @@ fn create_epoch_candidates_idp(validators: &[MockValidator]) -> Vec<CandidateReg
 			};
 
 			CandidateRegistrations {
-				mainchain_pub_key: MainchainPublicKey(mainchain_key_pair.public().0),
+				mainchain_pub_key: StakePoolPublicKey(mainchain_key_pair.public().0),
 				registrations: vec![registration_data],
 				stake_delegation: Some(StakeDelegation(validator.stake)),
 			}

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -653,6 +653,7 @@ pub struct RegistrationData {
 	/// UTXO that is an input parameter to the registration transaction
 	pub registration_utxo: UtxoId,
 	pub sidechain_signature: SidechainSignature,
+	/// Stake Pool key signature
 	pub mainchain_signature: MainchainSignature,
 	pub cross_chain_signature: CrossChainSignature,
 	pub sidechain_pub_key: SidechainPublicKey,
@@ -667,7 +668,7 @@ pub struct RegistrationData {
 #[derive(Debug, Clone, Encode, Decode, PartialEq, Eq, TypeInfo)]
 #[cfg_attr(feature = "serde", derive(Serialize))]
 pub struct CandidateRegistrations {
-	pub mainchain_pub_key: StakePoolPublicKey,
+	pub stake_pool_public_key: StakePoolPublicKey,
 	/// **List of Registrations** done by the **Authority Candidate**
 	pub registrations: Vec<RegistrationData>,
 	pub stake_delegation: Option<StakeDelegation>,
@@ -675,15 +676,15 @@ pub struct CandidateRegistrations {
 
 impl CandidateRegistrations {
 	pub fn new(
-		mainchain_pub_key: StakePoolPublicKey,
+		stake_pool_public_key: StakePoolPublicKey,
 		stake_delegation: Option<StakeDelegation>,
 		registrations: Vec<RegistrationData>,
 	) -> Self {
-		Self { mainchain_pub_key, registrations, stake_delegation }
+		Self { stake_pool_public_key, registrations, stake_delegation }
 	}
 
 	pub fn mainchain_pub_key(&self) -> &StakePoolPublicKey {
-		&self.mainchain_pub_key
+		&self.stake_pool_public_key
 	}
 
 	pub fn registrations(&self) -> &[RegistrationData] {

--- a/toolkit/primitives/plutus-data/src/registered_candidates.rs
+++ b/toolkit/primitives/plutus-data/src/registered_candidates.rs
@@ -261,7 +261,7 @@ mod tests {
 	fn test_datum_v0() -> RegisterValidatorDatum {
 		RegisterValidatorDatum::V0 {
 			stake_ownership: AdaBasedStaking {
-				pub_key: MainchainPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
+				pub_key: StakePoolPublicKey(hex!("bfbee74ab533f40979101057f96de62e95233f2a5216eb16b54106f09fd7350d")),
 				signature: MainchainSignature(hex!("28d1c3b7df297a60d24a3f88bc53d7029a8af35e8dd876764fd9e7a24203a3482a98263cc8ba2ddc7dc8e7faea31c2e7bad1f00e28c43bc863503e3172dc6b0a").into()),
 			},
 			sidechain_pub_key: SidechainPublicKey(hex!("02fe8d1eb1bcb3432b1db5833ff5f2226d9cb5e65cee430558c18ed3a3c86ce1af").into()),

--- a/toolkit/primitives/session-validator-management/query/src/commands.rs
+++ b/toolkit/primitives/session-validator-management/query/src/commands.rs
@@ -16,10 +16,10 @@ pub async fn cli_get_ariadne_parameters(
 pub async fn cli_get_registration_status(
 	query: impl SessionValidatorManagementQueryApi,
 	mc_epoch_number: McEpochNumber,
-	mainchain_pub_key: StakePoolPublicKey,
+	stake_pool_public_key: StakePoolPublicKey,
 ) -> Result<String, String> {
 	let registrations = query
-		.get_registrations(mc_epoch_number, mainchain_pub_key.clone())
+		.get_registrations(mc_epoch_number, stake_pool_public_key.clone())
 		.await
 		.map_err(|err| err.to_string())?;
 	let registrations_json = serde_json::to_value(registrations).map_err(|err| err.to_string())?;

--- a/toolkit/primitives/session-validator-management/query/src/commands.rs
+++ b/toolkit/primitives/session-validator-management/query/src/commands.rs
@@ -1,5 +1,5 @@
 use crate::SessionValidatorManagementQueryApi;
-use sidechain_domain::{MainchainPublicKey, McEpochNumber};
+use sidechain_domain::{McEpochNumber, StakePoolPublicKey};
 
 pub async fn cli_get_ariadne_parameters(
 	query: impl SessionValidatorManagementQueryApi,
@@ -16,7 +16,7 @@ pub async fn cli_get_ariadne_parameters(
 pub async fn cli_get_registration_status(
 	query: impl SessionValidatorManagementQueryApi,
 	mc_epoch_number: McEpochNumber,
-	mainchain_pub_key: MainchainPublicKey,
+	mainchain_pub_key: StakePoolPublicKey,
 ) -> Result<String, String> {
 	let registrations = query
 		.get_registrations(mc_epoch_number, mainchain_pub_key.clone())
@@ -40,8 +40,8 @@ mod tests {
 	use hex_literal::hex;
 	use serde_json::Value;
 	use sidechain_domain::{
-		AuraPublicKey, GrandpaPublicKey, MainchainPublicKey, McBlockNumber, McSlotNumber, McTxHash,
-		McTxIndexInBlock, SidechainPublicKey, UtxoId, UtxoIndex, UtxoInfo,
+		AuraPublicKey, GrandpaPublicKey, McBlockNumber, McSlotNumber, McTxHash, McTxIndexInBlock,
+		SidechainPublicKey, StakePoolPublicKey, UtxoId, UtxoIndex, UtxoInfo,
 	};
 
 	struct MockSessionValidatorManagementQuery {
@@ -58,7 +58,7 @@ mod tests {
 		async fn get_registrations(
 			&self,
 			_: McEpochNumber,
-			_: MainchainPublicKey,
+			_: StakePoolPublicKey,
 		) -> QueryResult<Vec<CandidateRegistrationEntry>> {
 			Ok(self.expected_registrations.clone())
 		}
@@ -158,7 +158,7 @@ mod tests {
 		let cmd_output = cli_get_registration_status(
 			query,
 			McEpochNumber(303),
-			MainchainPublicKey(hex!(
+			StakePoolPublicKey(hex!(
 				"7521303029fc73ea2dd6a410c4c3cf570bf294a7e02942e049d50ba117acec22"
 			)),
 		)

--- a/toolkit/primitives/session-validator-management/query/src/get_registrations.rs
+++ b/toolkit/primitives/session-validator-management/query/src/get_registrations.rs
@@ -30,7 +30,7 @@ where
 		let best_block = self.client.info().best_hash;
 
 		let registration_data_validation =
-			|pub_key: &MainchainPublicKey, registration_data: &RegistrationData| {
+			|pub_key: &StakePoolPublicKey, registration_data: &RegistrationData| {
 				api.validate_registered_candidate_data(best_block, pub_key, registration_data)
 			};
 		let stake_validation = |stake_delegation: &Option<StakeDelegation>| {
@@ -63,7 +63,7 @@ where
 fn get_registrations_response_map(
 	candidates: Vec<CandidateRegistrations>,
 	validate_registration_data: impl Fn(
-		&MainchainPublicKey,
+		&StakePoolPublicKey,
 		&RegistrationData,
 	) -> Result<Option<RegistrationDataError>, sp_api::ApiError>,
 	validate_stake: impl Fn(&Option<StakeDelegation>) -> Result<Option<StakeError>, sp_api::ApiError>,

--- a/toolkit/primitives/session-validator-management/query/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/query/src/lib.rs
@@ -9,7 +9,7 @@ use authority_selection_inherents::authority_selection_inputs::{
 use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
 use derive_new::new;
 use sidechain_block_search::{predicates::AnyBlockInEpoch, FindSidechainBlock, SidechainInfo};
-use sidechain_domain::{MainchainPublicKey, McEpochNumber, ScEpochNumber};
+use sidechain_domain::{McEpochNumber, ScEpochNumber, StakePoolPublicKey};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::{HeaderBackend, Info};
 use sp_core::bytes::to_hex;
@@ -37,7 +37,7 @@ pub trait SessionValidatorManagementQueryApi {
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: MainchainPublicKey,
+		mc_public_key: StakePoolPublicKey,
 	) -> QueryResult<Vec<CandidateRegistrationEntry>>;
 
 	/// Regardless of `epoch_number` value, all the candidates data validation is done based on the validation api from the latest sidechain block.
@@ -142,7 +142,7 @@ where
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: MainchainPublicKey,
+		mc_public_key: StakePoolPublicKey,
 	) -> QueryResult<Vec<CandidateRegistrationEntry>> {
 		let api = self.client.runtime_api();
 		let best_block = self.client.info().best_hash;

--- a/toolkit/primitives/session-validator-management/query/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/query/src/lib.rs
@@ -37,7 +37,7 @@ pub trait SessionValidatorManagementQueryApi {
 	async fn get_registrations(
 		&self,
 		mc_epoch_number: McEpochNumber,
-		mc_public_key: StakePoolPublicKey,
+		stake_pool_public_key: StakePoolPublicKey,
 	) -> QueryResult<Vec<CandidateRegistrationEntry>>;
 
 	/// Regardless of `epoch_number` value, all the candidates data validation is done based on the validation api from the latest sidechain block.

--- a/toolkit/primitives/session-validator-management/query/src/tests/mock.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/mock.rs
@@ -27,7 +27,7 @@ pub fn create_valid_candidate_registrations_from_seed(
 		create_valid_registration_data(mainchain_account, sidechain_account, genesis_utxo);
 
 	CandidateRegistrations {
-		mainchain_pub_key: MainchainPublicKey(mainchain_account.public().0),
+		mainchain_pub_key: StakePoolPublicKey(mainchain_account.public().0),
 		registrations: vec![registration_data],
 		stake_delegation: Some(StakeDelegation(7)),
 	}

--- a/toolkit/primitives/session-validator-management/query/src/tests/mock.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/mock.rs
@@ -27,7 +27,7 @@ pub fn create_valid_candidate_registrations_from_seed(
 		create_valid_registration_data(mainchain_account, sidechain_account, genesis_utxo);
 
 	CandidateRegistrations {
-		mainchain_pub_key: StakePoolPublicKey(mainchain_account.public().0),
+		stake_pool_public_key: StakePoolPublicKey(mainchain_account.public().0),
 		registrations: vec![registration_data],
 		stake_delegation: Some(StakeDelegation(7)),
 	}

--- a/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
@@ -234,7 +234,7 @@ mod get_registration_tests {
 			let supported_epoch = McEpochNumber(1);
 			let (mainchain_account, _) = ed25519::Pair::generate();
 			let (sidechain_account, _) = ecdsa::Pair::generate();
-			let mc_public_key = MainchainPublicKey(mainchain_account.public().0);
+			let mc_public_key = StakePoolPublicKey(mainchain_account.public().0);
 			let valid_registration_data = create_valid_registration_data(
 				mainchain_account,
 				sidechain_account.clone(),

--- a/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
@@ -234,7 +234,7 @@ mod get_registration_tests {
 			let supported_epoch = McEpochNumber(1);
 			let (mainchain_account, _) = ed25519::Pair::generate();
 			let (sidechain_account, _) = ecdsa::Pair::generate();
-			let mc_public_key = StakePoolPublicKey(mainchain_account.public().0);
+			let stake_pool_public_key = StakePoolPublicKey(mainchain_account.public().0);
 			let valid_registration_data = create_valid_registration_data(
 				mainchain_account,
 				sidechain_account.clone(),
@@ -264,7 +264,7 @@ mod get_registration_tests {
 				.with_candidates_per_epoch(vec![
 					vec![],
 					vec![CandidateRegistrations {
-						mainchain_pub_key: mc_public_key.clone(),
+						stake_pool_public_key: stake_pool_public_key.clone(),
 						registrations,
 						stake_delegation: stake,
 					}],
@@ -275,7 +275,7 @@ mod get_registration_tests {
 				SessionValidatorManagementQuery::new(client, Arc::new(candidate_data_source_mock));
 
 			let registrations =
-				api.get_registrations(supported_epoch, mc_public_key).await.unwrap();
+				api.get_registrations(supported_epoch, stake_pool_public_key).await.unwrap();
 
 			let block_numbers: Vec<McBlockNumber> = registrations
 				.clone()

--- a/toolkit/primitives/session-validator-management/query/src/tests/runtime_api_mock.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/runtime_api_mock.rs
@@ -79,7 +79,7 @@ sp_api::mock_impl_runtime_apis! {
 	}
 
 	impl CandidateValidationApi<Block> for TestRuntimeApi {
-		fn validate_registered_candidate_data(mainchain_pub_key: &MainchainPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
+		fn validate_registered_candidate_data(mainchain_pub_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
 			validate_registration_data(mainchain_pub_key, registration_data, TEST_UTXO_ID).err()
 		}
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError> {

--- a/toolkit/primitives/session-validator-management/query/src/types/registrations.rs
+++ b/toolkit/primitives/session-validator-management/query/src/types/registrations.rs
@@ -28,11 +28,13 @@ pub struct CandidateRegistrationEntry {
 	pub sidechain_pub_key: String,
 	/// SS58 address derived from public key. ss58(blake2b32(sidechainPubKey))
 	pub sidechain_account_id: String,
+	/// Stake Pool public key
 	pub mainchain_pub_key: String,
 	pub cross_chain_pub_key: String,
 	pub aura_pub_key: String,
 	pub grandpa_pub_key: String,
 	pub sidechain_signature: String,
+	/// Signature made with Stake Pool key
 	pub mainchain_signature: String,
 	pub cross_chain_signature: String,
 	/// Data of Utxo that contained this registration"
@@ -50,7 +52,7 @@ pub type GetRegistrationsResponseMap = HashMap<String, Vec<CandidateRegistration
 impl CandidateRegistrationEntry {
 	pub fn new(
 		registration_data: RegistrationData,
-		mainchain_pub_key: StakePoolPublicKey,
+		stake_pool_public_key: StakePoolPublicKey,
 		stake_delegation: Option<StakeDelegation>,
 		invalid_reasons: Option<RegistrationDataError>,
 	) -> Self {
@@ -60,7 +62,7 @@ impl CandidateRegistrationEntry {
 				registration_data.sidechain_pub_key.clone(),
 			)
 			.unwrap_or("Invalid Sidechain Public Key. Could not decode...".into()),
-			mainchain_pub_key: to_hex(&mainchain_pub_key.0.clone(), false),
+			mainchain_pub_key: to_hex(&stake_pool_public_key.0.clone(), false),
 			cross_chain_pub_key: to_hex(&registration_data.cross_chain_pub_key.0, false),
 			aura_pub_key: to_hex(&registration_data.aura_pub_key.0, false),
 			grandpa_pub_key: to_hex(&registration_data.grandpa_pub_key.0, false),

--- a/toolkit/primitives/session-validator-management/query/src/types/registrations.rs
+++ b/toolkit/primitives/session-validator-management/query/src/types/registrations.rs
@@ -4,7 +4,7 @@ use authority_selection_inherents::filter_invalid_candidates::{RegistrationDataE
 use parity_scale_codec::Decode;
 use serde::{Deserialize, Serialize};
 use sidechain_domain::{
-	MainchainPublicKey, RegistrationData, SidechainPublicKey, StakeDelegation, UtxoInfo,
+	RegistrationData, SidechainPublicKey, StakeDelegation, StakePoolPublicKey, UtxoInfo,
 };
 use sp_core::{
 	bytes::to_hex,
@@ -50,7 +50,7 @@ pub type GetRegistrationsResponseMap = HashMap<String, Vec<CandidateRegistration
 impl CandidateRegistrationEntry {
 	pub fn new(
 		registration_data: RegistrationData,
-		mainchain_pub_key: MainchainPublicKey,
+		mainchain_pub_key: StakePoolPublicKey,
 		stake_delegation: Option<StakeDelegation>,
 		invalid_reasons: Option<RegistrationDataError>,
 	) -> Self {


### PR DESCRIPTION
# Description

Separates StakePoolPublicKey and StakePublicKey and their respective signatures into separate types.
Before there was just MainchainPublicKey, but I argue that Stake key and StakePool key are two different things in the domain, used for different activities.

Please let me know what you think

This PR doesn't separate their hashes, it still is MainchainKeyHash.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff



