### PR TITLE
chore: avoid too many release candidates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -181,7 +181,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.sha }}
       - name: Setup tests
         uses: ./.github/actions/tests/setup-python
         env:
@@ -209,7 +209,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.sha }}
       - name: Setup tests
         uses: ./.github/actions/tests/setup-python
         env:
@@ -274,7 +274,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.sha }}
       - name: Setup tests
         uses: ./.github/actions/tests/setup-python
         env:
@@ -346,7 +346,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag }}
+          ref: ${{ inputs.sha }}
       - name: Setup tests
         uses: ./.github/actions/tests/setup-python
         env:


### PR DESCRIPTION
changed:
- use inputs.sha instead of tag to checkout proper e2e-tests to avoid unnecessary release candidates

Refs: ETCM-9451