### PR TITLE
test: one log file per worker

### DIFF
--- a/.github/actions/tests/local-environment-tests/action.yml
+++ b/.github/actions/tests/local-environment-tests/action.yml
@@ -157,7 +157,7 @@ runs:
     - name: Check if no skipped tests
       if: ${{ inputs.tests == 'postmerge' }}
       run: |
-        skipped=$(jq -r .summary.skipped e2e-tests/.report.json)
+        skipped=$(jq -r .summary.skipped e2e-tests/logs/.report.json)
         if [ "$skipped" != "null" ]; then
           echo "Skipped tests found: $skipped. Check test logs for more information."
           exit 1

--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -88,8 +88,9 @@ runs:
           ${deployment_mc_epoch_switch} \
           ${decrypt_switch} \
           --json-report \
+          --json-report-file=logs/.report.json \
           --json-report-summary \
-          --junitxml=junit_report.xml"
+          --junitxml=logs/junit_report.xml"
 
         if [[ "${{ inputs.local-environment }}" == "true" ]]; then
           echo "Running tests via docker exec"
@@ -111,16 +112,13 @@ runs:
       run: |
         echo "Copy test results from docker container"
         mkdir -p e2e-tests
-        docker cp tests:/e2e-tests/.report.json e2e-tests/.report.json
-        docker cp tests:/e2e-tests/debug.log e2e-tests/debug.log
+        docker cp tests:/e2e-tests/logs e2e-tests
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
       with:
         name: test-results
-        path: |
-          e2e-tests/.report.json
-          e2e-tests/debug.log
+        path: e2e-tests/logs
         overwrite: true
         if-no-files-found: error
         include-hidden-files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,10 +121,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Create logs directory
+        run: mkdir -p e2e-tests/logs
       - name: Download test report
         uses: actions/download-artifact@v4
         with:
           name: test-results
+          path: e2e-tests/logs
       - name: Report to slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -135,7 +138,6 @@ jobs:
           github_actor_username: ${{ github.actor }}
           env: local-pre-merge
         run: |
-          mv .report.json e2e-tests/.report.json
           cd e2e-tests
           ./report_slack.sh $repository $slack_ref_name $job_url $env $github_actor_username null
         shell: bash
@@ -420,10 +422,13 @@ jobs:
         with:
           fetch-depth: 0
           ref: master
+      - name: Create logs directory
+        run: mkdir -p e2e-tests/logs
       - name: Download test report
         uses: actions/download-artifact@v4
         with:
           name: test-results
+          path: e2e-tests/logs
       - name: Report to slack
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
@@ -434,7 +439,6 @@ jobs:
           github_actor_username: ${{ github.actor }}
           env: local-post-merge
         run: |
-          mv .report.json e2e-tests/.report.json
           cd e2e-tests
           ./report_slack.sh $repository $slack_ref_name $job_url $env $github_actor_username null
         shell: bash

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -131,14 +131,15 @@ jobs:
           --decrypt=true \
           --markers="$MARKERS"
 
-    - name: Archive Debug Log
+    - name: Archive Test Logs
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug_log
+        name: test-logs
         retention-days: 15
         overwrite: true
-        path: e2e-tests/debug.log
+        include-hidden-files: true
+        path: e2e-tests/logs
 
     - name: Setup Node
       uses: actions/setup-node@v4
@@ -156,4 +157,4 @@ jobs:
       if: ${{ !cancelled() }}
       run: |
         cd e2e-tests
-        npx github-actions-ctrf ctrf-report.json
+        npx github-actions-ctrf logs/ctrf-report.json

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -136,10 +136,11 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: debug_log
+        name: test-logs
         retention-days: 15
         overwrite: true
-        path: e2e-tests/debug.log
+        include-hidden-files: true
+        path: e2e-tests/logs
 
     - name: Setup Node
       uses: actions/setup-node@v4
@@ -157,4 +158,4 @@ jobs:
       if: ${{ !cancelled() }}
       run: |
         cd e2e-tests
-        npx github-actions-ctrf ctrf-report.json
+        npx github-actions-ctrf logs/ctrf-report.json

--- a/e2e-tests/.gitignore
+++ b/e2e-tests/.gitignore
@@ -5,6 +5,6 @@
 venv/
 contractlog.json
 reports
-debug.log
+logs/
 .vscode/settings.json
 my_env/

--- a/e2e-tests/Earthfile
+++ b/e2e-tests/Earthfile
@@ -30,7 +30,7 @@ ARG decrypt=false
 IF $decrypt
   ARG decrypt_switch="--decrypt"
 END
-ARG --global pytest_cmd=pytest --blockchain $blockchain --env $env --stack $stack --log-cli-level $log_level -k $keyword $latest_mc_epoch_switch $markers_switch $node_host_switch $node_port_switch $decrypt_switch --json-report --json-report-summary --junitxml=junit_report.xml --ctrf ctrf-report.json
+ARG --global pytest_cmd=pytest --blockchain $blockchain --env $env --stack $stack --log-cli-level $log_level -k $keyword $latest_mc_epoch_switch $markers_switch $node_host_switch $node_port_switch $decrypt_switch --json-report --json-report-file=logs/.report.json --json-report-summary --junitxml=logs/junit_report.xml --ctrf logs/ctrf-report.json
 
 build:
   ARG USERARCH
@@ -52,23 +52,17 @@ test:
 
 test-artifacts:
   FROM +test
-  SAVE ARTIFACT .report.json
-  SAVE ARTIFACT debug.log
-  SAVE ARTIFACT junit_report.xml
-  SAVE ARTIFACT ctrf-report.json
+  SAVE ARTIFACT logs
 
 report:
   FROM alpine:3.19
-  COPY +test-artifacts/.report.json .
-  COPY +test-artifacts/debug.log .
-  COPY +test-artifacts/ctrf-report.json .
-  SAVE ARTIFACT debug.log AS LOCAL debug.log
-  SAVE ARTIFACT ctrf-report.json AS LOCAL ctrf-report.json
+  COPY +test-artifacts/logs logs
+  SAVE ARTIFACT logs AS LOCAL logs
   COPY ./report_slack.sh ./report_xray.sh .
   RUN apk add --no-cache curl jq bash
-  RUN cat .report.json | jq
-  ARG exitcode=$(cat .report.json | jq '.exitcode')
-  ARG summary=$(cat .report.json | jq '.summary')
+  RUN cat logs/.report.json | jq
+  ARG exitcode=$(cat logs/.report.json | jq '.exitcode')
+  ARG summary=$(cat logs/.report.json | jq '.summary')
   ARG job_url
   ARG repository=unknown
   ARG plan
@@ -78,8 +72,7 @@ report:
   ELSE
     ARG xray_switch="-e ${execution}"
   END
-  COPY +test-artifacts/junit_report.xml .
-  ARG xray_report_name=junit_report.xml
+  ARG xray_report_name=logs/junit_report.xml
   ARG report_to_xray=false
   IF $report_to_xray
     RUN --secret XRAY_API_BASE_URL --secret XRAY_CLIENT_ID --secret XRAY_CLIENT_SECRET ./report_xray.sh -r $xray_report_name $xray_switch

--- a/e2e-tests/pytest.ini
+++ b/e2e-tests/pytest.ini
@@ -21,9 +21,9 @@ junit_duration_report = call
 log_format = %(asctime)s %(levelname)-8s [logger=%(name)s, file=%(filename)s:%(lineno)d] %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S %Z
 log_cli = true
-log_cli_level = info
-log_file = debug.log
-log_file_level = debug
+log_cli_level = INFO
+log_file = logs/debug.log
+log_file_level = DEBUG
 log_file_format = %(asctime)s %(levelname)-8s [logger=%(name)s, file=%(filename)s:%(lineno)d] %(message)s
 log_file_date_format = %Y-%m-%d %H:%M:%S %Z
 addopts = -ra

--- a/e2e-tests/report_slack.sh
+++ b/e2e-tests/report_slack.sh
@@ -2,7 +2,7 @@
 
 slack_webhook_url=$SLACK_WEBHOOK_URL
 jira_url=$JIRA_URL
-report=".report.json"
+report="logs/.report.json"
 repository=$1
 ref_name=$2
 job_url=$3

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -80,7 +80,17 @@ def pytest_configure(config: Config):
     paramiko_logger.setLevel(logging.ERROR)
     logging.getLogger().addFilter(sensitive_filter)
 
-    # create objects needed for collection phase
+    # Create one log file for each worker
+    worker_id = os.environ.get("PYTEST_XDIST_WORKER")
+    if worker_id is not None:
+        logging.basicConfig(
+            format=config.getini("log_file_format"),
+            filename=f"logs/debug_{worker_id}.log",
+            level=config.getini("log_file_level"),
+            datefmt=config.getini("log_file_date_format"),
+        )
+
+    # Create objects needed for collection phase
     blockchain = config.getoption("blockchain")
     global _config
     _config = load_config(
@@ -201,14 +211,6 @@ def pytest_collection_modifyitems(items):
         for marker in item.iter_markers(name="test_key"):
             test_key = marker.args[0]
             item.user_properties.append(("test_key", test_key))
-
-
-def pytest_runtest_logstart(nodeid):
-    logging.info(f"Starting test: {nodeid}")
-
-
-def pytest_runtest_logfinish(nodeid):
-    logging.info(f"Finished test: {nodeid}")
 
 
 def pytest_runtest_makereport(item, call):
@@ -398,6 +400,13 @@ def api(blockchain, config, secrets, db_sync) -> BlockchainApi:
     api: BlockchainApi = class_name(config, secrets, db_sync)
     yield api
     api.close()
+
+
+@fixture(scope="function", autouse=True)
+def log_test_name(request):
+    logging.info(f"Running test: {request.node.nodeid}")
+    yield
+    logging.info(f"Finished test: {request.node.nodeid}")
 
 
 @fixture(scope="function", autouse=True)


### PR DESCRIPTION
added:
- when tests are ran in parallel, each thread stores log separately to not overwrite debug.log file

changed:
- all test logs are now stored in e2e-tests/logs dir

Refs: ETCM-9484