### PR TITLE
test: fix non hex number in address association test

### DIFF
--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -750,6 +750,6 @@ class SubstrateApi(BlockchainApi):
         return tx
 
     def get_address_association(self, stake_key_hash):
-        result = self.substrate.query("AddressAssociations", "AddressAssociations", [hex(int(stake_key_hash, 16))])
+        result = self.substrate.query("AddressAssociations", "AddressAssociations", [f"0x{stake_key_hash}"])
         logger.debug(f"Address association for {stake_key_hash}: {result}")
         return result.value


### PR DESCRIPTION
fixes:
- stake key hash conversion to hex rairly could be broken if the leading number was 0