### PR TITLE
change: require block production log pallet inherent only after data becomes available

### DIFF
--- a/node/node/src/tests/runtime_api_mock.rs
+++ b/node/node/src/tests/runtime_api_mock.rs
@@ -114,14 +114,14 @@ sp_api::mock_impl_runtime_apis! {
 	}
 
 	impl sp_block_production_log::BlockProductionLogApi<Block, CommitteeMember<CrossChainPublic, SessionKeys>> for TestApi {
-		fn get_author(_slot: Slot) -> CommitteeMember<CrossChainPublic, SessionKeys> {
-			CommitteeMember::permissioned(
+		fn get_author(_slot: Slot) -> Option<CommitteeMember<CrossChainPublic, SessionKeys>> {
+			Some(CommitteeMember::permissioned(
 				ecdsa::Public::from_raw(hex!("000000000000000000000000000000000000000000000000000000000000000001")).into(),
 				SessionKeys {
 					aura: sr25519::Public::default().into(),
 					grandpa: ed25519::Public::default().into()
 				}
-			)
+			))
 		}
 	}
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -191,7 +191,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	//   `spec_version`, and `authoring_version` are the same between Wasm and native.
 	// This value is set to 100 to notify Polkadot-JS App (https://polkadot.js.org/apps) to use
 	//   the compatible custom types.
-	spec_version: 150,
+	spec_version: 151,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,
@@ -950,9 +950,8 @@ impl_runtime_apis! {
 	}
 
 	impl sp_block_production_log::BlockProductionLogApi<Block, CommitteeMember<CrossChainPublic, SessionKeys>>  for Runtime {
-		fn get_author(slot: Slot) -> CommitteeMember<CrossChainPublic, SessionKeys> {
+		fn get_author(slot: Slot) -> Option<CommitteeMember<CrossChainPublic, SessionKeys>> {
 			 SessionCommitteeManagement::get_current_authority_round_robin(*slot as usize)
-				.expect("Slot modulo committee size is a valid index unless committee is missing")
 		}
 	}
 

--- a/toolkit/pallets/block-production-log/src/lib.rs
+++ b/toolkit/pallets/block-production-log/src/lib.rs
@@ -43,6 +43,11 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type LatestBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, OptionQuery>;
 
+	/// This flag keeps track of whether the pallet has been initialized by receiving non-empty inherent data.
+	/// In initialized state, the inherent is requires for every block.
+	#[pallet::storage]
+	pub type Initialized<T: Config> = StorageValue<_, bool, ValueQuery>;
+
 	#[pallet::inherent]
 	impl<T: Config> ProvideInherent for Pallet<T> {
 		type Call = Call<T>;
@@ -50,19 +55,22 @@ pub mod pallet {
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
 		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
-			let block_producer_id = data
-				.get_data::<T::BlockProducerId>(&Self::INHERENT_IDENTIFIER)
-				.expect("Block Production Log inherent data not correctly encoded")
-				.expect("Block Production Log inherent data must be provided");
-			Some(Call::append { block_producer_id })
+			Self::decode_inherent_data(data)
+				.unwrap()
+				.map(|block_producer_id| Call::append { block_producer_id })
 		}
 
 		fn is_inherent(call: &Self::Call) -> bool {
 			matches!(call, Call::append { .. })
 		}
 
-		fn is_inherent_required(_: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
-			Ok(Some(Self::Error::InherentRequired))
+		fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
+			let has_data = Self::decode_inherent_data(data)?.is_some();
+			if has_data || Initialized::<T>::get() {
+				Ok(Some(Self::Error::InherentRequired))
+			} else {
+				Ok(None)
+			}
 		}
 	}
 
@@ -97,16 +105,23 @@ pub mod pallet {
 	#[pallet::hooks]
 	impl<T: Config> Hooks<BlockNumberFor<T>> for Pallet<T> {
 		fn on_finalize(block: BlockNumberFor<T>) {
-			let block_producer_id =
-				CurrentProducer::<T>::take().expect("Author is set before on_finalize; qed");
-
-			log::info!("👷 Block {block:?} producer is {block_producer_id:?}");
-
-			Log::<T>::append((T::current_slot(), block_producer_id))
+			if let Some(block_producer_id) = CurrentProducer::<T>::take() {
+				log::info!("👷 Block {block:?} producer is {block_producer_id:?}");
+				Log::<T>::append((T::current_slot(), block_producer_id));
+				Initialized::<T>::put(true);
+			} else {
+				log::warn!("👷 Block {block:?} producer not set. This should occur only at the beginning of the production log pallet's lifetime.")
+			}
 		}
 	}
 
 	impl<T: Config> Pallet<T> {
+		fn decode_inherent_data(
+			data: &InherentData,
+		) -> Result<Option<T::BlockProducerId>, InherentError> {
+			data.get_data::<T::BlockProducerId>(&Self::INHERENT_IDENTIFIER)
+				.map_err(|_| InherentError::InvalidData)
+		}
 		pub fn take_prefix(slot: &Slot) -> Vec<(Slot, T::BlockProducerId)> {
 			let removed_prefix = Log::<T>::mutate(|log| {
 				let pos = log.partition_point(|(s, _)| s <= slot);

--- a/toolkit/pallets/block-production-log/src/lib.rs
+++ b/toolkit/pallets/block-production-log/src/lib.rs
@@ -43,11 +43,6 @@ pub mod pallet {
 	#[pallet::storage]
 	pub type LatestBlock<T: Config> = StorageValue<_, BlockNumberFor<T>, OptionQuery>;
 
-	/// This flag keeps track of whether the pallet has been initialized by receiving non-empty inherent data.
-	/// In initialized state, the inherent is requires for every block.
-	#[pallet::storage]
-	pub type Initialized<T: Config> = StorageValue<_, bool, ValueQuery>;
-
 	#[pallet::inherent]
 	impl<T: Config> ProvideInherent for Pallet<T> {
 		type Call = Call<T>;
@@ -66,7 +61,7 @@ pub mod pallet {
 
 		fn is_inherent_required(data: &InherentData) -> Result<Option<Self::Error>, Self::Error> {
 			let has_data = Self::decode_inherent_data(data)?.is_some();
-			if has_data || Initialized::<T>::get() {
+			if has_data || LatestBlock::<T>::get().is_some() {
 				Ok(Some(Self::Error::InherentRequired))
 			} else {
 				Ok(None)
@@ -108,7 +103,6 @@ pub mod pallet {
 			if let Some(block_producer_id) = CurrentProducer::<T>::take() {
 				log::info!("👷 Block {block:?} producer is {block_producer_id:?}");
 				Log::<T>::append((T::current_slot(), block_producer_id));
-				Initialized::<T>::put(true);
 			} else {
 				log::warn!("👷 Block {block:?} producer not set. This should occur only at the beginning of the production log pallet's lifetime.")
 			}

--- a/toolkit/pallets/block-production-log/src/test.rs
+++ b/toolkit/pallets/block-production-log/src/test.rs
@@ -28,7 +28,6 @@ fn first_append_should_succeed() {
 		Pallet::<Test>::on_finalize(System::block_number());
 
 		assert_eq!(Log::<Test>::get().to_vec(), vec![(Slot::from(1001000), make_id(1))]);
-		assert_eq!(Initialized::<Test>::get(), true);
 	})
 }
 
@@ -105,7 +104,7 @@ fn inherent_is_required_if_data_is_present() {
 #[test]
 fn inherent_is_required_if_data_is_not_present_but_pallet_is_initialized() {
 	new_test_ext().execute_with(|| {
-		Initialized::<Test>::put(true);
+		LatestBlock::<Test>::put(1u64);
 		let inherent_data = InherentData::new();
 		let result = Pallet::<Test>::is_inherent_required(&inherent_data);
 

--- a/toolkit/pallets/session-validator-management/src/lib.rs
+++ b/toolkit/pallets/session-validator-management/src/lib.rs
@@ -316,6 +316,9 @@ pub mod pallet {
 
 		pub fn get_current_authority_round_robin(index: usize) -> Option<T::CommitteeMember> {
 			let committee = CurrentCommittee::<T>::get().committee;
+			if committee.is_empty() {
+				return None;
+			}
 
 			committee.get(index % committee.len() as usize).cloned()
 		}


### PR DESCRIPTION
# Description

- if `LastBlock` is empty, the pallet's inherent is NOT required. it becomes required, once the storage is set.
- changes the `get_current_author` API method to return Option, and the InherentDataProvider

The rationale for this is to allow the pallet to be added as part of a wider runtime upgrade and avoid issues on the first block after the upgrade, caused by access to yet-unmigrated storages. This is achieved by treating the `LastBlock` as an initialized state flag.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [ ] CI passes. See note on CI.
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG Partner Chains developers to do this
for you.

