### PR TITLE
chore: remove unused packages from devshell

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -49,17 +49,14 @@
 
           # local development tools
           rustToolchain
-          nodejs
           gawk
           cargo-edit
           cargo-license
-          perl
 
           # infra packages
           earthly
           awscli2
           kubectl
-          kubernetes-helm
 
           # our local packages
           self'.packages.cardano-cli


### PR DESCRIPTION
# Description

* nodejs - I'm not aware we need it (something for docs?)
* perl - I recall it was used in some CI, but I can't find it anymore
* kubernetes-helm - we don't have any helm files in this repo, to deploy our private infra we have a private repo, where there are helm files. I keep kubectl, becuase even in docs we use it to open ports to Ogmios or Db-sync from private devnet
