### PR TITLE
test: speed up block rewards tests

### DIFF
--- a/e2e-tests/secrets/substrate/staging/staging-ci.json
+++ b/e2e-tests/secrets/substrate/staging/staging-ci.json
@@ -1,0 +1,50 @@
+{
+	"dbSync": {
+		"host": "ENC[AES256_GCM,data:IryA/kJ8G8MAg0U26takPxbBzYD1ni7TPcdPSl7GVFvXDbXBY8yjYeuGdbQBn3LElcN4Ly3MGYbvTCde1xERnTY0,iv:Ul1eZG0dI8rL2m+g9c+fCzUn1Nb+/Coc8z0YRN9hNjA=,tag:llhy4AQceD7kFqfxZ17cyA==,type:str]"
+	},
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:eu-central-1:689191102645:key/ca20bdac-ce35-4859-a2ef-e796df8d0abc",
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "AQICAHiJ/VuNppiHx2jJW2hjoCiJJUKJ67yfY9h7QskzrjmoNQHpxp8xZYbcel/XCFNOSD7CAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQManRt6OLwZ8CFG/YeAgEQgDs6tw7IKLJNr0cxEg8PqnSNiZZfMOhwtd3NretoMTHB6aagXe2991LpPppQNK59Ve4zhO97E1GPzkei9A==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2025-02-13T10:48:38Z",
+		"mac": "ENC[AES256_GCM,data:20Y/YxxBxvlqZsx3bdKh81hvhp0TWQ8ZVSxe0fua+JqbDUrjyD0XxTAv32svQe4PjwucnrJ9e7Xey+lHSLEVftDyezCrrn2uuBPLj0Rx4xW0Ciar5lxlucEqvSDQiTxXXIgfjSVG46JFGF323G+a7fapkxUD+UxNQP1nbT1Z87Q=,iv:MzRJm4R5XZtIISNU0q/vOofbWVUzvdLHYH32xIVPRu0=,tag:IicW5dfj+pLvxWYD2dMBjw==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQIMAygBdvQRWWD6AQ/+KCHxdZetT9mjAiTDThgNWh9FNfvygYfe1aFhpNJ0sb9Z\n6UYyJ71G2w2WFWYHfPrK3ti+xfTJ/T/RYeziAsDx9E2QFueIPY7k8AeNs8h0aFNF\nXWxem8+y8ieBGRmp8vGz9VhGSaoUX5gKEiItn1zxYnwTCxNZaLNAIlgT+qfeijeA\nGcia6yWiVMvS9BZwPTUHpNhu6IhBKDzZi4mogROwtvtaMLhANvfT2bMFghax+7FM\nc561wKKVawpUrD8NIjIUIbnGsNh3q1fYM/N4tUTYCbyMEzfRktEecWc9yrdexulL\nAjXqxr812TciGeEu+hEXVcfj2smY2AUmyHWKEEFnBcnELIIAFlJ0Ea7YhJfNqggg\nMK37kK+kDiqPmmJdfIOmdf5mpTa/q1Tlc4Q8yw5CvovyGcKDkQkfB6c6UFRcSHk9\nrFTobCqWzJ7wXAGM+Y3f/4RCyuKYz89Ttp2z+mdF5feiNfEtwMwInHTLmThUN/HE\nCa/UDRnq1ftVjhXu4csrr4xavW2coCpUETjZVNSayE4PIjXnEEPDWJKDNLN2JpcM\nR0YnYP6EB0AIE9khBwDpbo7STDITX7/tWjSzJjBU/Ug30q8zyA8PNRb/pPj9s/Ap\nKzI7jMSuKVw14FHyvpFkDjwthkNVCrcpBpVAE/g/HqyQI7s7j+Q2Nqhigum20XnS\nXgFXx3+6Djie+MJAsyPOs3FtQEXioMTIs0tutQIKTfM1aor4IXsAPOceU8ZlnP1w\n8vdF7LKIdRsm5y0TSY1F+5AlUr6YwryIQTCSovVW6ZDT44cCkJTIjsGdqPWXvxU=\n=Roi/\n-----END PGP MESSAGE-----\n",
+				"fp": "15AC8EA84FC2A5AE768FFD753CEBBA453DE5BCFD"
+			},
+			{
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQIMAz1/YjKN8X53AQ//RM/BIW6Q78N89AbJb+4IGhR1Fou3nWL4qiltfH9TjLAN\nvMvlM6yvOyFUkDcpYhpAQ6lctZZe9k5yMYX78aQp/66UTHvIql8Knoif3PfT0CoW\nWGRsjctWN6VCdogW0cZbeITbZOnOPJXZvWVUzAuafBivY0qFcHgTaFl93el3ruqk\nB1evRWFttq7J/802jp3OafEaMubOgXcXXe9XK4nF9tP46eZYjmAq3p8WBaaohoAh\npqk7hQO6x9guG15E/9/POf/SazclpAPJj8jNkbAjLJ/jOLHSAAuc6z3SiH9lYau+\nE9ahSbaYPrvmnsLdBEkUufNvdwOk8tAoVW1cUEj13r6oAfZfK/woVyhxNrdrWIPZ\nBGuSp/wJlyJSHhYwYSjNBuPEKA2qdd5DFfkNTma9u1jULbUdb1MtJrO0LPbuCD+3\neQUo0DLbGl0wdmYLYgOfzap68r23l3dTF9b4TvXKHkkUUGoXd/eqbjfhidhQ3a0y\nxgw45WN0bFVoR+3Y6NgG+z3bAKYqhE74P1z4pFUZfgJtlUXAnsNS0p9vrJDdzc4D\nozN19dy9CBxSZo6ekBYXYFpBx3VC7tGFLh6/vZUTyXTaMZ49Hgx2W2Zc9ZHt0LFZ\nRnmyDmwHVpjeoO6Sv7uwAuYpxRzCTGhfg8Uo/+7DyFbysfwQqe329Hnr1RoTHzzS\nXgE0QR3kngUW0lRgJTpAZ1pjvot+wvYxXYSS5MembU/CnpCictO6CuXSPuPzOGD2\ncbZnqw5ENWRRBK/n+ZrUBB89uQtvRhJxZ3wRyu+Q+/DMop8AIU+caqA0I+9RlD0=\n=hmbq\n-----END PGP MESSAGE-----\n",
+				"fp": "33E4D64843E72C6C8A665703199BE5B70A2AACE3"
+			},
+			{
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhF4DakOMg1R3/sQSAQdAGC0T3zT0sb43+JrbbJ6PAdalK9WFP3l+HKG7jqixIRIw\nWiIzA3iGIlmf/L8/rw9KKggzp5dykTEyjuRPbpHukhCBTX6Et1cFEtothKb81ao9\n0l4BESmV42HALsh4h0K96XAkrqDHbPui1iK6rAlUzLL8tbG0EHEFSvA3WgJdWqhg\n6j6gncr0BFV5h/BNSrUeB83rGL9dWcuQX4gTfr6bjY2xDKgldyBwg+tfczbpR+Oy\n=lew4\n-----END PGP MESSAGE-----\n",
+				"fp": "54718D2B78DCAA9C770296F18985725DB5B0C122"
+			},
+			{
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQIMA+0koCT2f8m/AQ/9GsN9+13UreCNw+eqEfaSkyUjXGguhqcq/GKxs0RvR3GC\nI7N0Ja8R34x0KQ+w+v6PlmkGkpWy3bDiZVkU6STBPHH28mZ6dpukc6lZ6mZMxYUF\n1TDE/0QewddUrZuxKnqBTbdnavdyFQyneiZrmSy/Be8LoKLOQZVty9bmVS+i+x6k\nP3dysxKyUt2M0PnroQGp257W6G6oHthkf28igZy42tECXyLffl1QD+px/Ecwuhuv\nt1Da6Hvt8XKwUD3PZpC2Q61WZ67d/tODleoiRDJm2BZAlXRXwAbAC8uuFZis0ZVd\nUZyYClwd64FnBNlq80YUTKAf/NnyQAAvO5l/ZVg9WHI4HUcZQXEQw/swfr3+Djjr\nWn1Kbao+fO70sWnfTabM1pjPL+GQJpjDhYPhvW9/O0bKmOAxWDz9lNsrvCD3CPb+\nv+Vmroh5hbRGCrLczWnvgO3/uSUehWibX+zLXogpJKJKyyNct262jIiaJW2SLEqt\n0ea8LfHlbeK0/Pu0CS6XW4GQ5S4Q3rspEl6nTEyuo3RfNqLmLTwTMZQKaUl1WH71\npEdbunQktPc06fBFL3L0Hf5zlHEs6pJ/PdbxUsiqQhB6SYNp4XkXs2pTmgrdzV2C\nUBhgoIZ7Fi1/iQfkqeuzg9Y7eCj/e9F6456/1hH9xuQgalzoevWmtGq+0/V0oT3S\nXgGA0xO98slSCfxK+D+tfS7TAtLg3yt5AURONSzc70nowH98Zu4mnPQkTzBc3mOJ\nf7c6AFWRQWNcEltFr5ZnJDxBWvBufX8a4NvNHx9qiadt+rNkhwJnONqWiQDa9fI=\n=0KDp\n-----END PGP MESSAGE-----\n",
+				"fp": "C5C51001A3BF0F4031C37EC99681FA65B010848C"
+			},
+			{
+				"created_at": "2024-02-06T12:31:38Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcFMA0znJrxGVq2hAQ/+OIfWwHNngOw+/dPkKFlE9eObYZsbzwEIce7l+Wfl6FCH\ny7YOCpmI7DfFS4dTJr1LapP8MkmhsprDfG66Of+JQvsfWqYyigc1NLujQFs0h977\n1ggsscFosFN152MzLTz5bUt6kVTut8qq9I7AelO15fA0o9TwrWeJ2ls7omamruSb\nGoCeQiF9QK7Sz+ln0QPitNHuHbZ2jnzuqQKZLuz/sZLkjBLNvszS3u7UqrWXA1d6\npGBNFKDRByW01kRlMugHsDKOZKtgBw2jLIDnZFZ/tuTdI+HqSogf8Q0mEWC6swkU\nIYQ6YLP3el89xgCL81hmqpTjBOq163hHHyss45lyMQ1pEDQ+FL1yqZaiP8Z/uwr/\nzdGaNcASpqkne/INd1H5C5Zrb9F2VnGC32e6ExnF3G1KbBf3tOm1XYelTKlmR3pZ\nLQYns1il4kvRUiAzsn02JdOoBddnlM3njHzgatYjwly2zDJpUnfWdT3H2+Mucxcs\np/QQqo3yXV3iaV84pbLabNLTGhpRt9Wm0WD7mfgOrkTfGm55pD6rECl0KxWpyPnD\nhS64tjsX7263uyON5tAe7jsYPq9eWny0JCMx3sdD9H5DbWP9AFPESoVUSmDan7Tv\nXjUOiAlASXlT+NW8mNYmPJTiuWXHTzSbYQ1aCc5hOsla0kHCzcvojjkhUqm3VTfS\nUQGBJjnt3SUqfZKpvY/VMDkN9yO+eWWDEN2zkKjHI0DmXMGl0hav2DD4rRXsvJrb\nfYeF8K1RnGcZZ6JOKH7GqjIZTbA6WsgvNRbkYxod+346QQ==\n=CwNu\n-----END PGP MESSAGE-----",
+				"fp": "3A10EB97F2C401D93CC4685D6B0DDB72B8DEA45D"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.8.1"
+	}
+}

--- a/e2e-tests/secrets/substrate/staging/staging.json
+++ b/e2e-tests/secrets/substrate/staging/staging.json
@@ -12,7 +12,7 @@
 		"type": "ENC[AES256_GCM,data:rU0LSPIX73kqWg==,iv:5qktowdBAl59uNXVrmwI2mil7Thh4SDEQOzHLylBsEA=,tag:a5RNbDEZNqzw/kSye6LFTg==,type:str]",
 		"username": "ENC[AES256_GCM,data:1eTHUrdrcLs=,iv:l6QgW8p1xMajlWKu4RK4PYo/QIHiqfQJzzqO7PrDgAs=,tag:7ETwkCcENCngxwKE1LVvXw==,type:str]",
 		"password": "ENC[AES256_GCM,data:oVlgGHpnHIB0+J8=,iv:gmC701ZgCsg7byHM1WEEcjTQ54zlRWDyUjrARkUQKXk=,tag:ErikySOEnv7IqrSxYlkN2A==,type:str]",
-		"host": "ENC[AES256_GCM,data:8g4paL1NIkncmMdVagi2gGdPJm5Avgf0q/or8tF8eQKzhUPTOazE+RuiEtQuNNKh//z550ChXJ732nc5BYgelFEQ,iv:WCae7YK/Zq2VF290AW0bpDp3KQt3bamJvghGHVABBLM=,tag:PQM2MdQOiMW4Q/HTrH0wwg==,type:str]",
+		"host": "ENC[AES256_GCM,data:xadoKF+imkQ+rF8=,iv:+YyfI5K7tpjN/hCcjZenZZFxQWwCR2l2iX9jU0gDOTw=,tag:jUT9igF/crMbzP6r5KzHdg==,type:str]",
 		"port": "ENC[AES256_GCM,data:WUTE0w==,iv:S8fwURTz2InT0lniggKwzPK9xkUrCtd3hedURQMfs/U=,tag:g7xe9rII1vxTUUEASVRixw==,type:str]",
 		"name": "ENC[AES256_GCM,data:PHGEXKkMInKO,iv:AgI9EIiGUm9HL9bwnVN8VQPglTaSoV9cL13wTUK+GRo=,tag:QdIqJIDmltKUZTgG8Qup+Q==,type:str]",
 		"url": "ENC[AES256_GCM,data:OSFW9ZouWbOvbknToT4uGAkJsleS0ueJKfi8DzeDYUTykTL9kUm5FK9guoCGNak3D4Gmq2dH9kMaMgpjE7x87X4X+DFUx4IUho2aVgxqHaheLfPqQ96cT0hxVeGgOoOtAewX,iv:rbNGfPLN05nw40GCpA7VCw5p3/8QseH1UqdNwNKDjUM=,tag:m9YU1o5UA2Wvv2cMqCt9UQ==,type:str]"
@@ -95,8 +95,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2024-10-15T11:39:08Z",
-		"mac": "ENC[AES256_GCM,data:5oWCZWtAmYl7QEP/L1DjwCRGdXf/MnW4n91rPtFQX8+spZ0vGXEdH4QOt5B2RRL0s3wak+i79IkWuWst6w1Ny6UKhCWjUDm7MZWFv0LpdDZ++TV572UWtsTOLkh0GTfpUDA/CVBsbNMEj4rqq0Y1CdoQRPvck2VuvFP+y3TcwJI=,iv:aIBD1WAWkQ9DsMN1WKukpHpQBUN3p68buVjHV6IflZA=,tag:gemUoRjkdERy7CzDu5+L4g==,type:str]",
+		"lastmodified": "2025-02-18T08:33:13Z",
+		"mac": "ENC[AES256_GCM,data:Q5clNWFEModMCeFCPVNNyTwvGgEfPtrY4G3SAgE3SNuDk9Jd6jQOObUghGAKQmXQ6nD3vKoRb9UUTToEwdyUO4WDwzk7WdCkPr+elOPfvbXbgjfterotDdbDyoIuNhi6CYHXmXZ1AEhr2xGvWR3PM7W0Hh/Gc0G8lxy+MRz26Ks=,iv:BRkWBNQGU6g0n+yiHshs+lYDMnxQmMwObA3fR40Siro=,tag:qKxNpDrrwA9u9SRSx7E8gg==,type:str]",
 		"pgp": [
 			{
 				"created_at": "2024-02-06T12:31:38Z",

--- a/e2e-tests/src/blockchain_api.py
+++ b/e2e-tests/src/blockchain_api.py
@@ -470,11 +470,24 @@ class BlockchainApi(ABC):
         pass
 
     @abstractmethod
-    def get_block_author(self, block_number: int) -> str:
+    def get_validator_set(self, block) -> str:
+        """Gets validator set for a given block.
+
+        Arguments:
+            block -- block object
+
+        Returns:
+            str -- block author public key
+        """
+        pass
+
+    @abstractmethod
+    def get_block_author(self, block, validator_set) -> str:
         """Gets the author of a block.
 
         Arguments:
-            block_number {int} -- block number
+            block -- block object
+            validator_set -- validator set for given pc epoch
 
         Returns:
             str -- block author public key

--- a/e2e-tests/src/pc_block_finder.py
+++ b/e2e-tests/src/pc_block_finder.py
@@ -36,6 +36,7 @@ class BlockFinder:
             return None
 
     def get_block_range(self, next_epoch_timestamp, current_pc_epoch, pc_epoch):
+        logging.info(f"Finding block range for epoch {pc_epoch}...")
         epoch_to_test_start_timestamp = (
             next_epoch_timestamp
             - (current_pc_epoch - pc_epoch + 1)

--- a/e2e-tests/tests/committee/conftest.py
+++ b/e2e-tests/tests/committee/conftest.py
@@ -552,6 +552,7 @@ def get_pc_epoch_blocks(api: BlockchainApi, config: ApiConfig, blocks_dict, curr
                 block_range = range(0, 0)
             blocks_dict[epoch] = {}
             blocks_dict[epoch]["range"] = block_range
+            logging.info(f"Getting blocks for epoch {epoch}...")
             for block in block_range:
                 blocks_dict[epoch][block] = api.get_block(block)
         return blocks_dict[epoch]

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -97,9 +97,10 @@ def test_block_authors_match_committee_seats(
     for member in committee:
         committee_block_auth_pub_keys.append(get_block_authorship_keys_dict[member["sidechainPubKey"]])
 
+    validator_set = api.get_validator_set(get_pc_epoch_blocks(pc_epoch)[first_block_no])
     block_authors = []
     for block_no in get_pc_epoch_blocks(pc_epoch)["range"]:
-        block_author = api.get_block_author(block_number=block_no)
+        block_author = api.get_block_author(block=get_pc_epoch_blocks(pc_epoch)[block_no], validator_set=validator_set)
         assert block_author, f"Could not get author of block {block_no}."
         assert (
             block_author in committee_block_auth_pub_keys


### PR DESCRIPTION
fixes:
- use cache instead of querying for the same block twice
- get validators once per pc epoch instead on every block

Refs: ETCM-9389