### PR TITLE
change: Include candidate type and MC pubkey in committee data in the storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10023,6 +10023,7 @@ dependencies = [
  "plutus",
  "pretty_assertions",
  "scale-info",
+ "serde",
  "serde_json",
  "session-manager",
  "sidechain-domain",

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,9 @@ WARNING: Benchmarking command has been removed, because `frame-benchmarking-cli`
 mainnet or one of the official testnets, you don't need to change anything. Otherwise, the duration can
 be set through `MC__SLOT_DURATION_MILLIS` environment variable.
 * e2e-tests: updated python to 3.12 and libs versions.
+* Committee member data stored by the Session Validator Management Pallet is now fullly generic. To migrate to this version,
+define your own `CommitteeMember` type and implement the trait `CommitteeMember` for it. See the `CommitteeMember`
+type implemented in `node/runtime/src/lib.rs` for reference using Ariadne.
 
 ## Removed
 

--- a/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
+++ b/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
@@ -174,28 +174,34 @@ jq '.genesis.runtimeGenesis.config.session.initialValidators = [
 
 echo "Configuring Initial Authorities..."
 jq '.genesis.runtimeGenesis.config.sessionCommitteeManagement.initialAuthorities = [
-     [
-         "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
-         {
-             "aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-             "grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
-         }
-     ],
-     [
-         "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
-         {
-             "aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-             "grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
-         }
-     ],
-     [
-         "KWBpGtyJLBkJERdZT1a1uu19c2uPpZm9nFd8SGtCfRUAT3Y4w",
-         {
-             "aura": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
-             "grandpa": "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6"
-         }
-     ]
- ]' chain-spec.json > tmp.json && mv tmp.json chain-spec.json
+  {
+    "Permissioned": {
+      "id": "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
+      "keys": {
+        "aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+        "grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
+      }
+    }
+  },
+  {
+    "Permissioned": {
+      "id": "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
+      "keys": {
+        "aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+        "grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
+      }
+    }
+  },
+  {
+    "Permissioned": {
+      "id": "KWBpGtyJLBkJERdZT1a1uu19c2uPpZm9nFd8SGtCfRUAT3Y4w",
+      "keys": {
+        "aura": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
+        "grandpa": "5DbKjhNLpqX3zqZdNBc9BGb4fHU1cRBaDhJUskrvkwfraDi6"
+      }
+    }
+  }
+]' chain-spec.json > tmp.json && mv tmp.json chain-spec.json
 
 echo "Set initial funds to Alice (ecdsa), ?, and Alice (sr25519)"
 jq '.genesis.runtimeGenesis.config.balances.balances = [

--- a/node/node/src/staging.rs
+++ b/node/node/src/staging.rs
@@ -1,5 +1,6 @@
 use crate::chain_spec::get_account_id_from_seed;
 use crate::chain_spec::*;
+use authority_selection_inherents::CommitteeMember;
 use sc_service::ChainType;
 use sidechain_domain::*;
 use sidechain_runtime::{
@@ -143,7 +144,7 @@ pub fn staging_genesis(
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()
-				.map(|keys| (keys.cross_chain, keys.session))
+				.map(|keys| CommitteeMember::permissioned(keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},

--- a/node/node/src/testnet.rs
+++ b/node/node/src/testnet.rs
@@ -1,4 +1,5 @@
 use crate::chain_spec::*;
+use authority_selection_inherents::CommitteeMember;
 use sc_service::ChainType;
 use sidechain_domain::*;
 use sidechain_runtime::{
@@ -195,7 +196,7 @@ pub fn testnet_genesis(
 		session_committee_management: SessionCommitteeManagementConfig {
 			initial_authorities: initial_authorities
 				.into_iter()
-				.map(|keys| (keys.cross_chain, keys.session))
+				.map(|keys| CommitteeMember::permissioned(keys.cross_chain, keys.session))
 				.collect(),
 			main_chain_scripts: sp_session_validator_management::MainChainScripts::read_from_env()?,
 		},

--- a/node/runtime/Cargo.toml
+++ b/node/runtime/Cargo.toml
@@ -15,6 +15,7 @@ log = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 derive-new = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true, default-features = false, features = [
 	"alloc",
 ] }

--- a/node/runtime/src/mock.rs
+++ b/node/runtime/src/mock.rs
@@ -149,6 +149,7 @@ impl pallet_session_validator_management::Config for Test {
 	type AuthorityKeys = TestSessionKeys;
 	type AuthoritySelectionInputs = AuthoritySelectionInputs;
 	type ScEpochNumber = ScEpochNumber;
+	type CommitteeMember = (Self::AuthorityId, Self::AuthorityKeys);
 
 	/// Mock simply selects all valid registered candidates as validators.
 	fn select_authorities(

--- a/toolkit/pallets/session-validator-management/README.md
+++ b/toolkit/pallets/session-validator-management/README.md
@@ -1,0 +1,9 @@
+# Session Validator Management Pallet
+
+This pallet provides a way to rotate session validators based on arbitrary
+inputs and selection algorithm.
+
+## Migrations
+
+This pallet's storage has changed compared to its legacy version. See
+[src/migrations/README.md] for more information.

--- a/toolkit/pallets/session-validator-management/benchmarking/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/benchmarking/src/lib.rs
@@ -37,7 +37,7 @@ fn set_epoch_number<T: Config>(epoch: u64) {
 }
 
 use pallet_session_validator_management::Call;
-#[benchmarks]
+#[benchmarks(where <T as pallet_session_validator_management::Config>::CommitteeMember: From<(<T as pallet_session_validator_management::Config>::AuthorityId, <T as pallet_session_validator_management::Config>::AuthorityKeys)>)]
 pub mod benchmarks {
 	use super::*;
 
@@ -66,15 +66,15 @@ pub mod benchmarks {
 			})
 			.collect();
 		let validators: BoundedVec<
-			(<T as pallet_session_validator_management::Config>::AuthorityId, T::AuthorityKeys),
+			<T as pallet_session_validator_management::Config>::CommitteeMember,
 			T::MaxValidators,
-		> = validators.try_into().unwrap();
+		> = BoundedVec::truncate_from(validators.into_iter().map(|member| member.into()).collect());
 
 		let for_epoch_number = T::current_epoch_number() + One::one();
 		set_epoch_number::<T>(for_epoch_number.into());
 
 		#[extrinsic_call]
-		_(RawOrigin::None, validators.clone(), for_epoch_number, Default::default());
+		_(RawOrigin::None, validators, for_epoch_number, Default::default());
 	}
 
 	impl_benchmark_test_suite!(Pallet, crate::mock::new_test_ext(), crate::mock::Test);

--- a/toolkit/pallets/session-validator-management/benchmarking/src/mock.rs
+++ b/toolkit/pallets/session-validator-management/benchmarking/src/mock.rs
@@ -106,11 +106,12 @@ impl pallet::Config for Test {
 	type AuthorityKeys = SessionKeys;
 	type AuthoritySelectionInputs = ();
 	type ScEpochNumber = ScEpochNumber;
+	type CommitteeMember = (Self::AuthorityId, Self::AuthorityKeys);
 
 	fn select_authorities(
 		_: Self::AuthoritySelectionInputs,
 		_: ScEpochNumber,
-	) -> Option<BoundedVec<(Self::AuthorityId, Self::AuthorityKeys), Self::MaxValidators>> {
+	) -> Option<BoundedVec<Self::CommitteeMember, Self::MaxValidators>> {
 		todo!("not used in benchmarks")
 	}
 

--- a/toolkit/pallets/session-validator-management/src/migrations/README.md
+++ b/toolkit/pallets/session-validator-management/src/migrations/README.md
@@ -1,0 +1,51 @@
+# Migrations Readme
+
+This document describes changes in the storage of different versions
+of the pallet and how to migrate from legacy versions.
+
+**Important:** It is crucial to run the migrations when upgrading runtime
+to a version containing this pallet's storage version. Failing to do so
+WILL break the chain and require a wipe or a rollback.
+
+To schedule a migration, add it to the `Executive` definition for your
+runtime like this:
+
+``` rust
+pub type Migrations = (
+	pallet_session_validator_management::migrations::v1::LegacyToV1Migration<Runtime>,
+    // ...
+);
+/// Executive: handles dispatch to the various modules.
+pub type Executive = frame_executive::Executive<
+	Runtime,
+	Block,
+	ChainContext,
+	Runtime,
+	AllPalletsWithSystem,
+	Migrations,
+>;
+```
+
+Each migration will be run only once, for the storage version for which it is
+defined, and will update the storage version number.
+
+## V1 (v1.6.0+)
+
+### Changes
+
+This version changes the type used to store committee member information
+from a tuple `(T::AuthorityId, T::AuthorityKeys)` to a generic type
+`T::CommitteeMember`. This type can be arbitrary within normal
+constraints of Substrate runtime types and must implement the
+`CommitteeMember` trait. If your runtime uses `authority-selection-inherents`
+to select its committee, use the `CommitteeMember` type provided by this crate.
+A `CommitteeMember` implementation for the legacy `(T::AuthorityId, T::AuthorityKeys)`
+type is also provided and can be used.
+
+### Migration from Legacy
+
+Migration logic is provided by the `migrations::v1::LegacyToV1Migration` migration.
+It assumes that the types `T::AuthorityId` and `T::AuthorityKeys` do not change as
+part of the same runtime upgrade. The only requirement for the new type
+`T::CommitteeMember` is to implement the trait `From<(T::AuthorityId, T::AuthorityKeys)>`.
+ 

--- a/toolkit/pallets/session-validator-management/src/migrations/mod.rs
+++ b/toolkit/pallets/session-validator-management/src/migrations/mod.rs
@@ -1,0 +1,2 @@
+pub mod v0;
+pub mod v1;

--- a/toolkit/pallets/session-validator-management/src/migrations/v0.rs
+++ b/toolkit/pallets/session-validator-management/src/migrations/v0.rs
@@ -1,0 +1,52 @@
+use frame_support::pallet_prelude::{OptionQuery, ValueQuery, Zero};
+use frame_support::{storage_alias, BoundedVec, CloneNoBound};
+use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
+use scale_info::TypeInfo;
+
+#[derive(CloneNoBound, Encode, Decode, TypeInfo, MaxEncodedLen)]
+#[scale_info(skip_type_params(MaxValidators))]
+pub struct LegacyCommitteeInfo<
+	ScEpochNumber: Clone,
+	AuthorityId: Clone,
+	AuthorityKeys: Clone,
+	MaxValidators,
+> {
+	pub epoch: ScEpochNumber,
+	pub committee: BoundedVec<(AuthorityId, AuthorityKeys), MaxValidators>,
+}
+
+impl<ScEpochNumber, AuthorityId, AuthorityKeys, MaxValidators> Default
+	for LegacyCommitteeInfo<ScEpochNumber, AuthorityId, AuthorityKeys, MaxValidators>
+where
+	AuthorityId: Clone,
+	AuthorityKeys: Clone,
+	ScEpochNumber: Clone + Zero,
+{
+	fn default() -> Self {
+		Self { epoch: ScEpochNumber::zero(), committee: BoundedVec::new() }
+	}
+}
+
+#[storage_alias]
+pub type CurrentCommittee<T: crate::pallet::Config> = StorageValue<
+	crate::Pallet<T>,
+	LegacyCommitteeInfo<
+		<T as crate::pallet::Config>::ScEpochNumber,
+		<T as crate::pallet::Config>::AuthorityId,
+		<T as crate::pallet::Config>::AuthorityKeys,
+		<T as crate::pallet::Config>::MaxValidators,
+	>,
+	ValueQuery,
+>;
+
+#[storage_alias]
+pub type NextCommittee<T: crate::pallet::Config> = StorageValue<
+	crate::Pallet<T>,
+	LegacyCommitteeInfo<
+		<T as crate::pallet::Config>::ScEpochNumber,
+		<T as crate::pallet::Config>::AuthorityId,
+		<T as crate::pallet::Config>::AuthorityKeys,
+		<T as crate::pallet::Config>::MaxValidators,
+	>,
+	OptionQuery,
+>;

--- a/toolkit/pallets/session-validator-management/src/migrations/v1.rs
+++ b/toolkit/pallets/session-validator-management/src/migrations/v1.rs
@@ -1,0 +1,134 @@
+#[cfg(feature = "try-runtime")]
+extern crate alloc;
+use frame_support::traits::UncheckedOnRuntimeUpgrade;
+#[cfg(feature = "try-runtime")]
+use {
+	alloc::vec::Vec, parity_scale_codec::Encode, sp_session_validator_management::CommitteeMember,
+};
+
+use super::v0;
+
+pub struct InnerMigrateV0ToV1<T: crate::Config>(core::marker::PhantomData<T>);
+
+impl<T: crate::pallet::Config> UncheckedOnRuntimeUpgrade for InnerMigrateV0ToV1<T>
+where
+	T::CommitteeMember: From<(T::AuthorityId, T::AuthorityKeys)>,
+{
+	fn on_runtime_upgrade() -> sp_runtime::Weight {
+		use sp_core::Get;
+		use sp_runtime::BoundedVec;
+
+		let current_committee_v0 = v0::CurrentCommittee::<T>::get();
+		let current_committee_v1 = crate::pallet::CommitteeInfo::<
+			T::ScEpochNumber,
+			T::CommitteeMember,
+			T::MaxValidators,
+		> {
+			epoch: current_committee_v0.epoch,
+			committee: BoundedVec::truncate_from(
+				current_committee_v0.committee.into_iter().map(From::from).collect(),
+			),
+		};
+
+		crate::CurrentCommittee::<T>::put(current_committee_v1);
+
+		let Some(next_committee_v0) = v0::NextCommittee::<T>::get() else {
+			return T::DbWeight::get().reads_writes(2, 1);
+		};
+		let next_committee_v1 = crate::pallet::CommitteeInfo::<
+			T::ScEpochNumber,
+			T::CommitteeMember,
+			T::MaxValidators,
+		> {
+			epoch: next_committee_v0.epoch,
+			committee: BoundedVec::truncate_from(
+				next_committee_v0.committee.into_iter().map(From::from).collect(),
+			),
+		};
+
+		crate::NextCommittee::<T>::put(next_committee_v1);
+
+		T::DbWeight::get().reads_writes(2, 2)
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<Vec<u8>, sp_runtime::TryRuntimeError> {
+		let current_committee_v0 = v0::CurrentCommittee::<T>::get();
+		let next_committee_v0 = v0::NextCommittee::<T>::get();
+		Ok((current_committee_v0, next_committee_v0).encode())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn post_upgrade(state: Vec<u8>) -> Result<(), sp_runtime::TryRuntimeError> {
+		use frame_support::ensure;
+		use parity_scale_codec::Decode;
+		use v0::LegacyCommitteeInfo;
+
+		let (current_committee_v0, next_committee_v0): (
+			LegacyCommitteeInfo<
+				T::ScEpochNumber,
+				T::AuthorityId,
+				T::AuthorityKeys,
+				T::MaxValidators,
+			>,
+			Option<
+				LegacyCommitteeInfo<
+					T::ScEpochNumber,
+					T::AuthorityId,
+					T::AuthorityKeys,
+					T::MaxValidators,
+				>,
+			>,
+		) = Decode::decode(&mut state.as_slice())
+			.expect("Previously encoded state should be decodable");
+
+		let current_committee_v1 = crate::CurrentCommittee::<T>::get();
+		let next_committee_v1 = crate::NextCommittee::<T>::get();
+
+		ensure!(
+			current_committee_v0.epoch == current_committee_v1.epoch,
+			"current epoch should be preserved"
+		);
+
+		ensure!(
+			current_committee_v0.committee.to_vec()
+				== (current_committee_v1.committee.iter())
+					.map(|member| (member.authority_id(), member.authority_keys()))
+					.collect::<Vec<_>>(),
+			"current committee membership should be preserved"
+		);
+
+		if next_committee_v0.is_none() && next_committee_v0.is_none() {
+			return Ok(());
+		}
+
+		ensure!(next_committee_v0.is_some(), "V0 next committee should be Some if V1 is");
+		ensure!(next_committee_v1.is_some(), "V1 next committee should be Some if V0 is");
+
+		let next_committee_v0 = next_committee_v0.unwrap();
+		let next_committee_v1 = next_committee_v1.unwrap();
+
+		ensure!(
+			next_committee_v0.epoch == next_committee_v1.epoch,
+			"next epoch should be preserved"
+		);
+
+		ensure!(
+			next_committee_v0.committee.to_vec()
+				== (next_committee_v1.committee.iter())
+					.map(|member| (member.authority_id(), member.authority_keys()))
+					.collect::<Vec<_>>(),
+			"next committee membership should be preserved"
+		);
+
+		Ok(())
+	}
+}
+
+pub type LegacyToV1Migration<T> = frame_support::migrations::VersionedMigration<
+	0, // The migration will only execute when the on-chain storage version is 0
+	1, // The on-chain storage version will be set to 1 after the migration is complete
+	InnerMigrateV0ToV1<T>,
+	crate::pallet::Pallet<T>,
+	<T as frame_system::Config>::DbWeight,
+>;

--- a/toolkit/pallets/session-validator-management/src/mock.rs
+++ b/toolkit/pallets/session-validator-management/src/mock.rs
@@ -91,6 +91,7 @@ impl pallet::Config for Test {
 	type AuthoritySelectionInputs =
 		BoundedVec<(Self::AuthorityId, Self::AuthorityKeys), Self::MaxValidators>;
 	type ScEpochNumber = ScEpochNumber;
+	type CommitteeMember = (Self::AuthorityId, Self::AuthorityKeys);
 
 	fn select_authorities(
 		input: Self::AuthoritySelectionInputs,

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -4,7 +4,7 @@ use crate::permissioned_candidates::{ParsedPermissionedCandidatesKeys, Permissio
 use crate::{config::config_fields, CmdRun};
 use anyhow::{anyhow, Context};
 use serde::de::DeserializeOwned;
-use serde_json::Value as JValue;
+use serde_json::{json, Value as JValue};
 use sidechain_domain::UtxoId;
 
 #[cfg(test)]
@@ -120,7 +120,14 @@ impl CreateChainSpecCmd {
 		let initial_authorities = config
 			.initial_permissioned_candidates_parsed
 			.iter()
-			.map(|c| serde_json::to_value((c.sidechain, c.session_keys())))
+			.map(|c| -> anyhow::Result<serde_json::Value> {
+				Ok(json!({
+					"Permissioned": {
+						"id": serde_json::to_value(c.sidechain)?,
+						"keys": c.session_keys()
+					}
+				}))
+			})
 			.collect::<Result<Vec<serde_json::Value>, _>>()?;
 		let initial_authorities = serde_json::Value::Array(initial_authorities);
 		Self::update_field(

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -285,20 +285,24 @@ fn updated_chain_spec() -> serde_json::Value {
 						},
 						"sessionCommitteeManagement": {
 							"initialAuthorities": [
-								[
-									"KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
-									{
-										"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
-										"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
+								{
+									"Permissioned":{
+										"id": "KW39r9CJjAVzmkf9zQ4YDb2hqfAVGdRqn53eRqyruqpxAP5YL",
+										"keys": {
+											"aura": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
+											"grandpa": "5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu"
+										}
 									}
-								],
-								[
-									"KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
-									{
-										"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
-										"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
+								},
+								{
+									"Permissioned":{
+										"id": "KWByAN7WfZABWS5AoWqxriRmF5f2jnDqy3rB5pfHLGkY93ibN",
+										"keys": {
+											"aura": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+											"grandpa": "5GoNkf6WdbxCFnPdAnYYQyCjAKPJgLNxXwPjwTh6DGg6gN3E"
+										}
 									}
-								]
+								}
 							],
 							"main_chain_scripts": {
 								"committee_candidate_address": "0x002244",

--- a/toolkit/primitives/authority-selection-inherents/Cargo.toml
+++ b/toolkit/primitives/authority-selection-inherents/Cargo.toml
@@ -25,7 +25,7 @@ sp-inherents = { workspace = true }
 sp-runtime = { workspace = true }
 sp-std = { workspace = true }
 thiserror = { workspace = true, optional = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true }
 sp-consensus-slots = { workspace = true }
 
 [dev-dependencies]

--- a/toolkit/primitives/authority-selection-inherents/src/authority_selection_inputs.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/authority_selection_inputs.rs
@@ -13,7 +13,6 @@ pub struct AuthoritySelectionInputs {
 	pub epoch_nonce: EpochNonce,
 }
 
-// #[derive(Debug, PartialEq, Eq, Clone, Decode, thiserror::Error, Serialize, Deserialize)]
 #[cfg(feature = "std")]
 #[derive(Debug, thiserror::Error)]
 pub enum AuthoritySelectionInputsCreationError {
@@ -30,16 +29,14 @@ pub enum AuthoritySelectionInputsCreationError {
 	GetEpochNonceQuery(McEpochNumber, Box<dyn std::error::Error + Send + Sync>),
 }
 
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct RawPermissionedCandidateData {
 	pub sidechain_public_key: SidechainPublicKey,
 	pub aura_public_key: AuraPublicKey,
 	pub grandpa_public_key: GrandpaPublicKey,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct AriadneParameters {
 	pub d_parameter: DParameter,
 	pub permissioned_candidates: Vec<RawPermissionedCandidateData>,

--- a/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/filter_invalid_candidates.rs
@@ -1,5 +1,6 @@
 //! Functionality related to filtering invalid candidates from the candidates
 
+use crate::CommitteeMember;
 use frame_support::pallet_prelude::TypeInfo;
 use parity_scale_codec::{Decode, Encode};
 use plutus::*;
@@ -40,6 +41,23 @@ pub struct PermissionedCandidate<TAccountId, TAccountKeys> {
 pub enum Candidate<TAccountId, TAccountKeys> {
 	Permissioned(PermissionedCandidate<TAccountId, TAccountKeys>),
 	Registered(CandidateWithStake<TAccountId, TAccountKeys>),
+}
+
+impl<AuthorityId, AuthorityKeys> From<Candidate<AuthorityId, AuthorityKeys>>
+	for CommitteeMember<AuthorityId, AuthorityKeys>
+{
+	fn from(candidate: Candidate<AuthorityId, AuthorityKeys>) -> Self {
+		match candidate {
+			Candidate::Permissioned(member) => {
+				Self::Permissioned { id: member.account_id, keys: member.account_keys }
+			},
+			Candidate::Registered(member) => Self::Registered {
+				id: member.account_id,
+				keys: member.account_keys,
+				stake_pool_pub_key: member.stake_pool_pub_key,
+			},
+		}
+	}
 }
 
 impl<TAccountId, TAccountKeys> Candidate<TAccountId, TAccountKeys> {

--- a/toolkit/primitives/authority-selection-inherents/src/lib.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/lib.rs
@@ -2,6 +2,12 @@
 
 extern crate alloc;
 
+use scale_info::TypeInfo;
+use serde::{Deserialize, Serialize};
+use sidechain_domain::StakePoolPublicKey;
+use sp_core::{Decode, Encode, MaxEncodedLen};
+use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
+
 pub mod ariadne_inherent_data_provider;
 pub mod authority_selection_inputs;
 pub mod filter_invalid_candidates;
@@ -14,3 +20,46 @@ mod tests;
 
 #[cfg(any(test, feature = "mock"))]
 pub mod mock;
+
+#[derive(
+	Serialize, Deserialize, Clone, Encode, Decode, TypeInfo, MaxEncodedLen, Debug, PartialEq, Eq,
+)]
+pub enum CommitteeMember<AuthorityId, AuthorityKeys> {
+	Permissioned { id: AuthorityId, keys: AuthorityKeys },
+	Registered { id: AuthorityId, keys: AuthorityKeys, stake_pool_pub_key: StakePoolPublicKey },
+}
+
+impl<AuthorityId, AuthorityKeys> From<(AuthorityId, AuthorityKeys)>
+	for CommitteeMember<AuthorityId, AuthorityKeys>
+{
+	fn from((id, keys): (AuthorityId, AuthorityKeys)) -> Self {
+		Self::Permissioned { id, keys }
+	}
+}
+
+impl<AuthorityId, AuthorityKeys> CommitteeMember<AuthorityId, AuthorityKeys> {
+	pub fn permissioned(id: AuthorityId, keys: AuthorityKeys) -> Self {
+		Self::Permissioned { id, keys }
+	}
+}
+
+impl<AuthorityId: Clone, AuthorityKeys: Clone> CommitteeMemberT
+	for CommitteeMember<AuthorityId, AuthorityKeys>
+{
+	type AuthorityId = AuthorityId;
+	type AuthorityKeys = AuthorityKeys;
+
+	fn authority_id(&self) -> AuthorityId {
+		match self {
+			Self::Permissioned { id, .. } => id.clone(),
+			Self::Registered { id, .. } => id.clone(),
+		}
+	}
+
+	fn authority_keys(&self) -> AuthorityKeys {
+		match self {
+			Self::Permissioned { keys, .. } => keys.clone(),
+			Self::Registered { keys, .. } => keys.clone(),
+		}
+	}
+}

--- a/toolkit/primitives/session-manager/src/lib.rs
+++ b/toolkit/primitives/session-manager/src/lib.rs
@@ -4,6 +4,7 @@ use core::marker::PhantomData;
 use derive_new::new;
 use frame_system::pallet_prelude::BlockNumberFor;
 use log::info;
+use pallet_session_validator_management::CommitteeMember;
 use sp_staking::SessionIndex;
 use sp_std::vec::Vec;
 
@@ -27,7 +28,7 @@ impl<T: pallet_session_validator_management::Config + pallet_session::Config>
 			pallet_session_validator_management::Pallet::<T>::current_committee_storage()
 				.committee
 				.into_iter()
-				.map(|(id, keys)| (id.into(), keys))
+				.map(|member| (member.authority_id().into(), member.authority_keys()))
 				.collect::<Vec<_>>(),
 		)
 	}

--- a/toolkit/primitives/session-manager/src/pallet_session_support.rs
+++ b/toolkit/primitives/session-manager/src/pallet_session_support.rs
@@ -2,6 +2,7 @@ use core::marker::PhantomData;
 use derive_new::new;
 use frame_system::pallet_prelude::BlockNumberFor;
 use log::{debug, warn};
+use pallet_session_validator_management::CommitteeMember;
 use sp_staking::SessionIndex;
 use sp_std::vec::Vec;
 
@@ -23,7 +24,7 @@ impl<T: pallet_session_validator_management::Config + pallet_session::Config>
 			pallet_session_validator_management::Pallet::<T>::current_committee_storage()
 				.committee
 				.into_iter()
-				.map(|(id, _)| id.into())
+				.map(|member| member.authority_id().into())
 				.collect::<Vec<_>>(),
 		)
 	}

--- a/toolkit/primitives/session-validator-management/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/src/lib.rs
@@ -47,6 +47,23 @@ impl IsFatalError for InherentError {
 	}
 }
 
+pub trait CommitteeMember {
+	type AuthorityId;
+	type AuthorityKeys;
+	fn authority_id(&self) -> Self::AuthorityId;
+	fn authority_keys(&self) -> Self::AuthorityKeys;
+}
+impl<AuthorityId: Clone, AuthorityKeys: Clone> CommitteeMember for (AuthorityId, AuthorityKeys) {
+	type AuthorityId = AuthorityId;
+	type AuthorityKeys = AuthorityKeys;
+	fn authority_id(&self) -> AuthorityId {
+		self.0.clone()
+	}
+	fn authority_keys(&self) -> AuthorityKeys {
+		self.1.clone()
+	}
+}
+
 #[cfg(feature = "std")]
 impl From<InherentError> for sp_inherents::Error {
 	fn from(value: InherentError) -> Self {


### PR DESCRIPTION
# Description

IMPORTANT: This is a breaking change and must not be merged without a storage migration ready.

This PR's goal is to make previously missing committee member data available in the runtime: MC pubkey and type of candidate (permissioned, trustless)

* Makes committee member data a generic type in `pallet-session-validator-management::Config`
* Provides a `CommitteeMemberInfo` enum in the runtime to instantiate this generic type, which distinguishes between trustless and permissioned members and contains MC Public Key for the former

Follow up changes necessary:
- [x] storage migration: easiest way is to treat all members stored on runtime upgrade as permissioned 
- [ ] wizards update: at least build-spec
- [x] documentation / migration guide

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

