### PR TITLE
fix: use default of 1000ms in start-node when slot_duration_missing (ETCM-9582)

### DIFF
--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -272,7 +272,12 @@ pub struct CardanoParameters {
 	pub first_slot_number: u64,
 	pub epoch_duration_millis: u64,
 	pub first_epoch_timestamp_millis: u64,
+	#[serde(default = "default_slot_duration_millis")]
 	pub slot_duration_millis: u64,
+}
+
+fn default_slot_duration_millis() -> u64 {
+	1000
 }
 
 impl CardanoParameters {


### PR DESCRIPTION
# Description

This is for backwards compatibility with wizard config files from 1.5 and before.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
