### PR TITLE
feat: represent different governance policies in offchain code

### DIFF
--- a/toolkit/offchain/src/csl.rs
+++ b/toolkit/offchain/src/csl.rs
@@ -187,18 +187,18 @@ pub enum Costs {
 }
 
 pub trait CostStore {
-	fn get_mint(&self, script: &PlutusScript) -> ExUnits;
+	fn get_mint(&self, script: &ScriptHash) -> ExUnits;
 	fn get_spend(&self, spend_ix: u32) -> ExUnits;
 	fn get_one_spend(&self) -> ExUnits;
 }
 
 impl CostStore for Costs {
-	fn get_mint(&self, script: &PlutusScript) -> ExUnits {
+	fn get_mint(&self, script_hash: &ScriptHash) -> ExUnits {
 		match self {
 			Costs::ZeroCosts => zero_ex_units(),
 			Costs::Costs(cost_lookup) => cost_lookup
 				.mints
-				.get(&script.csl_script_hash())
+				.get(script_hash)
 				.expect("get_mint should not be called with an unknown script")
 				.clone(),
 		}
@@ -441,7 +441,7 @@ pub(crate) trait TransactionBuilderExt {
 	/// Adds minting of tokens (with empty asset name) for the given script using reference input
 	fn add_mint_script_token_using_reference_script(
 		&mut self,
-		script: &PlutusScript,
+		script: &Script,
 		ref_input: &TransactionInput,
 		amount: &Int,
 		ex_units: &ExUnits,
@@ -449,7 +449,7 @@ pub(crate) trait TransactionBuilderExt {
 
 	fn add_mint_one_script_token_using_reference_script(
 		&mut self,
-		script: &PlutusScript,
+		script: &Script,
 		ref_input: &TransactionInput,
 		ex_units: &ExUnits,
 	) -> Result<(), JsError> {
@@ -525,23 +525,41 @@ impl TransactionBuilderExt for TransactionBuilder {
 
 	fn add_mint_script_token_using_reference_script(
 		&mut self,
-		script: &PlutusScript,
+		script: &Script,
 		ref_input: &TransactionInput,
 		amount: &Int,
 		ex_units: &ExUnits,
 	) -> Result<(), JsError> {
 		let mut mint_builder = self.get_mint_builder().unwrap_or(MintBuilder::new());
 
-		let validator_source = PlutusScriptSource::new_ref_input(
-			&script.csl_script_hash(),
-			ref_input,
-			&script.language,
-			script.bytes.len(),
-		);
-		let mint_witness = MintWitness::new_plutus_script(
-			&validator_source,
-			&Redeemer::new(&RedeemerTag::new_mint(), &0u32.into(), &unit_plutus_data(), ex_units),
-		);
+		let mint_witness = match script {
+			Script::Plutus(script) => {
+				let source = PlutusScriptSource::new_ref_input(
+					&script.csl_script_hash(),
+					ref_input,
+					&script.language,
+					script.bytes.len(),
+				);
+				MintWitness::new_plutus_script(
+					&source,
+					&Redeemer::new(
+						&RedeemerTag::new_mint(),
+						&0u32.into(),
+						&unit_plutus_data(),
+						ex_units,
+					),
+				)
+			},
+			Script::Native(script) => {
+				let source = NativeScriptSource::new_ref_input(
+					&script.hash(),
+					ref_input,
+					script.to_bytes().len(),
+				);
+				MintWitness::new_native_script(&source)
+			},
+		};
+
 		mint_builder.add_asset(&mint_witness, &empty_asset_name(), amount)?;
 		self.set_mint_builder(&mint_builder);
 		Ok(())
@@ -616,6 +634,39 @@ impl TransactionBuilderExt for TransactionBuilder {
 		);
 
 		Ok(balanced_transaction)
+	}
+}
+
+pub(crate) enum Script {
+	Plutus(PlutusScript),
+	Native(NativeScript),
+}
+
+impl From<PlutusScript> for Script {
+	fn from(value: PlutusScript) -> Self {
+		Self::Plutus(value)
+	}
+}
+
+impl From<NativeScript> for Script {
+	fn from(value: NativeScript) -> Self {
+		Self::Native(value)
+	}
+}
+
+impl Script {
+	pub(crate) fn csl_script_hash(&self) -> ScriptHash {
+		match self {
+			Self::Plutus(script) => script.csl_script_hash(),
+			Self::Native(script) => script.hash(),
+		}
+	}
+
+	pub(crate) fn length(&self) -> usize {
+		match self {
+			Self::Plutus(script) => script.bytes.len(),
+			Self::Native(script) => script.to_bytes().len(),
+		}
 	}
 }
 

--- a/toolkit/offchain/src/d_param/mod.rs
+++ b/toolkit/offchain/src/d_param/mod.rs
@@ -207,7 +207,7 @@ fn mint_d_param_token_tx(
 		policy,
 		&empty_asset_name(),
 		&unit_plutus_data(),
-		&costs.get_mint(policy),
+		&costs.get_mint(&policy.csl_script_hash()),
 	)?;
 	tx_builder.add_output_with_one_script_token(
 		validator,
@@ -217,10 +217,11 @@ fn mint_d_param_token_tx(
 	)?;
 
 	let gov_tx_input = governance_data.utxo_id_as_tx_input();
+	let gov_policy_script = governance_data.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance_data.policy_script,
+		&gov_policy_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance_data.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)
@@ -254,10 +255,11 @@ fn update_d_param_tx(
 	)?;
 
 	let gov_tx_input = governance_data.utxo_id_as_tx_input();
+	let gov_policy_script = governance_data.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance_data.policy_script,
+		&gov_policy_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance_data.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)

--- a/toolkit/offchain/src/d_param/tests.rs
+++ b/toolkit/offchain/src/d_param/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 	test_values::*,
 };
 use cardano_serialization_lib::{
-	Address, ExUnits, Int, Language, NetworkIdKind, PlutusData, RedeemerTag, ScriptHash,
+	Address, ExUnits, Int, NetworkIdKind, PlutusData, RedeemerTag, ScriptHash,
 };
 use hex_literal::hex;
 use ogmios_client::types::{Asset as OgmiosAsset, OgmiosTx, OgmiosUtxo, OgmiosValue};
@@ -338,17 +338,13 @@ fn test_tx_context() -> TransactionContext {
 	}
 }
 
-fn governance_script() -> crate::plutus_script::PlutusScript {
-	crate::plutus_script::PlutusScript { language: Language::new_plutus_v2(), bytes: vec![] }
-}
-
 fn governance_script_hash() -> ScriptHash {
-	governance_script().csl_script_hash()
+	test_governance_policy().script().csl_script_hash()
 }
 
 fn governance_data() -> GovernanceData {
 	GovernanceData {
-		policy_script: governance_script(),
+		policy: test_governance_policy(),
 		utxo: OgmiosUtxo { transaction: OgmiosTx { id: [15; 32] }, index: 0, ..Default::default() },
 	}
 }

--- a/toolkit/offchain/src/governance.rs
+++ b/toolkit/offchain/src/governance.rs
@@ -2,16 +2,70 @@ use crate::csl::{NetworkTypeExt, OgmiosUtxoExt};
 use crate::plutus_script;
 use crate::scripts_data;
 use cardano_serialization_lib::*;
+use ogmios_client::types::{NativeScript as OgmiosNativeScript, OgmiosScript};
 use ogmios_client::{
 	query_ledger_state::QueryLedgerState, query_network::QueryNetwork, types::OgmiosUtxo,
 };
 use partner_chains_plutus_data::version_oracle::VersionOracleDatum;
+use partner_chains_plutus_data::PlutusDataExtensions as _;
 use sidechain_domain::UtxoId;
 
 #[derive(Clone, Debug)]
 pub(crate) struct GovernanceData {
-	pub(crate) policy_script: plutus_script::PlutusScript,
+	pub(crate) policy: GovernancePolicyScript,
 	pub(crate) utxo: OgmiosUtxo,
+}
+
+/// The supported Governance Policies are:
+/// - Plutus MultiSig implementation from partner-chain-smart-contracts
+/// - Native Script `atLeast` with only simple `sig` type of inner `scripts` field.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) enum GovernancePolicyScript {
+	MultiSig(PartnerChainsMultisigPolicy),
+	AtLeastNNativeScript(SimpleAtLeastN),
+}
+
+impl GovernancePolicyScript {
+	pub(crate) fn script(&self) -> crate::csl::Script {
+		match self {
+			Self::MultiSig(policy) => crate::csl::Script::Plutus(policy.script.clone()),
+			Self::AtLeastNNativeScript(policy) => {
+				crate::csl::Script::Native(policy.to_csl_native_script())
+			},
+		}
+	}
+}
+
+/// Plutus MultiSig implemented in partner-chains-smart-contracts repo,
+/// it is legacy and ideally should have been used only with a single key in the `governance init`.
+/// It allows to mint the governance token only if the transaction in `required_singers` field
+/// has at least `threshold` key hashes that are in the `key_hashes` list.
+/// `threshold` and `key_hashes` are applied Plutus Data applied to the script.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct PartnerChainsMultisigPolicy {
+	pub(crate) script: plutus_script::PlutusScript,
+	pub(crate) key_hashes: Vec<[u8; 28]>,
+	pub(crate) threshold: u32,
+}
+
+/// This represent Cardano Native Script of type `atLeast`, where each of `scripts` has to be
+/// of type `sig`. In other words, this type represents only a subset of `atLeast` Native Scripts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct SimpleAtLeastN {
+	pub(crate) required: u32,
+	pub(crate) sigs: Vec<[u8; 28]>,
+}
+
+impl SimpleAtLeastN {
+	pub fn to_csl_native_script(&self) -> NativeScript {
+		let mut native_scripts = NativeScripts::new();
+		for key_hash in self.sigs.clone() {
+			native_scripts.add(&NativeScript::new_script_pubkey(&ScriptPubkey::new(
+				&Ed25519KeyHash::from(key_hash),
+			)))
+		}
+		NativeScript::new_script_n_of_k(&ScriptNOfK::new(self.required, &native_scripts))
+	}
 }
 
 impl GovernanceData {
@@ -76,21 +130,71 @@ impl GovernanceData {
 		client: &T,
 	) -> Result<GovernanceData, JsError> {
 		let utxo = Self::get_governance_utxo(genesis_utxo, client).await?;
-		let policy_script = read_policy(&utxo)?;
-		Ok(GovernanceData { policy_script, utxo })
+		let policy = read_policy(&utxo)?;
+		Ok(GovernanceData { policy, utxo })
 	}
 }
 
-fn read_policy(governance_utxo: &OgmiosUtxo) -> Result<plutus_script::PlutusScript, JsError> {
+fn read_policy(governance_utxo: &OgmiosUtxo) -> Result<GovernancePolicyScript, JsError> {
 	let script = governance_utxo
 		.script
 		.clone()
 		.ok_or_else(|| JsError::from_str("No 'script' in governance UTXO"))?;
-	plutus_script::PlutusScript::from_ogmios(script).map_err(|e| {
+	let plutus_multisig = plutus_script::PlutusScript::from_ogmios(script.clone())
+		.ok()
+		.and_then(parse_pc_multisig);
+	let policy_script = plutus_multisig.or_else(|| match script {
+		OgmiosScript::Native(native) => parse_simple_at_least_n_native_script(native),
+		_ => None,
+	});
+	policy_script.ok_or_else(|| {
 		JsError::from_str(&format!(
-			"Cannot convert script from UTXO {}: {}",
-			governance_utxo.to_domain(),
-			e
+			"Cannot convert script from UTXO {} into a multisig policy",
+			governance_utxo.utxo_id(),
 		))
 	})
+}
+
+/// Returns decoded Governance Authorities and threshold is policy script is an applied MultiSig policy.
+/// Returns None in case decoding failed, perhaps when some other policy is used.
+/// This method does not check for the policy itself. If invoked for a different policy, most probably will return None, with some chance of returning trash data.
+fn parse_pc_multisig(script: plutus_script::PlutusScript) -> Option<GovernancePolicyScript> {
+	script.unapply_data_csl().ok().and_then(|data| data.as_list()).and_then(|list| {
+		let mut it = list.into_iter();
+		let key_hashes = it.next().and_then(|data| {
+			data.as_list().map(|list| {
+				list.into_iter()
+					.filter_map(|item| item.as_bytes().and_then(|bytes| bytes.try_into().ok()))
+					.collect::<Vec<_>>()
+			})
+		})?;
+		let threshold: u32 = it.next().and_then(|t| t.as_u32())?;
+		Some(GovernancePolicyScript::MultiSig(PartnerChainsMultisigPolicy {
+			script,
+			key_hashes,
+			threshold,
+		}))
+	})
+}
+
+fn parse_simple_at_least_n_native_script(
+	script: ogmios_client::types::NativeScript,
+) -> Option<GovernancePolicyScript> {
+	match script {
+		OgmiosNativeScript::Some { from, at_least } => {
+			let mut keys = Vec::with_capacity(from.len());
+			for x in from {
+				let key = match x {
+					OgmiosNativeScript::Signature { from: key_hash } => Some(key_hash),
+					_ => None,
+				}?;
+				keys.push(key);
+			}
+			Some(GovernancePolicyScript::AtLeastNNativeScript(SimpleAtLeastN {
+				required: at_least,
+				sigs: keys,
+			}))
+		},
+		_ => None,
+	}
 }

--- a/toolkit/offchain/src/init_governance/transaction.rs
+++ b/toolkit/offchain/src/init_governance/transaction.rs
@@ -25,7 +25,7 @@ pub(crate) fn init_governance_transaction(
 		&version_oracle.policy,
 		&version_oracle_asset_name(),
 		&mint_redeemer(&multi_sig_policy),
-		&costs.get_mint(&version_oracle.policy),
+		&costs.get_mint(&version_oracle.policy.csl_script_hash()),
 	)?;
 
 	tx_builder.add_output(&version_oracle_datum_output(

--- a/toolkit/offchain/src/permissioned_candidates.rs
+++ b/toolkit/offchain/src/permissioned_candidates.rs
@@ -240,7 +240,7 @@ fn mint_permissioned_candidates_token_tx(
 			policy,
 			&empty_asset_name(),
 			&permissioned_candidates_policy_redeemer_data(),
-			&costs.get_mint(policy),
+			&costs.get_mint(&policy.csl_script_hash()),
 		)?;
 	}
 	tx_builder.add_output_with_one_script_token(
@@ -251,10 +251,11 @@ fn mint_permissioned_candidates_token_tx(
 	)?;
 
 	let gov_tx_input = governance_data.utxo_id_as_tx_input();
+	let gov_script = governance_data.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance_data.policy_script,
+		&gov_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance_data.policy_script),
+		&costs.get_mint(&gov_script.csl_script_hash()),
 	)?;
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)
@@ -290,10 +291,11 @@ fn update_permissioned_candidates_tx(
 	)?;
 
 	let gov_tx_input = governance_data.utxo_id_as_tx_input();
+	let gov_policy_script = governance_data.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance_data.policy_script,
+		&gov_policy_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance_data.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)
@@ -309,10 +311,9 @@ mod tests {
 	use crate::{
 		csl::{empty_asset_name, Costs, TransactionContext},
 		governance::GovernanceData,
-		plutus_script::PlutusScript,
 		test_values::*,
 	};
-	use cardano_serialization_lib::{Address, ExUnits, Int, Language, NetworkIdKind, PlutusData};
+	use cardano_serialization_lib::{Address, ExUnits, Int, NetworkIdKind, PlutusData};
 	use hex_literal::hex;
 	use ogmios_client::types::{Asset as OgmiosAsset, OgmiosTx, OgmiosUtxo, OgmiosValue};
 	use partner_chains_plutus_data::permissioned_candidates::permissioned_candidates_to_plutus_data;
@@ -488,7 +489,7 @@ mod tests {
 		Costs::new(
 			vec![
 				(test_policy().csl_script_hash(), permissioned_candidates_ex_units()),
-				(test_goveranance_policy().csl_script_hash(), governance_ex_units()),
+				(test_governance_policy().script().csl_script_hash(), governance_ex_units()),
 			]
 			.into_iter()
 			.collect(),
@@ -498,15 +499,11 @@ mod tests {
 
 	fn test_costs_update() -> Costs {
 		Costs::new(
-			vec![(test_goveranance_policy().csl_script_hash(), governance_ex_units())]
+			vec![(test_governance_policy().script().csl_script_hash(), governance_ex_units())]
 				.into_iter()
 				.collect(),
 			vec![(0, permissioned_candidates_ex_units())].into_iter().collect(),
 		)
-	}
-
-	fn test_goveranance_policy() -> PlutusScript {
-		PlutusScript { bytes: hex!("88991122").into(), language: Language::new_plutus_v2() }
 	}
 
 	fn test_goveranance_utxo() -> OgmiosUtxo {
@@ -514,7 +511,7 @@ mod tests {
 	}
 
 	fn test_governance_data() -> GovernanceData {
-		GovernanceData { policy_script: test_goveranance_policy(), utxo: test_goveranance_utxo() }
+		GovernanceData { policy: test_governance_policy(), utxo: test_goveranance_utxo() }
 	}
 
 	fn test_tx_context() -> TransactionContext {

--- a/toolkit/offchain/src/plutus_script.rs
+++ b/toolkit/offchain/src/plutus_script.rs
@@ -72,6 +72,24 @@ impl PlutusScript {
 		Ok(Self { bytes, ..self })
 	}
 
+	pub fn unapply_data_uplc(&self) -> Result<uplc::PlutusData, anyhow::Error> {
+		let mut buffer = Vec::new();
+		let program = Program::<DeBruijn>::from_cbor(&self.bytes, &mut buffer).unwrap();
+		match program.term {
+			uplc::ast::Term::Apply { function: _, argument } => {
+				let res: Result<uplc::PlutusData, String> = (*argument).clone().try_into();
+				res.map_err(|e| anyhow!(e))
+			},
+			_ => Err(anyhow!("Given Plutus Script is not an applied term")),
+		}
+	}
+
+	pub fn unapply_data_csl(&self) -> Result<PlutusData, anyhow::Error> {
+		let uplc_pd = self.unapply_data_uplc()?;
+		let cbor_bytes = minicbor::to_vec(uplc_pd).expect("to_vec has Infallible error type");
+		Ok(PlutusData::from_bytes(cbor_bytes).expect("UPLC encoded PlutusData is valid"))
+	}
+
 	/// Builds an CSL `Address` for plutus script from the data obtained from smart contracts.
 	pub fn address(&self, network: NetworkIdKind) -> Address {
 		script_address(&self.bytes, network, self.language)
@@ -186,5 +204,51 @@ pub(crate) mod tests {
 				.apply_data(TEST_GENESIS_UTXO)
 				.unwrap();
 		assert_eq!(hex::encode(applied.bytes), hex::encode(CANDIDATES_SCRIPT_WITH_APPLIED_PARAMS));
+	}
+
+	#[test]
+	fn unapply_term_csl() {
+		let applied =
+			PlutusScript::from_wrapped_cbor(&CANDIDATES_SCRIPT_RAW, Language::new_plutus_v2())
+				.unwrap()
+				.apply_data(TEST_GENESIS_UTXO)
+				.unwrap();
+
+		let mut buffer = Vec::new();
+		let program = Program::<DeBruijn>::from_cbor(&applied.bytes, &mut buffer).unwrap();
+		let term = program.term;
+		let data: Option<uplc::PlutusData> = match term {
+			uplc::ast::Term::Apply { function: _, argument } => (*argument).clone().try_into().ok(),
+			_ => None,
+		};
+
+		assert_eq!(
+			data,
+			Some(plutus_data(&minicbor::to_vec(TEST_GENESIS_UTXO.to_datum()).unwrap()).unwrap())
+		)
+	}
+
+	#[test]
+	fn unapply_term_uplc() {
+		let applied =
+			PlutusScript::from_wrapped_cbor(&CANDIDATES_SCRIPT_RAW, Language::new_plutus_v2())
+				.unwrap()
+				.apply_data(TEST_GENESIS_UTXO)
+				.unwrap();
+
+		let mut buffer = Vec::new();
+		let program = Program::<DeBruijn>::from_cbor(&applied.bytes, &mut buffer).unwrap();
+		let term = program.term;
+		let data: Option<uplc::PlutusData> = match term {
+			uplc::ast::Term::Apply { function: _function, argument } => {
+				(*argument).clone().try_into().ok()
+			},
+			_ => None,
+		};
+
+		assert_eq!(
+			data,
+			Some(plutus_data(&minicbor::to_vec(TEST_GENESIS_UTXO.to_datum()).unwrap()).unwrap())
+		)
 	}
 }

--- a/toolkit/offchain/src/reserve/create.rs
+++ b/toolkit/offchain/src/reserve/create.rs
@@ -110,17 +110,18 @@ fn create_reserve_tx(
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&reserve.scripts.auth_policy,
+		&reserve.scripts.auth_policy.clone().into(),
 		&reserve.auth_policy_version_utxo.to_csl_tx_input(),
-		&costs.get_mint(&reserve.scripts.auth_policy),
+		&costs.get_mint(&reserve.scripts.auth_policy.csl_script_hash()),
 	)?;
 	tx_builder.add_output(&reserve_validator_output(parameters, &reserve.scripts, ctx)?)?;
 
 	let gov_tx_input = governance.utxo_id_as_tx_input();
+	let gov_policy_script = governance.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance.policy_script,
+		&gov_policy_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 	tx_builder.add_script_reference_input(
 		&reserve.validator_version_utxo.to_csl_tx_input(),

--- a/toolkit/offchain/src/reserve/deposit.rs
+++ b/toolkit/offchain/src/reserve/deposit.rs
@@ -108,10 +108,11 @@ fn deposit_to_reserve_tx(
 		&costs.get_one_spend(),
 	)?);
 
+	let gov_policy_script = governance.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance.policy_script,
+		&gov_policy_script,
 		&governance.utxo_id_as_tx_input(),
-		&costs.get_mint(&governance.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 
 	tx_builder.add_script_reference_input(

--- a/toolkit/offchain/src/reserve/handover.rs
+++ b/toolkit/offchain/src/reserve/handover.rs
@@ -95,12 +95,14 @@ fn build_tx(
 	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
 
 	let reserve_auth_policy_spend_cost = costs.get_one_spend();
-	let reserve_auth_policy_burn_cost = costs.get_mint(&reserve.scripts.auth_policy);
-	let governance_mint_cost = costs.get_mint(&governance.policy_script);
+	let reserve_auth_policy_burn_cost =
+		costs.get_mint(&reserve.scripts.auth_policy.csl_script_hash());
+	let governance_script = governance.policy.script();
+	let governance_mint_cost = costs.get_mint(&governance_script.csl_script_hash());
 
 	// mint goveranance token
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance.policy_script,
+		&governance_script,
 		&governance.utxo_id_as_tx_input(),
 		&governance_mint_cost,
 	)?;
@@ -115,7 +117,7 @@ fn build_tx(
 
 	// burn reserve auth policy token
 	tx_builder.add_mint_script_token_using_reference_script(
-		&reserve.scripts.auth_policy,
+		&reserve.scripts.auth_policy.clone().into(),
 		&reserve.auth_policy_version_utxo.to_csl_tx_input(),
 		&Int::new_i32(-1),
 		&reserve_auth_policy_burn_cost,

--- a/toolkit/offchain/src/reserve/init.rs
+++ b/toolkit/offchain/src/reserve/init.rs
@@ -162,7 +162,7 @@ fn init_script_tx(
 			&version_oracle.policy,
 			&version_oracle_asset_name(),
 			&witness,
-			&costs.get_mint(&version_oracle.policy),
+			&costs.get_mint(&version_oracle.policy.csl_script_hash()),
 		)?;
 	}
 	{
@@ -182,13 +182,14 @@ fn init_script_tx(
 	}
 	// Mint governance token
 	let gov_tx_input = governance.utxo_id_as_tx_input();
+	let gov_script = governance.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance.policy_script,
+		&gov_script,
 		&gov_tx_input,
-		&costs.get_mint(&governance.policy_script),
+		&costs.get_mint(&gov_script.csl_script_hash()),
 	)?;
 
-	tx_builder.add_script_reference_input(&gov_tx_input, governance.policy_script.bytes.len());
+	tx_builder.add_script_reference_input(&gov_tx_input, gov_script.length());
 	Ok(tx_builder.balance_update_and_build(ctx)?)
 }
 
@@ -243,15 +244,15 @@ mod tests {
 	use crate::{
 		csl::{unit_plutus_data, Costs, OgmiosUtxoExt, TransactionContext},
 		governance::GovernanceData,
-		plutus_script::PlutusScript,
 		scripts_data::{self, VersionOracleData},
-		test_values::{make_utxo, payment_addr, payment_key, protocol_parameters},
+		test_values::{
+			make_utxo, payment_addr, payment_key, protocol_parameters, test_governance_policy,
+		},
 	};
 	use cardano_serialization_lib::{
-		AssetName, BigNum, ConstrPlutusData, ExUnits, Int, Language, NetworkIdKind, PlutusData,
-		PlutusList, RedeemerTag, ScriptHash, Transaction,
+		AssetName, BigNum, ConstrPlutusData, ExUnits, Int, NetworkIdKind, PlutusData, PlutusList,
+		RedeemerTag, ScriptHash, Transaction,
 	};
-	use hex_literal::hex;
 	use ogmios_client::types::{OgmiosTx, OgmiosUtxo};
 	use raw_scripts::ScriptId;
 	use sidechain_domain::UtxoId;
@@ -310,7 +311,7 @@ mod tests {
 		let gov_token_amount = change_output
 			.amount()
 			.multiasset()
-			.and_then(|ma| ma.get(&test_governance_data().policy_script.csl_script_hash()))
+			.and_then(|ma| ma.get(&test_governance_data().policy.script().csl_script_hash()))
 			.and_then(|gov_ma| gov_ma.get(&AssetName::new(vec![]).unwrap()))
 			.unwrap();
 		assert_eq!(gov_token_amount, BigNum::one(), "Change contains one goverenance token");
@@ -342,7 +343,7 @@ mod tests {
 		let gov_mint = tx
 			.body()
 			.mint()
-			.and_then(|mint| mint.get(&test_governance_data().policy_script.csl_script_hash()))
+			.and_then(|mint| mint.get(&test_governance_data().policy.script().csl_script_hash()))
 			.and_then(|assets| assets.get(0))
 			.and_then(|assets| assets.get(&AssetName::new(vec![]).unwrap()))
 			.expect("Transaction should have a mint of Governance Policy token");
@@ -410,16 +411,12 @@ mod tests {
 		)
 	}
 
-	fn test_governance_script() -> PlutusScript {
-		PlutusScript { bytes: hex!("112233").to_vec(), language: Language::new_plutus_v2() }
-	}
-
 	fn test_governance_input() -> OgmiosUtxo {
 		OgmiosUtxo { transaction: OgmiosTx { id: [16; 32] }, index: 0, ..Default::default() }
 	}
 
 	fn test_governance_data() -> GovernanceData {
-		GovernanceData { policy_script: test_governance_script(), utxo: test_governance_input() }
+		GovernanceData { policy: test_governance_policy(), utxo: test_governance_input() }
 	}
 
 	fn version_oracle_data() -> VersionOracleData {
@@ -454,7 +451,7 @@ mod tests {
 	fn test_costs() -> Costs {
 		Costs::new(
 			vec![
-				(test_governance_script().csl_script_hash(), governance_script_cost()),
+				(test_governance_policy().script().csl_script_hash(), governance_script_cost()),
 				(version_oracle_policy_csl_script_hash(), versioning_script_cost()),
 			]
 			.into_iter()

--- a/toolkit/offchain/src/reserve/release.rs
+++ b/toolkit/offchain/src/reserve/release.rs
@@ -128,12 +128,12 @@ fn reserve_release_tx(
 
 	// Mint v-function tokens in the number equal to the *total* number of tokens transfered.
 	// This serves as a validation of the v-function value.
-	let v_function = v_function_from_utxo(reference_utxo)?;
+	let v_function = Script::Plutus(v_function_from_utxo(reference_utxo)?);
 	tx_builder.add_mint_script_token_using_reference_script(
 		&v_function,
 		&reference_utxo.to_csl_tx_input(),
 		&Int::new(&cumulative_total_transfer.into()),
-		&costs.get_mint(&v_function),
+		&costs.get_mint(&v_function.csl_script_hash()),
 	)?;
 
 	// Remove tokens from the reserve

--- a/toolkit/offchain/src/reserve/update_settings.rs
+++ b/toolkit/offchain/src/reserve/update_settings.rs
@@ -124,10 +124,11 @@ fn update_reserve_settings_tx(
 		tx_builder.add_output(&a)?;
 	}
 
+	let gov_policy_script = governance.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance.policy_script,
+		&gov_policy_script,
 		&governance.utxo_id_as_tx_input(),
-		&costs.get_mint(&governance.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 	tx_builder.add_script_reference_input(
 		&reserve.illiquid_circulation_supply_validator_version_utxo.to_csl_tx_input(),

--- a/toolkit/offchain/src/test_values.rs
+++ b/toolkit/offchain/src/test_values.rs
@@ -1,4 +1,7 @@
-use crate::plutus_script::PlutusScript;
+use crate::{
+	governance::{GovernancePolicyScript, PartnerChainsMultisigPolicy},
+	plutus_script::PlutusScript,
+};
 use cardano_serialization_lib::{Address, Language, PlutusData, PrivateKey};
 use hex_literal::hex;
 use ogmios_client::{
@@ -39,6 +42,18 @@ pub(crate) fn test_policy() -> PlutusScript {
 		bytes: hex!("49480100002221200101").to_vec(),
 		language: Language::new_plutus_v2(),
 	}
+}
+
+pub(crate) fn test_governance_policy() -> GovernancePolicyScript {
+	GovernancePolicyScript::MultiSig(PartnerChainsMultisigPolicy {
+		script: test_governance_script(),
+		key_hashes: vec![],
+		threshold: 0,
+	})
+}
+
+pub(crate) fn test_governance_script() -> PlutusScript {
+	PlutusScript { bytes: hex!("112233").to_vec(), language: Language::new_plutus_v2() }
 }
 
 pub(crate) fn test_plutus_data() -> PlutusData {

--- a/toolkit/offchain/src/update_governance/mod.rs
+++ b/toolkit/offchain/src/update_governance/mod.rs
@@ -100,11 +100,11 @@ fn update_governance_tx(
 
 	let config = crate::csl::get_builder_config(ctx)?;
 	let mut tx_builder = TransactionBuilder::new(&config);
-
+	let gov_policy_script = governance_data.policy.script();
 	tx_builder.add_mint_one_script_token_using_reference_script(
-		&governance_data.policy_script,
+		&gov_policy_script,
 		&governance_data.utxo_id_as_tx_input(),
-		&costs.get_mint(&governance_data.policy_script),
+		&costs.get_mint(&gov_policy_script.csl_script_hash()),
 	)?;
 
 	tx_builder.add_output(&version_oracle_datum_output(

--- a/toolkit/offchain/src/update_governance/test.rs
+++ b/toolkit/offchain/src/update_governance/test.rs
@@ -1,7 +1,7 @@
 use super::{test_values, update_governance_tx};
 use crate::csl::{empty_asset_name, Costs, OgmiosUtxoExt, TransactionContext};
 use crate::governance::GovernanceData;
-use crate::test_values::protocol_parameters;
+use crate::test_values::{protocol_parameters, test_governance_policy};
 use cardano_serialization_lib::*;
 use hex_literal::hex;
 use ogmios_client::types::{Asset, Datum, OgmiosTx, OgmiosUtxo, OgmiosValue};
@@ -86,12 +86,8 @@ fn genesis_utxo() -> OgmiosUtxo {
 	}
 }
 
-fn governance_script() -> crate::plutus_script::PlutusScript {
-	crate::plutus_script::PlutusScript { language: Language::new_plutus_v2(), bytes: vec![] }
-}
-
 fn governance_data() -> GovernanceData {
-	GovernanceData { policy_script: governance_script(), utxo: governance_utxo() }
+	GovernanceData { policy: test_governance_policy(), utxo: governance_utxo() }
 }
 
 fn new_governance_authority() -> MainchainKeyHash {
@@ -108,7 +104,7 @@ fn spend_ex_units() -> ExUnits {
 
 fn test_costs() -> Costs {
 	Costs::new(
-		vec![(governance_script().csl_script_hash(), mint_ex_units())]
+		vec![(test_governance_policy().script().csl_script_hash(), mint_ex_units())]
 			.into_iter()
 			.collect(),
 		vec![(0, spend_ex_units())].into_iter().collect(),
@@ -117,7 +113,7 @@ fn test_costs() -> Costs {
 
 fn multisig_policy_hash() -> [u8; 28] {
 	// important: this is the hash of the multisig policy parametrized with the *old* authority
-	hex!("a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a")
+	hex!("67400f8946a8572fe1d74005244979ae59ec021e4e2736d1a82e2e89")
 }
 
 fn version_oracle_validator_address() -> Address {

--- a/toolkit/offchain/src/update_governance/test_values.rs
+++ b/toolkit/offchain/src/update_governance/test_values.rs
@@ -42,10 +42,10 @@ pub(crate) fn test_update_governance_tx() -> serde_json::Value {
 					// change returned
 					"address": "addr_test1vpmd59ajuvm34d723r8q2qzyz9ylq0x9pygqn7vun8qgpkgs7y5hw",
 					"amount": {
-						"coin": "9922275427",
+						"coin": "9922275382",
 						// minted governance token
 						"multiasset": {
-							"a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a": {
+							"67400f8946a8572fe1d74005244979ae59ec021e4e2736d1a82e2e89": {
 								"": "1"
 							}
 						}
@@ -54,7 +54,7 @@ pub(crate) fn test_update_governance_tx() -> serde_json::Value {
 					"script_ref": null
 				}
 			],
-			"fee": "297747",
+			"fee": "297792",
 			"ttl": null,
 			"certs": null,
 			"withdrawals": null,
@@ -64,7 +64,7 @@ pub(crate) fn test_update_governance_tx() -> serde_json::Value {
 			"mint": [
 				[
 					// governance token
-					"a646474b8f5431261506b6c273d307c7569a4eb6c96b42dd4a29520a",
+					"67400f8946a8572fe1d74005244979ae59ec021e4e2736d1a82e2e89",
 					{
 						"": "1"
 					}
@@ -84,13 +84,13 @@ pub(crate) fn test_update_governance_tx() -> serde_json::Value {
 			"collateral_return": {
 				"address": "addr_test1vpmd59ajuvm34d723r8q2qzyz9ylq0x9pygqn7vun8qgpkgs7y5hw",
 				"amount": {
-					"coin": "9922499316",
+					"coin": "9922499248",
 					"multiasset": null
 				},
 				"plutus_data": null,
 				"script_ref": null
 			},
-			"total_collateral": "446621",
+			"total_collateral": "446689",
 			"reference_inputs": null,
 			"voting_procedures": null,
 			"voting_proposals": null,


### PR DESCRIPTION
# Description

Introduces `Script` type as enum that can represent `PlutsScript` (our wrapper) or `NativeScript` (CSL only, not wrapped).

Draft, because some new tests should be added here.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
