### PR TITLE
ETCM-9305 per pool stake distribution queries with caching

### DIFF
--- a/toolkit/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -318,31 +318,6 @@ pub(crate) struct StakePoolDelegationOutputRow {
 	pub stake_address_script_hash: Option<[u8; 28]>,
 }
 
-pub(crate) async fn get_stake_pool_delegations(
-	pool: &Pool<Postgres>,
-	epoch: EpochNumber,
-) -> Result<Vec<StakePoolDelegationOutputRow>, SqlxError> {
-	Ok(sqlx::query_as::<_, StakePoolDelegationOutputRow>(
-		"
-SELECT
-	epoch_stake.amount AS epoch_stake_amount,
-	pool_hash.hash_raw AS pool_hash_raw,
-	stake_address.hash_raw AS stake_address_hash_raw,
-	stake_address.script_hash AS stake_address_script_hash
-FROM
-			   epoch_stake
-	INNER JOIN stake_address      ON epoch_stake.addr_id = stake_address.id
-	INNER JOIN pool_hash          ON epoch_stake.pool_id = pool_hash.id
-WHERE
-	    epoch_stake.epoch_no = $1
-	AND epoch_stake.amount > 0
-    ",
-	)
-	.bind(epoch)
-	.fetch_all(pool)
-	.await?)
-}
-
 pub(crate) async fn get_stake_pool_delegations_for_pools(
 	pool: &Pool<Postgres>,
 	epoch: EpochNumber,

--- a/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
@@ -43,8 +43,8 @@ impl StakeDistributionDataSource for StakeDistributionDataSourceImpl {
 			.get_stake_pool_delegation_distribution_for_pools(epoch, vec![pool_hash])
 			.await?
 			.0
-			.get(&pool_hash)
-			.expect("infallible: result has to contain pool hash")
+			.entry(pool_hash)
+			.or_default()
 			.clone())
 	}
 

--- a/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
@@ -1,18 +1,26 @@
 use crate::db_model::{EpochNumber, StakePoolDelegationOutputRow};
 use crate::metrics::McFollowerMetrics;
 use crate::observed_async_trait;
-use derive_new::new;
+use lru::LruCache;
 use sidechain_domain::*;
 use sp_stake_distribution::StakeDistributionDataSource;
 use sqlx::PgPool;
+use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
 mod tests;
 
-#[derive(new)]
+type DistributionPerPoolCacheKey = (McEpochNumber, MainchainKeyHash);
 pub struct StakeDistributionDataSourceImpl {
 	pub pool: PgPool,
 	metrics_opt: Option<McFollowerMetrics>,
+	cache: Cache,
+}
+
+impl StakeDistributionDataSourceImpl {
+	pub fn new(pool: PgPool, metrics_opt: Option<McFollowerMetrics>, cache_size: usize) -> Self {
+		StakeDistributionDataSourceImpl { pool, metrics_opt, cache: Cache::new(cache_size) }
+	}
 }
 
 observed_async_trait!(
@@ -21,10 +29,55 @@ impl StakeDistributionDataSource for StakeDistributionDataSourceImpl {
 		&self,
 		epoch: McEpochNumber,
 	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>> {
-		let rows = crate::db_model::get_stake_pool_delegations(&self.pool, EpochNumber::from(epoch)).await?;
+		let rows =
+			crate::db_model::get_stake_pool_delegations(&self.pool, EpochNumber::from(epoch))
+				.await?;
 		Ok(rows_to_distribution(rows))
 	}
-});
+
+	async fn get_stake_pool_delegation_distribution_for_pool(
+		&self,
+		epoch: McEpochNumber,
+		pool_hash: MainchainKeyHash,
+	) -> Result<PoolDelegation, Box<dyn std::error::Error + Send + Sync>> {
+		Ok(self
+			.get_stake_pool_delegation_distribution_for_pools(epoch, vec![pool_hash])
+			.await?
+			.0
+			.get(&pool_hash)
+			.expect("infallible: result has to contain pool hash")
+			.clone())
+	}
+
+	async fn get_stake_pool_delegation_distribution_for_pools(
+		&self,
+		epoch: McEpochNumber,
+		pool_hashes: Vec<MainchainKeyHash>,
+	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>> {
+		let mut to_query = Vec::<[u8; 28]>::new();
+		let mut res = BTreeMap::new();
+
+		for pool_hash in pool_hashes {
+			match self.cache.get_distribution_for_pool(epoch, pool_hash) {
+				Some(pool_delegation) => {
+					res.insert(pool_hash, pool_delegation);
+				},
+				None => to_query.push(pool_hash.0),
+			}
+		}
+		let rows = crate::db_model::get_stake_pool_delegations_for_pools(
+			&self.pool,
+			EpochNumber::from(epoch),
+			to_query,
+		)
+		.await?;
+		let mut queried_pool_delegations = rows_to_distribution(rows);
+		self.cache.put_distribution_for_pools(epoch, queried_pool_delegations.clone());
+		res.append(&mut queried_pool_delegations.0);
+		Ok(StakeDistribution(res))
+	}
+}
+);
 
 fn rows_to_distribution(rows: Vec<StakePoolDelegationOutputRow>) -> StakeDistribution {
 	let mut res = BTreeMap::<MainchainKeyHash, PoolDelegation>::new();
@@ -59,5 +112,43 @@ fn get_delegator_key(row: &StakePoolDelegationOutputRow) -> Result<DelegatorKey,
 		_ => {
 			Err(format!("invalid stake address hash: {}", hex::encode(row.stake_address_hash_raw)))
 		},
+	}
+}
+
+struct Cache {
+	distribution_per_pool_cache: Arc<Mutex<LruCache<DistributionPerPoolCacheKey, PoolDelegation>>>,
+}
+
+impl Cache {
+	fn new(cache_size: usize) -> Self {
+		Self {
+			distribution_per_pool_cache: Arc::new(Mutex::new(LruCache::new(
+				cache_size.try_into().unwrap(),
+			))),
+		}
+	}
+
+	fn get_distribution_for_pool(
+		&self,
+		epoch: McEpochNumber,
+		pool_hash: MainchainKeyHash,
+	) -> Option<PoolDelegation> {
+		if let Ok(mut cache) = self.distribution_per_pool_cache.lock() {
+			cache.get(&(epoch, pool_hash)).map(|e| e.clone())
+		} else {
+			None
+		}
+	}
+
+	fn put_distribution_for_pools(
+		&self,
+		epoch: McEpochNumber,
+		stake_distribution: StakeDistribution,
+	) {
+		if let Ok(mut cache) = self.distribution_per_pool_cache.lock() {
+			for (pool_hash, pool_delegation) in stake_distribution.0 {
+				cache.put((epoch, pool_hash), pool_delegation);
+			}
+		}
 	}
 }

--- a/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/mod.rs
@@ -24,16 +24,6 @@ impl StakeDistributionDataSourceImpl {
 
 observed_async_trait!(
 impl StakeDistributionDataSource for StakeDistributionDataSourceImpl {
-	async fn get_stake_pool_delegation_distribution(
-		&self,
-		epoch: McEpochNumber,
-	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>> {
-		let rows =
-			crate::db_model::get_stake_pool_delegations(&self.pool, EpochNumber::from(epoch))
-				.await?;
-		Ok(rows_to_distribution(rows))
-	}
-
 	async fn get_stake_pool_delegation_distribution_for_pool(
 		&self,
 		epoch: McEpochNumber,

--- a/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/tests.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/tests.rs
@@ -6,16 +6,6 @@ use sqlx::PgPool;
 use super::StakeDistributionDataSourceImpl;
 
 #[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
-async fn stake_pool_delegation_distribution_works(pool: PgPool) {
-	let epoch = McEpochNumber(188);
-	let distribution =
-		make_source(pool).get_stake_pool_delegation_distribution(epoch).await.unwrap().0;
-
-	assert_eq!(distribution.get(&stake_pool_key_hash_1()).unwrap(), &pool_delegation_1());
-	assert_eq!(distribution.get(&stake_pool_key_hash_2()).unwrap(), &pool_delegation_2());
-}
-
-#[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
 async fn stake_pool_delegation_distribution_for_pool_works(pool: PgPool) {
 	let epoch = McEpochNumber(188);
 	let pool_delegation = make_source(pool)

--- a/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/tests.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/stake_distribution/tests.rs
@@ -6,7 +6,7 @@ use sqlx::PgPool;
 use super::StakeDistributionDataSourceImpl;
 
 #[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
-async fn stake_distribution_works(pool: PgPool) {
+async fn stake_pool_delegation_distribution_works(pool: PgPool) {
 	let epoch = McEpochNumber(188);
 	let distribution =
 		make_source(pool).get_stake_pool_delegation_distribution(epoch).await.unwrap().0;
@@ -15,8 +15,55 @@ async fn stake_distribution_works(pool: PgPool) {
 	assert_eq!(distribution.get(&stake_pool_key_hash_2()).unwrap(), &pool_delegation_2());
 }
 
+#[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
+async fn stake_pool_delegation_distribution_for_pool_works(pool: PgPool) {
+	let epoch = McEpochNumber(188);
+	let pool_delegation = make_source(pool)
+		.get_stake_pool_delegation_distribution_for_pool(epoch, stake_pool_key_hash_1())
+		.await
+		.unwrap();
+
+	assert_eq!(pool_delegation, pool_delegation_1());
+}
+
+#[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
+async fn stake_pool_delegation_distribution_for_pool_works_twice(pool: PgPool) {
+	let epoch = McEpochNumber(188);
+	let source = make_source(pool);
+
+	let pool_delegation = source
+		.get_stake_pool_delegation_distribution_for_pool(epoch, stake_pool_key_hash_1())
+		.await
+		.unwrap();
+
+	assert_eq!(pool_delegation, pool_delegation_1());
+
+	let pool_delegation = source
+		.get_stake_pool_delegation_distribution_for_pool(epoch, stake_pool_key_hash_1())
+		.await
+		.unwrap();
+
+	assert_eq!(pool_delegation, pool_delegation_1());
+}
+
+#[sqlx::test(migrations = "./testdata/stake-distribution/migrations")]
+async fn stake_pool_delegation_distribution_for_pools_works(pool: PgPool) {
+	let epoch = McEpochNumber(188);
+	let distribution = make_source(pool)
+		.get_stake_pool_delegation_distribution_for_pools(
+			epoch,
+			vec![stake_pool_key_hash_1(), stake_pool_key_hash_2()],
+		)
+		.await
+		.unwrap()
+		.0;
+
+	assert_eq!(distribution.get(&stake_pool_key_hash_1()).unwrap(), &pool_delegation_1());
+	assert_eq!(distribution.get(&stake_pool_key_hash_2()).unwrap(), &pool_delegation_2());
+}
+
 fn make_source(pool: PgPool) -> StakeDistributionDataSourceImpl {
-	StakeDistributionDataSourceImpl::new(pool, None)
+	StakeDistributionDataSourceImpl::new(pool, None, 100)
 }
 
 fn stake_pool_key_hash_1() -> MainchainKeyHash {

--- a/toolkit/primitives/stake-distribution/src/lib.rs
+++ b/toolkit/primitives/stake-distribution/src/lib.rs
@@ -9,4 +9,18 @@ pub trait StakeDistributionDataSource {
 		&self,
 		epoch: McEpochNumber,
 	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>>;
+
+	/// Retrieves stake pool delegation distribution for provided epoch and pool
+	async fn get_stake_pool_delegation_distribution_for_pool(
+		&self,
+		epoch: McEpochNumber,
+		pool_hash: MainchainKeyHash,
+	) -> Result<PoolDelegation, Box<dyn std::error::Error + Send + Sync>>;
+
+	/// Retrieves stake pool delegation distribution for provided epoch and pools
+	async fn get_stake_pool_delegation_distribution_for_pools(
+		&self,
+		epoch: McEpochNumber,
+		pool_hashes: Vec<MainchainKeyHash>,
+	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>>;
 }

--- a/toolkit/primitives/stake-distribution/src/lib.rs
+++ b/toolkit/primitives/stake-distribution/src/lib.rs
@@ -4,12 +4,6 @@ use sidechain_domain::*;
 
 #[async_trait::async_trait]
 pub trait StakeDistributionDataSource {
-	/// Retrieves stake pool delegation distribution for provided epoch
-	async fn get_stake_pool_delegation_distribution(
-		&self,
-		epoch: McEpochNumber,
-	) -> Result<StakeDistribution, Box<dyn std::error::Error + Send + Sync>>;
-
 	/// Retrieves stake pool delegation distribution for provided epoch and pool
 	async fn get_stake_pool_delegation_distribution_for_pool(
 		&self,


### PR DESCRIPTION
# Description

This PR adds 2 more queries for stake distributions:
`get_stake_pool_delegation_distribution_for_pool(McEpochNumber, MainchainKeyHash) -> PoolDelegation`
`get_stake_pool_delegation_distribution_for_pools(McEpochNumber, Vec<MainchainKeyHash>) -> StakeDistribution`
These queries also implement caching through an LRU cache, the key being `(McEpochNumber, MainchainKeyHash)`.

I plan on adding caching to `get_stake_pool_delegation_distribution` in a follow up PR.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

