### PR TITLE
feat: prepare upsert-permissioned-candidates for MultiSig

### DIFF
--- a/toolkit/offchain/src/governance.rs
+++ b/toolkit/offchain/src/governance.rs
@@ -34,6 +34,22 @@ impl GovernancePolicyScript {
 			},
 		}
 	}
+
+	/// Checks if the policy is 1 of 1 for given key hash
+	pub(crate) fn is_single_key_policy_for(&self, key_hash: &Ed25519KeyHash) -> bool {
+		match self {
+			Self::MultiSig(PartnerChainsMultisigPolicy { script: _, key_hashes, threshold }) => {
+				*threshold == 1
+					&& key_hashes.len() == 1
+					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(h.clone()) == key_hash)
+			},
+			Self::AtLeastNNativeScript(SimpleAtLeastN { threshold, key_hashes }) => {
+				*threshold == 1
+					&& key_hashes.len() == 1
+					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(h.clone()) == key_hash)
+			},
+		}
+	}
 }
 
 /// Plutus MultiSig smart contract implemented in partner-chains-smart-contracts repo

--- a/toolkit/offchain/src/permissioned_candidates.rs
+++ b/toolkit/offchain/src/permissioned_candidates.rs
@@ -25,7 +25,7 @@ use ogmios_client::types::OgmiosUtxo;
 use partner_chains_plutus_data::permissioned_candidates::{
 	permissioned_candidates_to_plutus_data, PermissionedCandidateDatums,
 };
-use sidechain_domain::{McTxHash, PermissionedCandidateData, UtxoId};
+use sidechain_domain::{McSmartContractResult, McTxHash, PermissionedCandidateData, UtxoId};
 
 pub trait UpsertPermissionedCandidates {
 	#[allow(async_fn_in_trait)]
@@ -34,7 +34,7 @@ pub trait UpsertPermissionedCandidates {
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<McTxHash>>;
+	) -> anyhow::Result<Option<McSmartContractResult>>;
 }
 
 impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId>
@@ -45,7 +45,7 @@ impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId>
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<McTxHash>> {
+	) -> anyhow::Result<Option<McSmartContractResult>> {
 		upsert_permissioned_candidates(
 			genesis_utxo,
 			candidates,
@@ -66,7 +66,7 @@ pub async fn upsert_permissioned_candidates<
 	payment_signing_key: &CardanoPaymentSigningKey,
 	ogmios_client: &C,
 	await_tx: &A,
-) -> anyhow::Result<Option<McTxHash>> {
+) -> anyhow::Result<Option<McSmartContractResult>> {
 	let ctx = TransactionContext::for_payment_key(payment_signing_key, ogmios_client).await?;
 	let (validator, policy) =
 		scripts_data::permissioned_candidates_scripts(genesis_utxo, ctx.network)?;
@@ -76,7 +76,7 @@ pub async fn upsert_permissioned_candidates<
 	let mut candidates = candidates.to_owned();
 	candidates.sort();
 
-	let tx_hash_opt = match get_current_permissioned_candidates(validator_utxos)? {
+	let result_opt = match get_current_permissioned_candidates(validator_utxos)? {
 		Some((_, current_permissioned_candidates))
 			if current_permissioned_candidates == *candidates =>
 		{
@@ -115,10 +115,10 @@ pub async fn upsert_permissioned_candidates<
 			)
 		},
 	};
-	if let Some(tx_hash) = tx_hash_opt {
+	if let Some(McSmartContractResult::TxHash(tx_hash)) = result_opt {
 		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
 	}
-	Ok(tx_hash_opt)
+	Ok(result_opt)
 }
 
 fn get_current_permissioned_candidates(
@@ -151,7 +151,7 @@ async fn insert_permissioned_candidates<C>(
 	governance_data: &GovernanceData,
 	ctx: TransactionContext,
 	client: &C,
-) -> anyhow::Result<McTxHash>
+) -> anyhow::Result<McSmartContractResult>
 where
 	C: Transactions + QueryLedgerState + QueryNetwork,
 {
@@ -170,17 +170,22 @@ where
 	)
 	.await?;
 
-	let signed_tx = ctx.sign(&tx).to_bytes();
-	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
-		anyhow!(
-			"Submit insert permissioned candidates transaction request failed: {}, bytes: {}",
-			e,
-			hex::encode(tx.to_bytes())
-		)
-	})?;
-	let tx_id = McTxHash(res.transaction.id);
-	log::info!("Transaction submitted: {}", hex::encode(tx_id.0));
-	Ok(tx_id)
+	if governance_data.policy.is_single_key_policy_for(&ctx.payment_key_hash()) {
+		let signed_tx = ctx.sign(&tx).to_bytes();
+		let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+			anyhow!(
+				"Submit insert permissioned candidates transaction request failed: {}, bytes: {}",
+				e,
+				hex::encode(tx.to_bytes())
+			)
+		})?;
+		let tx_id = res.transaction.id;
+		log::info!("Transaction submitted: {}", hex::encode(tx_id));
+		Ok(McSmartContractResult::tx_hash(tx_id))
+	} else {
+		log::info!("Transaction CBOR: {}", hex::encode(tx.to_bytes()));
+		Ok(McSmartContractResult::TxCBOR(tx.to_bytes()))
+	}
 }
 
 async fn update_permissioned_candidates<C>(
@@ -191,7 +196,7 @@ async fn update_permissioned_candidates<C>(
 	governance_data: &GovernanceData,
 	ctx: TransactionContext,
 	client: &C,
-) -> anyhow::Result<McTxHash>
+) -> anyhow::Result<McSmartContractResult>
 where
 	C: Transactions + QueryNetwork + QueryLedgerState,
 {
@@ -211,17 +216,25 @@ where
 	)
 	.await?;
 
-	let signed_tx = ctx.sign(&tx).to_bytes();
-	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
-		anyhow!(
-			"Submit update permissioned candidates transaction request failed: {}, bytes: {}",
-			e,
-			hex::encode(&signed_tx)
-		)
-	})?;
-	let tx_id = McTxHash(res.transaction.id);
-	log::info!("Update permissioned candidates transaction submitted: {}", hex::encode(tx_id.0));
-	Ok(tx_id)
+	if governance_data.policy.is_single_key_policy_for(&ctx.payment_key_hash()) {
+		let signed_tx = ctx.sign(&tx).to_bytes();
+		let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+			anyhow!(
+				"Submit update permissioned candidates transaction request failed: {}, bytes: {}",
+				e,
+				hex::encode(&signed_tx)
+			)
+		})?;
+		let tx_id = McTxHash(res.transaction.id);
+		log::info!(
+			"Update permissioned candidates transaction submitted: {}",
+			hex::encode(tx_id.0)
+		);
+		Ok(McSmartContractResult::TxHash(tx_id))
+	} else {
+		log::info!("Transaction CBOR: {}", hex::encode(tx.to_bytes()));
+		Ok(McSmartContractResult::TxCBOR(tx.to_bytes()))
+	}
 }
 
 /// Builds a transaction that mints a Permissioned Candidates token and also mint governance token

--- a/toolkit/offchain/src/permissioned_candidates.rs
+++ b/toolkit/offchain/src/permissioned_candidates.rs
@@ -85,7 +85,7 @@ pub async fn upsert_permissioned_candidates<
 		},
 		Some((current_utxo, _)) => {
 			log::info!(
-				"Current permissioned candidates are different to the one to be set. Updating."
+				"Current permissioned candidates are different to the one to be set. Preparing transaction to update."
 			);
 			Some(
 				update_permissioned_candidates(
@@ -101,7 +101,9 @@ pub async fn upsert_permissioned_candidates<
 			)
 		},
 		None => {
-			log::info!("There are permissioned candidates. Inserting new ones.");
+			log::info!(
+				"There aren't any permissioned candidates. Preparing transaction to insert."
+			);
 			Some(
 				insert_permissioned_candidates(
 					&validator,

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -11,7 +11,8 @@ use crate::{verify_json, CmdRun};
 use hex_literal::hex;
 use serde_json::json;
 use sidechain_domain::{
-	AuraPublicKey, DParameter, GrandpaPublicKey, McTxHash, SidechainPublicKey, UtxoId,
+	AuraPublicKey, DParameter, GrandpaPublicKey, McSmartContractResult, McTxHash,
+	SidechainPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 
@@ -47,7 +48,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			genesis_utxo(),
 			&initial_permissioned_candidates(),
 			payment_signing_key(),
-			Ok(Some(McTxHash([2; 32]))),
+			Ok(Some(McSmartContractResult::tx_hash([2; 32]))),
 		);
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
@@ -101,7 +102,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			genesis_utxo(),
 			&initial_permissioned_candidates(),
 			payment_signing_key(),
-			Ok(Some(McTxHash([2; 32]))),
+			Ok(Some(McSmartContractResult::tx_hash([2; 32]))),
 		);
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -10,7 +10,8 @@ use partner_chains_cardano_offchain::scripts_data::{GetScriptsData, ScriptsData}
 use partner_chains_cardano_offchain::{cardano_keys::CardanoPaymentSigningKey, OffchainError};
 use pretty_assertions::assert_eq;
 use sidechain_domain::{
-	CandidateRegistration, DParameter, MainchainKeyHash, McTxHash, StakePoolPublicKey, UtxoId,
+	CandidateRegistration, DParameter, MainchainKeyHash, McSmartContractResult, McTxHash,
+	StakePoolPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 use std::collections::HashMap;
@@ -238,7 +239,7 @@ pub struct OffchainMock {
 		HashMap<(UtxoId, DParameter, PrivateKeyBytes), Result<Option<McTxHash>, String>>,
 	pub upsert_permissioned_candidates: HashMap<
 		(UtxoId, Vec<sidechain_domain::PermissionedCandidateData>, PrivateKeyBytes),
-		Result<Option<McTxHash>, String>,
+		Result<Option<McSmartContractResult>, String>,
 	>,
 	pub register: HashMap<
 		(UtxoId, CandidateRegistration, PrivateKeyBytes),
@@ -322,7 +323,7 @@ impl OffchainMock {
 		genesis_utxo: UtxoId,
 		candidates: &[sidechain_domain::PermissionedCandidateData],
 		payment_key: PrivateKeyBytes,
-		result: Result<Option<McTxHash>, String>,
+		result: Result<Option<McSmartContractResult>, String>,
 	) -> Self {
 		Self {
 			upsert_permissioned_candidates: [(
@@ -423,7 +424,7 @@ impl UpsertPermissionedCandidates for OffchainMock {
 		genesis_utxo: UtxoId,
 		candidates: &[sidechain_domain::PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<McTxHash>> {
+	) -> anyhow::Result<Option<McSmartContractResult>> {
 		self.upsert_permissioned_candidates
 			.get(&(genesis_utxo, candidates.to_vec(), payment_signing_key.to_bytes()))
 			.cloned()

--- a/toolkit/primitives/domain/src/lib.rs
+++ b/toolkit/primitives/domain/src/lib.rs
@@ -606,6 +606,12 @@ pub enum McSmartContractResult {
 	TxCBOR(Vec<u8>),
 }
 
+impl McSmartContractResult {
+	pub fn tx_hash(hash: [u8; 32]) -> Self {
+		Self::TxHash(McTxHash(hash))
+	}
+}
+
 #[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct McBlockHash(pub [u8; 32]);


### PR DESCRIPTION
# Description

`upsert-permissioned-candidates` will return transaction cbor if the governance authority is not 1-of-1 for a payment key.


I cannot get this to test with multisig governance yet, because we don't have update governance implemented

Ref: https://input-output.atlassian.net/browse/ETCM-9500

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
