### PR TITLE
test: fix staging validators' ports and smart-contracts response handling

### DIFF
--- a/e2e-tests/config/substrate/staging-ci.json
+++ b/e2e-tests/config/substrate/staging-ci.json
@@ -16,6 +16,10 @@
             "validator-4": {
                 "host": "staging-preview-validator-4-service.staging-preview.svc.cluster.local",
                 "port": "${nodes_config[default_port]}"
+            },
+            "validator-5": {
+                "host": "staging-preview-validator-5-service.staging-preview.svc.cluster.local",
+                "port": "${nodes_config[default_port]}"
             }
         }
     },

--- a/e2e-tests/config/substrate/staging_nodes.json
+++ b/e2e-tests/config/substrate/staging_nodes.json
@@ -8,7 +8,7 @@
         "nodes": {
             "validator-1": {
                 "host": "10.0.10.90",
-                "port": "30621",
+                "port": "30321",
                 "aura_ss58_address": "5GHLr2zBDNPXno9XdKgh541uRSiTxnZyzFcr4jK6HUbHMpit",
                 "pool_id": "da74fc8256d15c7ab3370a6ca28398986cb97c32e9ef66026ac61e99",
                 "public_key": "0x03b827f4da9711bab7292e5695576a841a4d20af9a07b1ba7a230168d2a78e9df4",
@@ -26,7 +26,7 @@
             },
             "validator-2": {
                 "host": "10.0.10.90",
-                "port": "30622",
+                "port": "30322",
                 "aura_ss58_address": "5DHbxU687f1Y3x8yBCWMtqSiJ5qt2yrxQPXNXZNNDaFtmXKv",
                 "pool_id": "eaed153a8b046770cfd094ee72d080ea682188e63ac11937e3f7f827",
                 "public_key": "0x02ef5bcd94d54a18ad199559782cd72ac3ccd850976aaaafbca8f9d2625afbf7c4",
@@ -44,7 +44,7 @@
             },
             "validator-3": {
                 "host": "10.0.10.90",
-                "port": "30623",
+                "port": "30323",
                 "aura_ss58_address": "5FYtL6HccYhk6KZeFP7hNnkMaXrAwVpTHJWsfnNJcu8AM6in",
                 "pool_id": "7dfba85597a867fffa59037df7f6adcd50e745dcceac2b48eda94b20",
                 "public_key": "0x02f2762ab6e1a125dc03908a7b738f8023d13763f28a11d7633c6c8bc463478430",
@@ -62,7 +62,7 @@
             },
             "validator-4": {
                 "host": "10.0.10.90",
-                "port": "30624",
+                "port": "30324",
                 "aura_ss58_address": "5GVpqdtqjxqUjuVKMkmh8ehSwcs2nXjpvzHqjouZXMJAyC4b",
                 "pool_id": "2a3f5dd02da1310e081f2367412e02b72baad3e2a5045f62df2c78c5",
                 "public_key": "0x025e19f82c5e2bac5e8869d49ff26359e442628bc5cfa38eeb5275f43d04015da8",
@@ -80,7 +80,7 @@
             },
             "validator-5": {
                 "host": "10.0.10.90",
-                "port": "30625",
+                "port": "30325",
                 "aura_ss58_address": "5DsfhT7HJe6i5LYeKBzefrXijW5UgPsn2Cuyw5WMa4uEktTn",
                 "pool_id": "ae81beee7a6c3fa13bba811f91f63ebdd7eb25dd8a62476d4996de10",
                 "public_key": "0x03f38a062a4b372c045c1dddc4fe98a2c9cb1d6eec8bf02f973fd29b1096cd8155",

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -280,33 +280,37 @@ class SubstrateApi(BlockchainApi):
     def update_d_param(self, permissioned_candidates_count, registered_candidates_count):
         signing_key = self.config.nodes_config.governance_authority.mainchain_key
 
-        tx_id = self.partner_chains_node.smart_contracts.update_d_param(
+        response = self.partner_chains_node.smart_contracts.update_d_param(
             permissioned_candidates_count, registered_candidates_count, signing_key
         )
+        tx_id = response.transaction_id
         effective_in_mc_epoch = self._effective_in_mc_epoch()
 
-        if tx_id and effective_in_mc_epoch:
+        if tx_id:
             logger.info(
                 f"Update of D Param of P: {permissioned_candidates_count} and R: {registered_candidates_count} "
                 f" was successful and will take effect in {effective_in_mc_epoch} epoch. Transaction id: {tx_id}"
             )
             return True, effective_in_mc_epoch
         else:
+            logger.error(f"Update of D Param failed, STDOUT: {response.stdout}, STDERR: {response.stderr}")
             return False, None
 
     def upsert_permissioned_candidates(self, new_candidates_list):
-        txId = self.partner_chains_node.smart_contracts.upsert_permissioned_candidates(
+        response = self.partner_chains_node.smart_contracts.upsert_permissioned_candidates(
             self.config.nodes_config.governance_authority.mainchain_key, new_candidates_list
         )
+        tx_id = response.transaction_id
         effective_in_mc_epoch = self._effective_in_mc_epoch()
 
-        if txId and effective_in_mc_epoch:
+        if tx_id:
             logger.info(
                 f"Success! New permissioned candidates are set and will be effective in "
-                f"{effective_in_mc_epoch} MC epoch. Transaction id: {txId}"
+                f"{effective_in_mc_epoch} MC epoch. Transaction id: {tx_id}"
             )
             return True, effective_in_mc_epoch
         else:
+            logger.error(f"Upsert permissioned candidates failed, STDOUT: {response.stdout}, STDERR: {response.stderr}")
             return False, None
 
     def register_candidate(self, candidate_name):
@@ -324,37 +328,45 @@ class SubstrateApi(BlockchainApi):
             self.config.nodes_config.nodes[candidate_name].grandpa_public_key,
         )
 
-        txId = self.partner_chains_node.smart_contracts.register(
+        response = self.partner_chains_node.smart_contracts.register(
             signatures,
             keys_files.cardano_payment_key,
             self.read_cardano_key_file(keys_files.spo_public_key),
             registration_utxo,
         )
+        tx_id = response.transaction_id
         effective_in_mc_epoch = self._effective_in_mc_epoch()
 
-        if txId and effective_in_mc_epoch:
+        if tx_id:
             logger.info(
                 f"Registration of {candidate_name} was successful and will take effect in "
-                f"{effective_in_mc_epoch} MC epoch. Transaction id: {txId}"
+                f"{effective_in_mc_epoch} MC epoch. Transaction id: {tx_id}"
             )
             return True, effective_in_mc_epoch
         else:
+            logger.error(
+                f"Registration of {candidate_name} failed, STDOUT: {response.stdout}, STDERR: {response.stderr}"
+            )
             return False, None
 
     def deregister_candidate(self, candidate_name):
         keys_files = self.config.nodes_config.nodes[candidate_name].keys_files
-        txId = self.partner_chains_node.smart_contracts.deregister(
+        response = self.partner_chains_node.smart_contracts.deregister(
             keys_files.cardano_payment_key, self.read_cardano_key_file(keys_files.spo_public_key)
         )
+        tx_id = response.transaction_id
         effective_in_mc_epoch = self._effective_in_mc_epoch()
 
-        if txId and effective_in_mc_epoch:
+        if tx_id:
             logger.info(
                 f"Deregistration of {candidate_name} was successful and will take effect in "
-                f"{effective_in_mc_epoch} MC epoch. Transaction id: {txId}"
+                f"{effective_in_mc_epoch} MC epoch. Transaction id: {tx_id}"
             )
             return True, effective_in_mc_epoch
         else:
+            logger.error(
+                f"Deregistration of {candidate_name} failed, STDOUT: {response.stdout}, STDERR: {response.stderr}"
+            )
             return False, None
 
     def get_pc_epoch(self):

--- a/e2e-tests/tests/committee/test_committee.py
+++ b/e2e-tests/tests/committee/test_committee.py
@@ -38,6 +38,7 @@ class TestCommitteeDistribution:
     @mark.committee_distribution
     @mark.ariadne
     @mark.xdist_group("governance_action")
+    @mark.usefixtures("governance_skey_with_cli")
     def test_update_d_param(
         self,
         api: BlockchainApi,
@@ -73,7 +74,7 @@ class TestCommitteeDistribution:
         result, mc_epoch = api.update_d_param(
             new_d_param.permissioned_candidates_number, new_d_param.trustless_candidates_number
         )
-        assert result, "D-param update failed"
+        assert result, "D-param transaction id is empty. Check command output for errors."
 
         # FIXME: ETCM-8945 - create and use wait_for_transaction function instead of wait_for_next_pc_block
         api.wait_for_next_pc_block()


### PR DESCRIPTION
added:
- staging validator-5 dns resolvable when run in CI

fixed:
- staging validators' ports
- `node smart-contracts` response handling after recent refactoring
- `test_update_d_param` could not be run on staging due to missing fixture to scp skey