### PR TITLE
Fix e2e python env in nix shell for linux

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -9,18 +9,20 @@
           file = ../../rust-toolchain.toml;
           sha256 = "VZZnlyP69+Y3crrLHQyJirqlHrTtGTsyiSnZB8jEvVo=";
         };
-    in {
+    in
+    {
       devShells = {
         default = pkgs.mkShell {
           # envs needed for rust toochain
           RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
           LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
-          LD_LIBRARY_PATH = "${rustToolchain}/lib";
+          LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [ rustToolchain pkgs.stdenv.cc.cc pkgs.libz ];
           # https://github.com/NixOS/nixpkgs/issues/370494#issuecomment-2625163369
-          CFLAGS = if isLinux then
-            "-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE"
-          else
-            "";
+          CFLAGS =
+            if isLinux then
+              "-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE"
+            else
+              "";
 
           # envs needed in order to construct some of the rust crates
           ROCKSDB_LIB_DIR = "${pkgs.rocksdb}/lib/";

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -14,8 +14,7 @@ Welcome to `Partner Chains Tests`, a powerful and flexible test automation frame
 
 ## Installation
 
-1. Install `python 3.12` and `pip`. At this point, python from nix devshell does not work with e2e-tests, please install a separate one in your system.
-2. Create and activate virtual environment
+1. Create and activate virtual environment
 
 ```bash
   pip install virtualenv
@@ -23,8 +22,8 @@ Welcome to `Partner Chains Tests`, a powerful and flexible test automation frame
   source venv/bin/activate
 ```
 
-3. Install requirements `pip install -r requirements.txt`.
-4. Install sops to [manage keys](/e2e-tests/docs/secrets.md). You can also configure [your own keys with sops](/e2e-tests/docs/configure-sops.md)
+2. Install requirements `pip install -r requirements.txt`.
+3. Install sops to [manage keys](/e2e-tests/docs/secrets.md). You can also configure [your own keys with sops](/e2e-tests/docs/configure-sops.md)
 
 ## Getting Started
 


### PR DESCRIPTION
This change extends the LD_LIBRARY_PATH to include libs required by numpy. This wouldn't be necessary if we were providing python packages through Nix but we aren't so we need to make them visible

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
