### PR TITLE
test: fix non hex number in address association test

### DIFF
--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -5,6 +5,6 @@
 venv/
 contractlog.json
 reports
-debug.log
+debug*.log
 .vscode/settings.json
 my_env/

--- a/e2e-tests/pytest.ini
+++ b/e2e-tests/pytest.ini
@@ -21,9 +21,9 @@ junit_duration_report = call
 log_format = %(asctime)s %(levelname)-8s [logger=%(name)s, file=%(filename)s:%(lineno)d] %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S %Z
 log_cli = true
-log_cli_level = info
+log_cli_level = INFO
 log_file = debug.log
-log_file_level = debug
+log_file_level = DEBUG
 log_file_format = %(asctime)s %(levelname)-8s [logger=%(name)s, file=%(filename)s:%(lineno)d] %(message)s
 log_file_date_format = %Y-%m-%d %H:%M:%S %Z
 addopts = -ra

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -750,6 +750,6 @@ class SubstrateApi(BlockchainApi):
         return tx
 
     def get_address_association(self, stake_key_hash):
-        result = self.substrate.query("AddressAssociations", "AddressAssociations", [hex(int(stake_key_hash, 16))])
+        result = self.substrate.query("AddressAssociations", "AddressAssociations", [f"0x{stake_key_hash}"])
         logger.debug(f"Address association for {stake_key_hash}: {result}")
         return result.value


### PR DESCRIPTION
fixes:
- stake key hash conversion to hex rairly could be broken if the leading number was 0

added:
- create one log file for each thread