### PR TITLE
reserve-init-separate-test

### DIFF
--- a/e2e-tests/secrets/substrate/staging/staging.json
+++ b/e2e-tests/secrets/substrate/staging/staging.json
@@ -12,7 +12,7 @@
 		"type": "ENC[AES256_GCM,data:rU0LSPIX73kqWg==,iv:5qktowdBAl59uNXVrmwI2mil7Thh4SDEQOzHLylBsEA=,tag:a5RNbDEZNqzw/kSye6LFTg==,type:str]",
 		"username": "ENC[AES256_GCM,data:1eTHUrdrcLs=,iv:l6QgW8p1xMajlWKu4RK4PYo/QIHiqfQJzzqO7PrDgAs=,tag:7ETwkCcENCngxwKE1LVvXw==,type:str]",
 		"password": "ENC[AES256_GCM,data:oVlgGHpnHIB0+J8=,iv:gmC701ZgCsg7byHM1WEEcjTQ54zlRWDyUjrARkUQKXk=,tag:ErikySOEnv7IqrSxYlkN2A==,type:str]",
-		"host": "ENC[AES256_GCM,data:xadoKF+imkQ+rF8=,iv:+YyfI5K7tpjN/hCcjZenZZFxQWwCR2l2iX9jU0gDOTw=,tag:jUT9igF/crMbzP6r5KzHdg==,type:str]",
+		"host": "ENC[AES256_GCM,data:aPf6DPdUbcS2Ow4=,iv:Ylt5U0VD6q3HmIMU6qnpFConsRhE4Hk4E2DGNaVd+nc=,tag:0oVJYFEmqEI1oHi5HGU98w==,type:str]",
 		"port": "ENC[AES256_GCM,data:WUTE0w==,iv:S8fwURTz2InT0lniggKwzPK9xkUrCtd3hedURQMfs/U=,tag:g7xe9rII1vxTUUEASVRixw==,type:str]",
 		"name": "ENC[AES256_GCM,data:PHGEXKkMInKO,iv:AgI9EIiGUm9HL9bwnVN8VQPglTaSoV9cL13wTUK+GRo=,tag:QdIqJIDmltKUZTgG8Qup+Q==,type:str]",
 		"url": "ENC[AES256_GCM,data:OSFW9ZouWbOvbknToT4uGAkJsleS0ueJKfi8DzeDYUTykTL9kUm5FK9guoCGNak3D4Gmq2dH9kMaMgpjE7x87X4X+DFUx4IUho2aVgxqHaheLfPqQ96cT0hxVeGgOoOtAewX,iv:rbNGfPLN05nw40GCpA7VCw5p3/8QseH1UqdNwNKDjUM=,tag:m9YU1o5UA2Wvv2cMqCt9UQ==,type:str]"
@@ -95,8 +95,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2025-02-18T08:33:13Z",
-		"mac": "ENC[AES256_GCM,data:Q5clNWFEModMCeFCPVNNyTwvGgEfPtrY4G3SAgE3SNuDk9Jd6jQOObUghGAKQmXQ6nD3vKoRb9UUTToEwdyUO4WDwzk7WdCkPr+elOPfvbXbgjfterotDdbDyoIuNhi6CYHXmXZ1AEhr2xGvWR3PM7W0Hh/Gc0G8lxy+MRz26Ks=,iv:BRkWBNQGU6g0n+yiHshs+lYDMnxQmMwObA3fR40Siro=,tag:qKxNpDrrwA9u9SRSx7E8gg==,type:str]",
+		"lastmodified": "2025-03-12T10:48:46Z",
+		"mac": "ENC[AES256_GCM,data:hVJEYip2vBmUVBLrGU04dbgBW5bsUkntG86cHxeavXZnGkk2rnn2l7Hu6pLgEZ3nSSzfZNLbAQ9EguBf77Q1gEDE5+o/8AJkeB9kWq8gqV4D74NLPGM+SZnMGLoU/Vty4m7ejPelGDf5gXjt22ht+mri/1ZdanOk+3GLFMtDNdo=,iv:xOCFNmG6oAnTN/SJFSumMDcCXY/hWCN2fcm3ayBpukk=,tag:nciLPb6l5rqUIArpvPXFJA==,type:str]",
 		"pgp": [
 			{
 				"created_at": "2024-02-06T12:31:38Z",


### PR DESCRIPTION
changed:
- `reserve init` was moved to its own test
- handle running native token tests multiple times on existing chain
- updated staging-services IP (matter only if running tests from localhost)

Refs: ETCM-9243