### PR TITLE
ETCM-8543 Fix test_block_headers_have_mc_hash

### DIFF
--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -1,6 +1,6 @@
 # Partner Chains Tests
 
-Welcome to `Partner Chains Tests`, a powerful and flexible test automation framework for system and end-to-end (E2E) tests for partner chains. 
+Welcome to `Partner Chains Tests`, a powerful and flexible test automation framework for system and end-to-end (E2E) tests for partner chains.
 
 ## Features
 
@@ -10,23 +10,25 @@ Welcome to `Partner Chains Tests`, a powerful and flexible test automation frame
 
 ## Partner Chains Tests - Infrastructure
 
-![Test Infrastructure](/docs/pc-tests-infra.png)
+![Test Infrastructure](/e2e-tests/docs/pc-tests-infra.png)
 
 ## Installation
 
 1. Install `python 3.12` and `pip`.
 2. Create and activate virtual environment
+
 ```bash
-   $ pip install virtualenv
-   $ python -m venv venv
-   $ source venv/bin/active
+  pip install virtualenv
+  python -m venv venv
+  source venv/bin/activate
 ```
+
 3. Install requirements `pip install -r requirements.txt`.
-4. Install sops to [manage keys](/docs/secrets.md). You can also configure [your own keys with sops](/docs/configure-sops.md)
+4. Install sops to [manage keys](/e2e-tests/docs/secrets.md). You can also configure [your own keys with sops](/e2e-tests/docs/configure-sops.md)
 
 ## Getting Started
 
-- Choose an environment to run tests. You have an option to run on [local](/docs/run-tests-on-local-env.md) or [your own custom](/docs/run-tests-on-new-env.md) environments
+- Choose an environment to run tests. You have an option to run on [local](/e2e-tests/docs/run-tests-on-local-env.md) or [your own custom](/e2e-tests/docs/run-tests-on-new-env.md) environments
 - Run `pytest -h` to see all available options, or simply `pytest` to execute all tests.
 
 ### Execution Options
@@ -56,5 +58,5 @@ Custom options:
 ### Run tests on the local environment
 
 ```bash
-$ pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
+pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
 ```

--- a/e2e-tests/docs/run-tests-on-local-env.md
+++ b/e2e-tests/docs/run-tests-on-local-env.md
@@ -1,31 +1,34 @@
-# How to run system  tests on a partner-chains local environment
+# How to run system tests on a partner-chains local environment
 
 ## Prerequisites
 
 - Docker Desktop, lazydocker
 - python3, pip
 
-## Steps 
+## Steps
 
-1. Configure partner-chains local environment by running [setup.sh](https://github.com/input-output-hk/partner-chains/blob/master/dev/local-environment/setup.sh)
-   * If you want to use a pre-configured postgres password from /secrets/local/local.json: `$ ./setup.sh -p <PASSWORD>`
-   * If you want to use generated password from local env: run `$ ./setup.sh -n`. Password is saved in `.env` file, you will need it later
+1. Configure partner-chains local environment by running [setup.sh](/dev/local-environment/setup.sh)
+   - If you want to use a pre-configured postgres password from /e2e-tests/secrets/substrate/local/local.json: `$ ./setup.sh -p <PASSWORD>`
+   - If you want to use generated password from local env: run `$ ./setup.sh -n`. Password is saved in `.env` file, you will need it later
 2. Run local environment: `$ docker-compose up -d` and wait until the partner chains nodes finish syncing
 3. Get initial_timestamp value: `$ docker exec cardano-node-1 cat /shared/cardano.start`
 4. Set postgres passwords
-   * If you used a pre-configured password, skip this step
-   * If you used a generated password - update db and dbSync password values in `secrets/substrate/local/local.json` with the POSTGRES_PASSWORD env variable value from the `.env` file
-5. Update `main_chain.init_timestamp` at config/substrate/local_nodes.json to the resulting value of `docker exec cardano-node-1 cat /shared/cardano.start`
+   - If you used a pre-configured password, skip this step
+   - If you used a generated password - update db and dbSync password values in `secrets/substrate/local/local.json` with the POSTGRES_PASSWORD env variable value from the `.env` file
+5. Update `main_chain.init_timestamp` at config/substrate/local_nodes.json to the resulting value of `docker exec cardano-node-1 cat /shared/cardano.start` or alteratively pass it directly to `pytest` with `--init-timestamp=1234567890`
 6. Create and activate virtual environment
+
 ```bash
-   $ pip install virtualenv
-   $ python -m venv venv
-   $ source venv/bin/active
+   pip install virtualenv
+   python -m venv venv
+   source venv/bin/active
 ```
+
 1. Install project dependencies: `$ pip install -r requirements.txt`
 2. Run partner-chains tests on partner-chains local environment
+
 ```bash
-$ pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
+pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
 ```
 
 ## Substrate Portal

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -162,6 +162,11 @@ def test_block_headers_have_mc_hash(api: BlockchainApi, config: ApiConfig, pc_ep
 
         logger.debug(f"Difference between latest and stable mc block: {latest_stable_block_diff} for block {block_no}")
 
+        OFFSET = 1
+
         assert (
-            latest_stable_block_diff >= config.main_chain.security_param + config.main_chain.block_stability_margin
+            latest_stable_block_diff + OFFSET >= config.main_chain.security_param + config.main_chain.block_stability_margin
         ), f"Unexpected stable block number saved in header of block {block_no}"
+
+        if latest_stable_block_diff < config.main_chain.security_param + config.main_chain.block_stability_margin:
+            logger.warning(f"Unexpected (but within offset) stable block number saved in header of block {block_no}")


### PR DESCRIPTION
# Description

* Adds OFFSET to test_block_headers_have_mc_hash based on specs, allowing for small discrepancy, but logging a warning
* Some improvements to docs

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

