### PR TITLE
change: Update Validators Management Pallet's runtime API and RPC

### DIFF
--- a/node/node/src/inherent_data.rs
+++ b/node/node/src/inherent_data.rs
@@ -2,6 +2,7 @@ use authority_selection_inherents::ariadne_inherent_data_provider::AriadneInhere
 use authority_selection_inherents::authority_selection_inputs::{
 	AuthoritySelectionDataSource, AuthoritySelectionInputs,
 };
+use authority_selection_inherents::CommitteeMember;
 use derive_new::new;
 use jsonrpsee::core::async_trait;
 use sc_consensus_aura::{find_pre_digest, SlotDuration};
@@ -10,10 +11,9 @@ use sidechain_domain::mainchain_epoch::MainchainEpochConfig;
 use sidechain_domain::{McBlockHash, ScEpochNumber};
 use sidechain_mc_hash::McHashDataSource;
 use sidechain_mc_hash::McHashInherentDataProvider as McHashIDP;
-use sidechain_runtime::{
-	opaque::{Block, SessionKeys},
-	BeneficiaryId, CrossChainPublic,
-};
+use sidechain_runtime::opaque::SessionKeys;
+use sidechain_runtime::CrossChainPublic;
+use sidechain_runtime::{opaque::Block, BeneficiaryId};
 use sidechain_slots::ScSlotConfig;
 use sp_api::ProvideRuntimeApi;
 use sp_block_production_log::BlockProducerIdInherentProvider;
@@ -51,8 +51,7 @@ where
 	T: HeaderBackend<Block>,
 	T::Api: SessionValidatorManagementApi<
 		Block,
-		SessionKeys,
-		CrossChainPublic,
+		CommitteeMember<CrossChainPublic, SessionKeys>,
 		AuthoritySelectionInputs,
 		ScEpochNumber,
 	>,
@@ -149,8 +148,7 @@ where
 	T: ProvideRuntimeApi<Block> + Send + Sync + HeaderBackend<Block>,
 	T::Api: SessionValidatorManagementApi<
 		Block,
-		SessionKeys,
-		CrossChainPublic,
+		CommitteeMember<CrossChainPublic, SessionKeys>,
 		AuthoritySelectionInputs,
 		ScEpochNumber,
 	>,

--- a/node/node/src/rpc.rs
+++ b/node/node/src/rpc.rs
@@ -6,8 +6,10 @@
 #![warn(missing_docs)]
 
 use crate::main_chain_follower::DataSources;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
 use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
+use authority_selection_inherents::{
+	authority_selection_inputs::AuthoritySelectionInputs, CommitteeMember,
+};
 use jsonrpsee::RpcModule;
 use pallet_session_validator_management_rpc::*;
 use pallet_sidechain_rpc::*;
@@ -19,12 +21,11 @@ use sc_rpc::SubscriptionTaskExecutor;
 use sc_transaction_pool_api::TransactionPool;
 use sidechain_domain::mainchain_epoch::MainchainEpochConfig;
 use sidechain_domain::ScEpochNumber;
-use sidechain_runtime::CrossChainPublic;
 use sidechain_runtime::{
 	opaque::{Block, SessionKeys},
 	AccountId, Balance, Nonce,
 };
-use sidechain_runtime::{BlockNumber, Hash};
+use sidechain_runtime::{BlockNumber, CrossChainPublic, Hash};
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
@@ -77,8 +78,7 @@ where
 	C::Api: sp_sidechain::GetSidechainStatus<Block>,
 	C::Api: sp_session_validator_management::SessionValidatorManagementApi<
 		Block,
-		SessionKeys,
-		CrossChainPublic,
+		CommitteeMember<CrossChainPublic, SessionKeys>,
 		AuthoritySelectionInputs,
 		ScEpochNumber,
 	>,

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -15,6 +15,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 use sp_runtime::AccountId32;
+use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
 use sp_session_validator_management::SessionValidatorManagementApi;
 use sp_session_validator_management_query::commands::*;
 use sp_session_validator_management_query::SessionValidatorManagementQuery;
@@ -102,7 +103,7 @@ pub enum PartnerChainsSubcommand {
 	Wizards(partner_chains_cli::Command),
 }
 
-pub fn run<Cli, Block, CrossChainPublic, SessionKeys, Client>(
+pub fn run<Cli, Block, CommitteeMember, Client>(
 	cli: &Cli,
 	get_deps: impl FnOnce(
 		sc_service::Configuration,
@@ -119,15 +120,15 @@ where
 		+ GetSidechainStatus<Block>
 		+ SessionValidatorManagementApi<
 			Block,
-			SessionKeys,
-			CrossChainPublic,
+			CommitteeMember,
 			AuthoritySelectionInputs,
 			ScEpochNumber,
 		> + CandidateValidationApi<Block>,
 	Block: BlockT,
 	NumberFor<Block>: From<u32> + Into<u32>,
-	SessionKeys: Decode + Send + Sync + 'static,
-	CrossChainPublic: Decode + Encode + AsRef<[u8]> + Send + Sync + 'static,
+	CommitteeMember: CommitteeMemberT + Encode + Decode + Send + Sync + 'static,
+	CommitteeMember::AuthorityId: Decode + Encode + AsRef<[u8]> + Send + Sync + 'static,
+	CommitteeMember::AuthorityKeys: Decode + Encode,
 {
 	match cmd {
 		PartnerChainsSubcommand::SidechainParams(cmd) => {

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -354,16 +354,12 @@ pub mod pallet {
 			T::select_authorities(authority_selection_inputs, sidechain_epoch).map(|c| c.to_vec())
 		}
 
-		pub fn rotate_committee_to_next_epoch() -> Option<Vec<(T::AccountId, T::AuthorityKeys)>> {
+		pub fn rotate_committee_to_next_epoch() -> Option<Vec<T::CommitteeMember>> {
 			let next_committee = NextCommittee::<T>::take()?;
 
 			CurrentCommittee::<T>::put(next_committee.clone());
 
-			let validators: Vec<(T::AccountId, T::AuthorityKeys)> = next_committee
-				.committee
-				.into_iter()
-				.map(|member| (member.authority_id().into(), member.authority_keys()))
-				.collect();
+			let validators = next_committee.committee.to_vec();
 			let len = validators.len();
 			info!(
 				"Committee rotated: Returning {len} validators, stored in epoch {}",
@@ -372,28 +368,14 @@ pub mod pallet {
 			Some(validators)
 		}
 
-		pub fn get_current_committee() -> (T::ScEpochNumber, Vec<T::AuthorityId>) {
+		pub fn get_current_committee() -> (T::ScEpochNumber, Vec<T::CommitteeMember>) {
 			let committee_info = CurrentCommittee::<T>::get();
-			(
-				committee_info.epoch,
-				committee_info
-					.committee
-					.into_iter()
-					.map(|member| member.authority_id())
-					.collect(),
-			)
+			(committee_info.epoch, committee_info.committee.to_vec())
 		}
 
-		pub fn get_next_committee() -> Option<(T::ScEpochNumber, Vec<T::AuthorityId>)> {
+		pub fn get_next_committee() -> Option<(T::ScEpochNumber, Vec<T::CommitteeMember>)> {
 			let committee_info = NextCommittee::<T>::get()?;
-			Some((
-				committee_info.epoch,
-				committee_info
-					.committee
-					.into_iter()
-					.map(|member| member.authority_id())
-					.collect(),
-			))
+			Some((committee_info.epoch, committee_info.committee.to_vec()))
 		}
 
 		pub fn get_main_chain_scripts() -> MainChainScripts {

--- a/toolkit/primitives/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
@@ -2,6 +2,7 @@
 use crate::authority_selection_inputs::AuthoritySelectionDataSource;
 use crate::authority_selection_inputs::AuthoritySelectionInputs;
 use parity_scale_codec::{Decode, Encode};
+use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
 #[cfg(feature = "std")]
 use {
 	crate::authority_selection_inputs::AuthoritySelectionInputsCreationError,
@@ -40,7 +41,7 @@ impl AriadneInherentDataProvider {
 		})
 	}
 
-	pub async fn new<Block, SessionKeys, CrossChainPublic, T>(
+	pub async fn new<Block, CommitteeMember, T>(
 		client: &T,
 		sc_slot_config: &ScSlotConfig,
 		mc_epoch_config: &MainchainEpochConfig,
@@ -50,14 +51,14 @@ impl AriadneInherentDataProvider {
 		mc_reference_epoch: McEpochNumber,
 	) -> Result<Self, InherentProviderCreationError>
 	where
-		SessionKeys: Decode,
-		CrossChainPublic: Decode + Encode,
+		CommitteeMember: CommitteeMemberT + Decode + Encode,
+		CommitteeMember::AuthorityKeys: Decode + Encode,
+		CommitteeMember::AuthorityId: Decode + Encode,
 		Block: BlockT,
 		T: ProvideRuntimeApi<Block> + Send + Sync,
 		T::Api: SessionValidatorManagementApi<
 			Block,
-			SessionKeys,
-			CrossChainPublic,
+			CommitteeMember,
 			AuthoritySelectionInputs,
 			ScEpochNumber,
 		>,
@@ -103,7 +104,7 @@ pub enum InherentProviderCreationError {
 }
 
 #[cfg(feature = "std")]
-fn mc_epoch_for_next_ariadne_cidp<Block, SessionKeys, CrossChainPublic, T>(
+fn mc_epoch_for_next_ariadne_cidp<Block, CommitteeMember, T>(
 	client: &T,
 	sc_slot_config: &ScSlotConfig,
 	epoch_config: &MainchainEpochConfig,
@@ -112,13 +113,13 @@ fn mc_epoch_for_next_ariadne_cidp<Block, SessionKeys, CrossChainPublic, T>(
 ) -> Result<McEpochNumber, InherentProviderCreationError>
 where
 	Block: BlockT,
-	SessionKeys: Decode,
-	CrossChainPublic: Decode + Encode,
+	CommitteeMember: Decode + Encode + CommitteeMemberT,
+	CommitteeMember::AuthorityKeys: Decode + Encode,
+	CommitteeMember::AuthorityId: Decode + Encode,
 	T: ProvideRuntimeApi<Block> + Send + Sync,
 	T::Api: SessionValidatorManagementApi<
 		Block,
-		SessionKeys,
-		CrossChainPublic,
+		CommitteeMember,
 		AuthoritySelectionInputs,
 		ScEpochNumber,
 	>,

--- a/toolkit/primitives/authority-selection-inherents/src/runtime_api_mock.rs
+++ b/toolkit/primitives/authority-selection-inherents/src/runtime_api_mock.rs
@@ -21,10 +21,10 @@ impl sp_api::ProvideRuntimeApi<Block> for TestApi {
 }
 
 sp_api::mock_impl_runtime_apis! {
-	impl SessionValidatorManagementApi<Block, AccountKeys, CrossChainPublicKey, AuthoritySelectionInputs, ScEpochNumber>
+	impl SessionValidatorManagementApi<Block, (CrossChainPublicKey, AccountKeys), AuthoritySelectionInputs, ScEpochNumber>
 		for TestApi
 	{
-		fn get_current_committee() -> (ScEpochNumber, Vec<CrossChainPublicKey>) {
+		fn get_current_committee() -> (ScEpochNumber, Vec<(CrossChainPublicKey, AccountKeys)>) {
 			unimplemented!()
 		}
 		fn get_next_unset_epoch_number() -> sidechain_domain::ScEpochNumber {

--- a/toolkit/primitives/session-manager/src/lib.rs
+++ b/toolkit/primitives/session-manager/src/lib.rs
@@ -43,7 +43,10 @@ impl<T: pallet_session_validator_management::Config + pallet_session::Config>
 				.expect(
 					"Session should never end without current epoch validators defined. \
 				Check ShouldEndSession implementation or if it is used before starting new session",
-				),
+				)
+				.into_iter()
+				.map(|member| (member.authority_id().into(), member.authority_keys()))
+				.collect(),
 		)
 	}
 

--- a/toolkit/primitives/session-manager/src/pallet_session_support.rs
+++ b/toolkit/primitives/session-manager/src/pallet_session_support.rs
@@ -39,7 +39,7 @@ impl<T: pallet_session_validator_management::Config + pallet_session::Config>
 			pallet_session_validator_management::Pallet::<T>::rotate_committee_to_next_epoch()
 				.expect(
 					"PalletSessionSupport: Session should never end without current epoch validators defined. This may be caused by ShouldEndSession invalid behavior or being called before starting new session",
-				).into_iter().map(|(id, _)| id).collect::<Vec<_>>(),
+				).into_iter().map(|member| member.authority_id().into()).collect::<Vec<_>>(),
 		)
 	}
 

--- a/toolkit/primitives/session-validator-management/Cargo.toml
+++ b/toolkit/primitives/session-validator-management/Cargo.toml
@@ -28,8 +28,11 @@ std = [
     "sp-inherents/std",
     "sp-std/std",
     "sp-runtime/std",
+    "sidechain-domain/std",
+    "sidechain-domain/serde",
     "thiserror",
-    "envy"
+    "envy",
+    "serde"
 ]
 serde = [
 	"dep:serde",

--- a/toolkit/primitives/session-validator-management/query/Cargo.toml
+++ b/toolkit/primitives/session-validator-management/query/Cargo.toml
@@ -29,3 +29,4 @@ hex-literal = { workspace = true }
 minicbor = { workspace = true }
 plutus-datum-derive = { workspace = true }
 tokio = { workspace = true }
+authority-selection-inherents = { workspace = true, features = ["mock"] }

--- a/toolkit/primitives/session-validator-management/query/src/get_registrations.rs
+++ b/toolkit/primitives/session-validator-management/query/src/get_registrations.rs
@@ -9,12 +9,8 @@ use sidechain_domain::{
 use sp_core::bytes::to_hex;
 use sp_sidechain::GetGenesisUtxo;
 
-impl<
-		C,
-		Block,
-		SessionKeys: parity_scale_codec::Decode + Send + Sync + 'static,
-		CrossChainPublic,
-	> SessionValidatorManagementQuery<C, Block, SessionKeys, CrossChainPublic>
+impl<C, Block, SessionKeys: parity_scale_codec::Decode + Send + Sync + 'static>
+	SessionValidatorManagementQuery<C, Block, SessionKeys>
 where
 	Block: BlockT,
 	C: HeaderBackend<Block>,

--- a/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
+++ b/toolkit/primitives/session-validator-management/query/src/tests/mod.rs
@@ -34,7 +34,7 @@ async fn get_epoch_committee() {
 			sidechain_epoch: 777,
 			committee: expected_initial_committee
 				.into_iter()
-				.map(|key| CommitteeMember::new(key.as_ref()))
+				.map(|key| CommitteeMember::new(key.authority_id().as_ref()))
 				.collect()
 		}
 	)
@@ -69,7 +69,7 @@ async fn get_epoch_committee_should_return_initial_committee_for_genesis_and_fir
 		runtime_api_mock::committee_for_epoch(conversion::GENESIS_EPOCH);
 	let expected_initial_committee: Vec<CommitteeMember> = expected_initial_committee
 		.into_iter()
-		.map(|key| CommitteeMember::new(key.as_ref()))
+		.map(|key| CommitteeMember::new(key.authority_id().as_ref()))
 		.collect();
 
 	let GetCommitteeResponse {
@@ -95,7 +95,7 @@ async fn get_epoch_committee_should_work_correctly_for_next_epoch() {
 
 	let expected_committee: Vec<_> = runtime_api_mock::committee_for_epoch(epoch)
 		.into_iter()
-		.map(|key| CommitteeMember::new(key.as_ref()))
+		.map(|key| CommitteeMember::new(key.authority_id().as_ref()))
 		.collect();
 
 	assert_eq!(

--- a/toolkit/primitives/session-validator-management/src/lib.rs
+++ b/toolkit/primitives/session-validator-management/src/lib.rs
@@ -107,19 +107,35 @@ impl MainChainScripts {
 }
 
 sp_api::decl_runtime_apis! {
+	#[api_version(2)]
 	pub trait SessionValidatorManagementApi<
-		SessionKeys: parity_scale_codec::Decode,
-		CrossChainPublic: parity_scale_codec::Decode + parity_scale_codec::Encode,
+		CommitteeMember: parity_scale_codec::Decode + parity_scale_codec::Encode + crate::CommitteeMember,
 		AuthoritySelectionInputs: parity_scale_codec::Encode,
 		ScEpochNumber: parity_scale_codec::Encode + parity_scale_codec::Decode
-	> {
+	> where
+	CommitteeMember::AuthorityId: Encode + Decode,
+	CommitteeMember::AuthorityKeys: Encode + Decode,
+	{
 		fn get_main_chain_scripts() -> MainChainScripts;
-		fn get_current_committee() -> (ScEpochNumber, sp_std::vec::Vec<CrossChainPublic>);
-		fn get_next_committee() -> Option<(ScEpochNumber, sp_std::vec::Vec<CrossChainPublic>)>;
 		fn get_next_unset_epoch_number() -> ScEpochNumber;
+
+		#[changed_in(2)]
+		fn get_current_committee() -> (ScEpochNumber, sp_std::vec::Vec<CommitteeMember::AuthorityId>);
+		fn get_current_committee() -> (ScEpochNumber, sp_std::vec::Vec<CommitteeMember>);
+
+		#[changed_in(2)]
+		fn get_next_committee() -> Option<(ScEpochNumber, sp_std::vec::Vec<CommitteeMember::AuthorityId>)>;
+		fn get_next_committee() -> Option<(ScEpochNumber, sp_std::vec::Vec<CommitteeMember>)>;
+
+		#[changed_in(2)]
 		fn calculate_committee(
 			authority_selection_inputs: AuthoritySelectionInputs,
 			sidechain_epoch: ScEpochNumber
-		) -> Option<sp_std::vec::Vec<(CrossChainPublic, SessionKeys)>>;
+		) -> Option<sp_std::vec::Vec<(CommitteeMember::AuthorityId, CommitteeMember::AuthorityKeys)>>;
+
+		fn calculate_committee(
+			authority_selection_inputs: AuthoritySelectionInputs,
+			sidechain_epoch: ScEpochNumber
+		) -> Option<sp_std::vec::Vec<CommitteeMember>>;
 	}
 }


### PR DESCRIPTION
# Description

- Adds V2 methods in `SessionValidatorManagementApi` that `CommitteeMember` where possible.
- Updates `pallet-session-validator-management-query` to be version-aware
- Various updates in the test mocks required by the changes above

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

