### PR TITLE
Merge reserve init and create

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -18,6 +18,7 @@ define your own `CommitteeMember` type and implement the trait `CommitteeMember`
 type implemented in `node/runtime/src/lib.rs` for reference using Ariadne.
 * Merged functionality of `NativeTokenManagementInherentDataProvider::new_if_pallet_present` into `new`. Use this single constructor from now on.
 * `smart-contracts reserve deposit` command parameter `token` has been removed, because it was redundant.
+* `smart-contracts reserve init` and `create` command has been merged into one command `smart-contracts reserve create`. This means that the reserve system is initialized during the creation of the reserve.
 
 ## Removed
 

--- a/docs/developer-guides/native-token-reserve-management.md
+++ b/docs/developer-guides/native-token-reserve-management.md
@@ -34,7 +34,7 @@ Please note that rewards schemes for token release is the responsibility of the 
 
 # Initialization
 
-Initialization includes creating the native token on Cardano, writing the `VFunction`, running the commands `smart-contracts reserve init` and `smart-contracts reserve create` at the `partner-chains-node` side.
+Initialization includes creating the native token on Cardano, writing the `VFunction`, and running the command `smart-contracts reserve create` at the `partner-chains-node` side.
 
 ## 1. Setting up your token on Cardano
 
@@ -131,32 +131,11 @@ cardano-cli conway transaction submit --tx-file tx.signed --testnet-magic 2
 
 5. Find and note the hash#id for the transaction that has the `VFunction` script attached.
 
-### 1.3 Initializing token reserve controls
-
-Objective: Initialize the reserve management system for your token.
-
-#### 1.3.1 Run the `reserve init` command
-
-Command template:
-
-```bash
-./partner-chains-node smart-contracts reserve init \
-  --genesis-utxo <GENESIS_UTXO> \
-  --ogmios-url <OGMIOS_URL> \
-  --payment-key-file <PAYMENT_KEY_FILE>
-```
-
-#### Steps
-
-1. Execute the `reserve init` command.
-
-2. Confirm initialization: Ensure that the `InitReserveManagement` scripts are correctly initialized by checking the command output.
-
-### 1.4 Creating your token reserve
+### 1.3 Initializing token reserve controls and creating your token reserve
 
 Objective: Create a reserve for your token and define the release function `V`. There can be only one reserve, therefore one reserve token, for a partner chain.
 
-#### 1.4.1 Run the `reserve create` command
+#### 1.3.1 Run the `reserve create` command
 
 Command template:
 
@@ -246,30 +225,9 @@ Objective: Release available reserve tokens (defined by the `VFunction`).
 
 2. Confirm completion: make sure that the release process has been completed by checking the command output.
 
-## 2.2 Transferring token control to smart contracts
+## 3. Depositing additional tokens to the reserve
 
-Objective: Complete the reserve setup by handing over control to the appropriate scripts.
-
-### 2.2.1 Run the `reserve handover` command
-
-#### Command template
-
-```bash
-./partner-chains-node smart-contracts reserve handover \
-  --genesis-utxo <GENESIS_UTXO> \
-  --ogmios-url <OGMIOS_URL> \
-  --payment-key-file <PAYMENT_KEY_FILE>
-```
-
-#### Steps
-
-1. Execute the `reserve handover` command.
-
-2. Confirm completion: Make sure that the handover process has been completed and the illiquid circulation supply transaction has been confirmed by checking the command output.
-
-## 3 Initializing token reserve with initial deposit
-
-Objective: Configure the initial token reserve by depositing a specified amount of tokens into the reserve contract.
+Objective: Add tokens to the reserve by depositing a specified amount of tokens into the reserve contract.
 
 ### 3.1 Run the `reserve deposit` command (optional)
 
@@ -301,15 +259,36 @@ Objective: increase the pool of reserve tokens.
 
 3. Verify that the deposit completed successfully by checking the command output status.
 
+## 4. Transferring token control to smart contracts
+
+Objective: Tear down the reserve by transferring all the tokens to the illiquid circulation supply smart contract and removing its configuration.
+
+### 4.1 Run the `reserve handover` command
+
+#### Command template
+
+```bash
+./partner-chains-node smart-contracts reserve handover \
+  --genesis-utxo <GENESIS_UTXO> \
+  --ogmios-url <OGMIOS_URL> \
+  --payment-key-file <PAYMENT_KEY_FILE>
+```
+
+#### Steps
+
+1. Execute the `reserve handover` command.
+
+2. Confirm completion: Make sure that the handover process has been completed and the illiquid circulation supply transaction has been confirmed by checking the command output.
+
 # Configuration
 
-Configuration includes `reserve update-settings` commands used to either change token in reserve or `VFunction`.
+Configuration includes `reserve update-settings` commands used to change `VFunction`.
 
 <!-- Only "initialize", "create" and "update settings" are related to configuration.  -->
 
-## 4. Connecting your token to your partner chain
+## 5. Connecting your token to your partner chain
 
-### 4.1 Gathering required token parameters
+### 5.1 Gathering required token parameters
 
 Objective: Collect the essential parameters needed to configure the native token management contract on the partner chain.
 
@@ -321,7 +300,7 @@ Objective: Collect the essential parameters needed to configure the native token
 
 - ILLIQUID_SUPPLY_VALIDATOR_ADDRESS - can be obtained from the output of the `get-scripts` command (see below).
 
-#### 4.1.1 Retrieving the validator address
+#### 5.1.1 Retrieving the validator address
 
 Execute the `get-scripts` command:
 
@@ -343,7 +322,7 @@ Locate the validator address in the command output:
 }
 ```
 
-### 4.2 Following the native token migration guide
+### 5.2 Following the native token migration guide
 
 Objective: Migrate and synchronize the token state between Cardano and the partner chain.
 
@@ -355,7 +334,7 @@ Objective: Migrate and synchronize the token state between Cardano and the partn
 
 3. Verify synchronization by checking that the token state is appropriately observed on the partner chain.
 
-### 4.3 Updating current native token management configuration (optional)
+### 5.3 Updating current native token management configuration (optional)
 
 Objective: Update native token configuration if migration has already happened.
 

--- a/docs/user-guides/governance/governance.md
+++ b/docs/user-guides/governance/governance.md
@@ -13,7 +13,7 @@ The Governance System sets and updates the key required to sign the following tr
 
 * management of *D-Parameter*
 * management of *Permissioned Candidates List*
-* management of *Rewards Reserve Mechanism* lifecycle: initialization, creation, and handover
+* management of *Rewards Reserve Mechanism* lifecycle: creation and handover
 * update of the Governance System itself
 
 The Governance System has to be initialized before performing any of these operations.

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -40,6 +40,10 @@ use partner_chains_plutus_data::reserve::{
 };
 use sidechain_domain::{AssetId, McTxHash, PolicyId, UtxoId};
 
+/// Submits transaction that creates a new reserve UTXO at Reserve Validator address.
+/// Returns transaction id if the reserve was created successfully.
+/// Returns None if reserve already exists with the same settings.
+/// Returns Error if reserve already exists with different settings.
 pub async fn create_reserve_utxo<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 	A: AwaitTx,
@@ -49,17 +53,45 @@ pub async fn create_reserve_utxo<
 	payment_key: &CardanoPaymentSigningKey,
 	client: &T,
 	await_tx: &A,
-) -> anyhow::Result<McTxHash> {
+) -> anyhow::Result<Option<McTxHash>> {
 	let ctx = TransactionContext::for_payment_key(payment_key, client).await?;
 	let governance = GovernanceData::get(genesis_utxo, client).await?;
 	let reserve = ReserveData::get(genesis_utxo, &ctx, client).await?;
 
+	match compare_reserve_settings(&parameters, &reserve, &ctx, client).await? {
+		ReserveSettingsComparison::NoSettingsOnChain => {
+			let tx_id =
+				do_create_reserve_utxo(&parameters, &reserve, &governance, &ctx, client, await_tx)
+					.await?;
+			Ok(Some(tx_id))
+		},
+		ReserveSettingsComparison::SettingsMatch => {
+			log::info!("Reserve already exists with the same settings");
+			Ok(None)
+		},
+		ReserveSettingsComparison::SettingsMismatch => {
+			log::info!("Reserve already exists with different settings");
+			Err(anyhow::anyhow!("Reserve already exists with different settings"))
+		},
+	}
+}
+
+async fn do_create_reserve_utxo<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	parameters: &ReserveParameters,
+	reserve: &ReserveData,
+	governance: &GovernanceData,
+	ctx: &TransactionContext,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
 	let tx = Costs::calculate_costs(
-		|costs| create_reserve_tx(&parameters, &reserve, &governance, costs, &ctx),
+		|costs| create_reserve_tx(parameters, reserve, governance, costs, ctx),
 		client,
 	)
 	.await?;
-
 	let signed_tx = ctx.sign(&tx).to_bytes();
 	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
 		anyhow::anyhow!(
@@ -71,7 +103,7 @@ pub async fn create_reserve_utxo<
 	let tx_id = res.transaction.id;
 	log::info!("Create Reserve transaction submitted: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
-	Ok(McTxHash(tx_id))
+	Ok(McTxHash(res.transaction.id))
 }
 
 pub struct ReserveParameters {
@@ -144,4 +176,33 @@ fn reserve_validator_output(
 		.with_asset_amount(&parameters.token, parameters.initial_deposit)?;
 
 	amount_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()
+}
+
+enum ReserveSettingsComparison {
+	NoSettingsOnChain,
+	SettingsMatch,
+	SettingsMismatch,
+}
+
+async fn compare_reserve_settings<T: QueryLedgerState>(
+	parameters: &ReserveParameters,
+	reserve: &ReserveData,
+	ctx: &TransactionContext,
+	client: &T,
+) -> anyhow::Result<ReserveSettingsComparison> {
+	Ok(match reserve.get_reserve_utxo_opt(ctx, client).await? {
+		None => ReserveSettingsComparison::NoSettingsOnChain,
+		Some(reserve_utxo) => {
+			let datum = reserve_utxo.datum;
+			let on_chain_token = datum.immutable_settings.token;
+			let on_chain_script_hash = datum.mutable_settings.total_accrued_function_script_hash;
+			if on_chain_token != parameters.token
+				|| on_chain_script_hash != parameters.total_accrued_function_script_hash
+			{
+				ReserveSettingsComparison::SettingsMismatch
+			} else {
+				ReserveSettingsComparison::SettingsMatch
+			}
+		},
+	})
 }

--- a/toolkit/offchain/src/reserve/mod.rs
+++ b/toolkit/offchain/src/reserve/mod.rs
@@ -81,11 +81,11 @@ impl ReserveData {
 		})
 	}
 
-	pub(crate) async fn get_reserve_utxo<T: QueryLedgerState>(
+	pub(crate) async fn get_reserve_utxo_opt<T: QueryLedgerState>(
 		&self,
 		ctx: &TransactionContext,
 		client: &T,
-	) -> Result<ReserveUtxo, anyhow::Error> {
+	) -> Result<Option<ReserveUtxo>, anyhow::Error> {
 		let validator_address = self.scripts.validator.address(ctx.network).to_bech32(None)?;
 		let validator_utxos = client.query_utxos(&[validator_address]).await?;
 
@@ -94,21 +94,25 @@ impl ReserveData {
 			asset_name: AssetName::empty(),
 		};
 
-		let (reserve_utxo, reserve_settings) = validator_utxos
-			.into_iter()
-			.find_map(|utxo| {
-				if utxo.get_asset_amount(&auth_token_asset_id) != 1u64 {
-					return None;
-				}
-				utxo.get_plutus_data()
-					.and_then(|d| ReserveDatum::try_from(d).ok())
-					.map(|d| (utxo, d))
-			})
-			.ok_or_else(|| {
-				anyhow!("Reserve Utxo not found, is the Reserve Token Management initialized?")
-			})?;
+		let reserve_utxo = validator_utxos.into_iter().find_map(|utxo| {
+			if utxo.get_asset_amount(&auth_token_asset_id) != 1u64 {
+				return None;
+			}
+			utxo.get_plutus_data()
+				.and_then(|d| ReserveDatum::try_from(d).ok())
+				.map(|datum| ReserveUtxo { utxo, datum })
+		});
+		Ok(reserve_utxo)
+	}
 
-		Ok(ReserveUtxo { utxo: reserve_utxo, datum: reserve_settings })
+	pub(crate) async fn get_reserve_utxo<T: QueryLedgerState>(
+		&self,
+		ctx: &TransactionContext,
+		client: &T,
+	) -> Result<ReserveUtxo, anyhow::Error> {
+		self.get_reserve_utxo_opt(ctx, client).await?.ok_or_else(|| {
+			anyhow!("Reserve Utxo not found, is the Reserve Token Management initialized?")
+		})
 	}
 }
 

--- a/toolkit/offchain/tests/integration_tests.rs
+++ b/toolkit/offchain/tests/integration_tests.rs
@@ -138,6 +138,9 @@ async fn reserve_management_scenario() {
 	let txs = run_init_reserve_management(genesis_utxo, &client).await;
 	assert_eq!(txs.len(), 0);
 	let _ = run_create_reserve_management(genesis_utxo, V_FUNCTION_HASH, &client).await;
+	let second_create_result =
+		run_create_reserve_management(genesis_utxo, V_FUNCTION_HASH, &client).await;
+	assert_eq!(second_create_result, None, "reserve create should be idempotent");
 	assert_reserve_deposited(genesis_utxo, INITIAL_DEPOSIT_AMOUNT, &client).await;
 	run_deposit_to_reserve(genesis_utxo, &client).await;
 	assert_reserve_deposited(genesis_utxo, INITIAL_DEPOSIT_AMOUNT + DEPOSIT_AMOUNT, &client).await;
@@ -363,7 +366,7 @@ async fn run_create_reserve_management<
 	genesis_utxo: UtxoId,
 	v_function_hash: PolicyId,
 	client: &T,
-) -> McTxHash {
+) -> Option<McTxHash> {
 	reserve::create::create_reserve_utxo(
 		reserve::create::ReserveParameters {
 			total_accrued_function_script_hash: v_function_hash,


### PR DESCRIPTION
# Description

* merges CLI command `reserve init` and `reserve create`
* makes `create` idempotent-ish (idempotent when settings are same)
* updates docs - there is some shuffling of docs in this PR, I'll revert if there are objections for it

Ref: ETCM-9243

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
