### PR TITLE
feat: simplify 'deposit' by removing token (asset id) parameter

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ be set through `MC__SLOT_DURATION_MILLIS` environment variable.
 define your own `CommitteeMember` type and implement the trait `CommitteeMember` for it. See the `CommitteeMember`
 type implemented in `node/runtime/src/lib.rs` for reference using Ariadne.
 * Merged functionality of `NativeTokenManagementInherentDataProvider::new_if_pallet_present` into `new`. Use this single constructor from now on.
+* `smart-contracts reserve deposit` command parameter `token` has been removed, because it was redundant.
 
 ## Removed
 

--- a/docs/developer-guides/native-token-reserve-management.md
+++ b/docs/developer-guides/native-token-reserve-management.md
@@ -154,7 +154,7 @@ Command template:
 
 ### 1.4 Creating your token reserve
 
-Objective: Create a reserve for your token and define the release function `V`.
+Objective: Create a reserve for your token and define the release function `V`. There can be only one reserve, therefore one reserve token, for a partner chain.
 
 #### 1.4.1 Run the `reserve create` command
 
@@ -188,9 +188,9 @@ Command template:
 
 * `--total-accrued-function-script-hash`: The script hash of your `V` function
 
-* `--token`: Reserve token asset id encoded in form `<policy_id_hex>.<asset_name_hex>`
+* `--token`: Reserve token asset id encoded in form `<policy_id_hex>.<asset_name_hex>`, this sets the reserve token asset id
 
-* `--initial-deposit-amount`: The initial amount of tokens to deposit into the reserve
+* `--initial-deposit-amount`: The initial amount of tokens to deposit into the reserve, at least this amout of tokens has to available in the payment wallet
 
 * `--payment-key-file`: Your payment key file for transaction signing. This key has to have `initial-deposit-amount` in its wallet.
 
@@ -232,7 +232,7 @@ Objective: Release available reserve tokens (defined by the `VFunction`).
 
 * `--payment-key-file`: Your payment key file for transaction signing
 
-* `--reference-utxo`: UTXO where the `VFunction` script is attached as a reference
+* `--reference-utxo`: UTXO where the `VFunction` script is attached as a reference, this value should be published by the governance authority that has created the reserve
 
 * `--amount`: amount of tokens to release
 
@@ -273,6 +273,8 @@ Objective: Configure the initial token reserve by depositing a specified amount 
 
 ### 3.1 Run the `reserve deposit` command (optional)
 
+Objective: increase the pool of reserve tokens.
+
 #### Command template
 
 ```bash
@@ -280,7 +282,6 @@ Objective: Configure the initial token reserve by depositing a specified amount 
   --genesis-utxo <GENESIS_UTXO> \
   --ogmios-url ws://localhost:1337 \
   --payment-key-file <PAYMENT_KEY_FILE> \
-  --token <TOKEN> \
   --amount <AMOUNT>
 ```
 
@@ -289,8 +290,6 @@ Objective: Configure the initial token reserve by depositing a specified amount 
 * `--genesis-utxo`: The genesis UTXO of the running partner chain
 
 * `--payment-key-file`: Your payment key file for transaction signing
-
-* `--token`: Reserve token asset id encoded in form `<policy_id_hex>.<asset_name_hex>`
 
 * `--amount`: Amount of tokens to deposit. They must be present in the payment wallet.
 

--- a/docs/developer-guides/native-token-reserve-management.md
+++ b/docs/developer-guides/native-token-reserve-management.md
@@ -190,7 +190,7 @@ Command template:
 
 * `--token`: Reserve token asset id encoded in form `<policy_id_hex>.<asset_name_hex>`, this sets the reserve token asset id
 
-* `--initial-deposit-amount`: The initial amount of tokens to deposit into the reserve, at least this amout of tokens has to available in the payment wallet
+* `--initial-deposit-amount`: The initial amount of tokens to deposit into the reserve, at least this amount of tokens has to be available in the payment wallet
 
 * `--payment-key-file`: Your payment key file for transaction signing. This key has to have `initial-deposit-amount` in its wallet.
 

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -19,7 +19,7 @@ use partner_chains_cardano_offchain::{
 	cardano_keys::CardanoPaymentSigningKey,
 	d_param, init_governance, permissioned_candidates,
 	register::Register,
-	reserve::{self, release::release_reserve_funds, TokenAmount},
+	reserve::{self, release::release_reserve_funds},
 	scripts_data, update_governance,
 };
 use partner_chains_plutus_data::reserve::ReserveDatum;
@@ -389,13 +389,7 @@ async fn run_deposit_to_reserve<
 	client: &T,
 ) {
 	reserve::deposit::deposit_to_reserve(
-		TokenAmount {
-			token: AssetId {
-				policy_id: REWARDS_TOKEN_POLICY_ID,
-				asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
-			},
-			amount: DEPOSIT_AMOUNT,
-		},
+		DEPOSIT_AMOUNT,
 		genesis_utxo,
 		&governance_authority_payment_key(),
 		client,


### PR DESCRIPTION
# Description

Removed `token` parameter from the `smart-contracts reserve deposit` command, because asset id is already present in the reserve settings.

Ref: ETCM-9243 (Point 1 & 3)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
