### PR TITLE
ETCM-9535 provide default for test_helper_pallet::participation_data_release_period

### DIFF
--- a/node/runtime/src/genesis_config_presets.rs
+++ b/node/runtime/src/genesis_config_presets.rs
@@ -45,7 +45,17 @@ fn testnet_genesis(
 			..Default::default()
 		},
 		sudo: SudoConfig { key: Some(root) },
-		..Default::default()
+		test_helper_pallet: crate::test_helper_pallet::GenesisConfig {
+			participation_data_release_period: 30,
+			_phantom: core::marker::PhantomData,
+		},
+		system: Default::default(),
+		transaction_payment: Default::default(),
+		sidechain: Default::default(),
+		session_committee_management: Default::default(),
+		pallet_session: Default::default(),
+		session: Default::default(),
+		native_token_management: Default::default(),
 	};
 
 	serde_json::to_value(config).expect("Could not build genesis config.")

--- a/node/runtime/src/genesis_config_presets.rs
+++ b/node/runtime/src/genesis_config_presets.rs
@@ -15,7 +15,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{AccountId, BalancesConfig, RuntimeGenesisConfig, SudoConfig};
+use crate::{test_helper_pallet, AccountId, BalancesConfig, RuntimeGenesisConfig, SudoConfig};
 use alloc::{vec, vec::Vec};
 use serde_json::Value;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
@@ -45,8 +45,9 @@ fn testnet_genesis(
 			..Default::default()
 		},
 		sudo: SudoConfig { key: Some(root) },
-		test_helper_pallet: crate::test_helper_pallet::GenesisConfig {
-			participation_data_release_period: 30,
+		test_helper_pallet: test_helper_pallet::GenesisConfig {
+			participation_data_release_period:
+				test_helper_pallet::DEFAULT_PARTICIPATION_DATA_RELEASE_PERIOD,
 			_phantom: core::marker::PhantomData,
 		},
 		system: Default::default(),

--- a/node/runtime/src/test_helper_pallet.rs
+++ b/node/runtime/src/test_helper_pallet.rs
@@ -14,6 +14,8 @@ pub mod pallet {
 
 	type ParticipationData = BlockProductionData<BlockAuthor, DelegatorKey>;
 
+	pub const DEFAULT_PARTICIPATION_DATA_RELEASE_PERIOD: u64 = 30;
+
 	#[pallet::pallet]
 	pub struct Pallet<T>(_);
 
@@ -26,7 +28,7 @@ pub mod pallet {
 
 	#[pallet::type_value]
 	pub fn DefaultParticipationDataReleasePeriod<T: Config>() -> u64 {
-		30u64
+		DEFAULT_PARTICIPATION_DATA_RELEASE_PERIOD
 	}
 
 	#[pallet::storage]

--- a/node/runtime/src/test_helper_pallet.rs
+++ b/node/runtime/src/test_helper_pallet.rs
@@ -24,8 +24,14 @@ pub mod pallet {
 	#[pallet::unbounded]
 	pub type LatestParticipationData<T: Config> = StorageValue<_, ParticipationData, OptionQuery>;
 
+	#[pallet::type_value]
+	pub fn DefaultParticipationDataReleasePeriod<T: Config>() -> u64 {
+		30u64
+	}
+
 	#[pallet::storage]
-	pub type ParticipationDataReleasePeriod<T: Config> = StorageValue<_, u64, ValueQuery>;
+	pub type ParticipationDataReleasePeriod<T: Config> =
+		StorageValue<_, u64, ValueQuery, DefaultParticipationDataReleasePeriod<T>>;
 
 	#[pallet::genesis_config]
 	#[derive(frame_support::DefaultNoBound)]


### PR DESCRIPTION
# Description

`participation_data_release_period` in `test_helper_pallet` does not have an explicit default, so it defaults to 0 (for example when upgrading the runtime). This causes test_helper_pallet to cause an execution failure because it is used on the right-hand side of a modulo operation.
This PR provides the default value of 30.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
