### PR TITLE
test: do not run native token on last post merge run

### DIFF
--- a/.github/actions/tests/local-environment-tests/action.yml
+++ b/.github/actions/tests/local-environment-tests/action.yml
@@ -153,6 +153,7 @@ runs:
         mc_epoch: 3
         init_timestamp: ${{ env.INIT_TIMESTAMP }}
         blockchain: substrate
+        markers: "not active_flow and not passive_flow and not probability and not native_token"
         local-environment: "true"
     - name: Check if no skipped tests
       if: ${{ inputs.tests == 'postmerge' }}

--- a/e2e-tests/pytest.ini
+++ b/e2e-tests/pytest.ini
@@ -14,6 +14,7 @@ markers =
     committee_members: run tests for Committee Members feature
     mc_state_reference_block: run tests for Mainchain State Reference feature
     block_production_log: run test for block production log pallet
+    native_token: run tests for Native Token Managemenet System feature
     rpc: run tests for RPC endpoints
     substrate: run tests for Substrate framework core features
     test_key: key for xray

--- a/e2e-tests/tests/smart_contracts/test_native_token.py
+++ b/e2e-tests/tests/smart_contracts/test_native_token.py
@@ -3,6 +3,8 @@ from pytest import fixture, mark, skip
 from src.blockchain_api import BlockchainApi
 from config.api_config import ApiConfig, NativeToken, MainchainAccount
 
+pytestmark = mark.native_token
+
 
 @fixture(scope="session", autouse=True)
 def reserve_cfg(config: ApiConfig) -> NativeToken:


### PR DESCRIPTION
changed:
- post-merge CI action excludes native token tests because they're skipped (were executed earlier) and that was causing job to fail (we expect no skipped tests on last run