### PR TITLE
ETCM-9514 drop --stack arg from e2e runner

### DIFF
--- a/.github/actions/tests/argocd-tests/action.yml
+++ b/.github/actions/tests/argocd-tests/action.yml
@@ -1,7 +1,7 @@
 name: "Run Tests against ArgoCD Node"
 description: "Run end-to-end tests against the ArgoCD node"
 inputs:
-  sha: 
+  sha:
     description: "SHA of the commit"
     required: true
   node-host:
@@ -25,7 +25,7 @@ runs:
         curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
         chmod +x ./kubectl
         sudo mv ./kubectl /usr/local/bin/kubectl
-  
+
         # Install or update AWS CLI v2
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
         unzip -o awscliv2.zip
@@ -45,7 +45,7 @@ runs:
         kubectl config use-context my-context
       shell: bash
 
-    - name: Check Deployment 
+    - name: Check Deployment
       run: |
         kubectl get deployment -n integration-testing substrate-node-sha-${{ inputs.sha }}
         kubectl describe deployment -n integration-testing substrate-node-sha-${{ inputs.sha }}
@@ -108,6 +108,5 @@ runs:
                 --repository "${{ github.repository }}" \
                 --job_url="$JOB_URL" \
                 --env="ci" \
-                --stack="ci" \
                 --decrypt=true
       shell: bash

--- a/.github/actions/tests/run-e2e-tests/action.yml
+++ b/.github/actions/tests/run-e2e-tests/action.yml
@@ -75,7 +75,6 @@ runs:
 
         pytest_cmd="pytest --blockchain '${{ inputs.blockchain }}' \
           --env '${{ inputs.env }}' \
-          --stack '${{ inputs.env }}' \
           --log-cli-level '${{ inputs.log_level }}' \
           -k '${{ inputs.keyword }}' \
           -m '${{ inputs.markers }}' \
@@ -122,7 +121,7 @@ runs:
         overwrite: true
         if-no-files-found: error
         include-hidden-files: true
-        
+
     - name: Fail the job
       if: ${{ steps.run-tests.outcome == 'failure' }}
       run: exit 1

--- a/.github/workflows/devnet.yml
+++ b/.github/workflows/devnet.yml
@@ -117,7 +117,6 @@ jobs:
           +report \
           --log_level="${LOG_LEVEL:-"info"}" \
           --env=${{ env.TEST_ENVIRONMENT }} \
-          --stack=${{ env.TEST_ENVIRONMENT }} \
           --keyword="${KEYWORD:-"test_"}" \
           --repository ${{ github.repository }} \
           --job_url="$JOB_URL" \

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -118,7 +118,6 @@ jobs:
           +report \
           --log_level="${LOG_LEVEL:-"info"}" \
           --env=${{ env.TEST_ENVIRONMENT }} \
-          --stack=${{ env.TEST_ENVIRONMENT }} \
           --keyword="${KEYWORD:-"test_"}" \
           --repository ${{ github.repository }} \
           --job_url="$JOB_URL" \

--- a/e2e-tests/Earthfile
+++ b/e2e-tests/Earthfile
@@ -7,7 +7,6 @@ COPY --dir ./config ./secrets ./tests ./src ./requirements.txt ./pytest.ini ./to
 ARG AWS_DEFAULT_REGION=eu-central-1
 ARG blockchain=substrate
 ARG env=staging
-ARG stack=staging
 ARG log_level=info
 ARG keyword=test_
 ARG markers
@@ -30,7 +29,7 @@ ARG decrypt=false
 IF $decrypt
   ARG decrypt_switch="--decrypt"
 END
-ARG --global pytest_cmd=pytest --blockchain $blockchain --env $env --stack $stack --log-cli-level $log_level -k $keyword $latest_mc_epoch_switch $markers_switch $node_host_switch $node_port_switch $decrypt_switch --json-report --json-report-file=logs/.report.json --json-report-summary --junitxml=logs/junit_report.xml --ctrf logs/ctrf-report.json
+ARG --global pytest_cmd=pytest --blockchain $blockchain --env $env --log-cli-level $log_level -k $keyword $latest_mc_epoch_switch $markers_switch $node_host_switch $node_port_switch $decrypt_switch --json-report --json-report-file=logs/.report.json --json-report-summary --junitxml=logs/junit_report.xml --ctrf logs/ctrf-report.json
 
 build:
   ARG USERARCH

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -36,7 +36,6 @@ Welcome to `Partner Chains Tests`, a powerful and flexible test automation frame
 Custom options:
   --ctrf=CTRF           generate test report. Report file name is optional
   --env=ENV             Target node environment
-  --stack=STACK         Target dependencies stack
   --blockchain={substrate,midnight}
                         Blockchain network type
   --ci-run              Overrides config values specific for executing from ci runner
@@ -57,5 +56,5 @@ Custom options:
 ### Run tests on the local environment
 
 ```bash
-pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
+pytest -rP -v --blockchain substrate --env local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
 ```

--- a/e2e-tests/docs/run-tests-on-local-env.md
+++ b/e2e-tests/docs/run-tests-on-local-env.md
@@ -28,7 +28,7 @@
 2. Run partner-chains tests on partner-chains local environment
 
 ```bash
-pytest -rP -v --blockchain substrate --env local --stack local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
+pytest -rP -v --blockchain substrate --env local --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
 ```
 
 ## Substrate Portal

--- a/e2e-tests/docs/run-tests-on-new-env.md
+++ b/e2e-tests/docs/run-tests-on-new-env.md
@@ -226,12 +226,11 @@ E.g. for Cardano Preview it will be:
 ### 6. Run tests on your custom environment
 
 ```bash
-$ pytest -rP -v --blockchain <blockchain> --env <env> --stack <env> --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
+$ pytest -rP -v --blockchain <blockchain> --env <env> --log-cli-level debug -vv -s -m "not active_flow and not passive_flow and not probability"
 ```
 where:
 
 * `--env` - target node environment
-* `--stack` - target dependencies stack
 * `--blockchain` - target type of blockchain: substrate, `<blockchain>`
 * `--log-cli-level` - log level for output (info, debug, warning, critical, error)
 * `-m` - pytest markers to filter tests for execution

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -23,7 +23,6 @@ partner_chain_epoch_calc: PartnerChainEpochCalculator = None
 
 def pytest_addoption(parser):
     parser.addoption("--env", action="store", default="local", help="Target node environment")
-    parser.addoption("--stack", action="store", default="local", help="Target dependencies stack")
     parser.addoption(
         "--blockchain",
         action="store",
@@ -96,7 +95,6 @@ def pytest_configure(config: Config):
     _config = load_config(
         blockchain,
         config.getoption("env"),
-        config.getoption("stack"),
         config.getoption("--ci-run"),
         config.getoption("--node-host"),
         config.getoption("--node-port"),
@@ -224,11 +222,6 @@ def nodes_env(request):
 
 
 @fixture(scope="session")
-def stack_env(request):
-    return request.config.getoption("--stack")
-
-
-@fixture(scope="session")
 def blockchain(request):
     return request.config.getoption("--blockchain")
 
@@ -243,7 +236,7 @@ def decrypt(request):
     return request.config.getoption("--decrypt")
 
 
-def load_config(blockchain, nodes_env, stack_env, ci_run, node_host, node_port, deployment_mc_epoch, init_timestamp):
+def load_config(blockchain, nodes_env, ci_run, node_host, node_port, deployment_mc_epoch, init_timestamp):
     default_config_path = f"{os.getcwd()}/config/config.json"
     assert os.path.isfile(default_config_path), f"Config file not found {default_config_path}"
     default_config = OmegaConf.load(default_config_path)
@@ -252,7 +245,7 @@ def load_config(blockchain, nodes_env, stack_env, ci_run, node_host, node_port, 
     assert os.path.isfile(blockchain_config_path), f"Config file not found {blockchain_config_path}"
     blockchain_config = OmegaConf.load(blockchain_config_path)
 
-    stack_config_path = f"{os.getcwd()}/config/{blockchain}/{stack_env}_stack.json"
+    stack_config_path = f"{os.getcwd()}/config/{blockchain}/{nodes_env}_stack.json"
     assert os.path.isfile(stack_config_path), f"Config file not found {stack_config_path}"
     stack_config = OmegaConf.load(stack_config_path)
 


### PR DESCRIPTION
# Description

Removes --stack arg from E2E runner. Previously it made sense to have different --env and --stack but with the introduction of local-env this is no longer the case.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
