### PR TITLE
add: ETCM-9596 block producer metadata singing command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,10 +1287,12 @@ dependencies = [
  "parity-scale-codec",
  "plutus",
  "plutus-datum-derive",
+ "pretty_assertions",
  "secp256k1 0.28.2",
  "serde",
  "serde_json",
  "sidechain-domain",
+ "sp-block-producer-metadata",
  "sp-io",
  "thiserror",
 ]
@@ -9543,6 +9545,7 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d24b59d129cdadea20aea4fb2352fa053712e5d713eee47d700cd4b2bc002f10"
 dependencies = [
+ "bitcoin_hashes",
  "secp256k1-sys 0.9.2",
 ]
 
@@ -10261,6 +10264,16 @@ dependencies = [
  "sp-runtime",
  "thiserror",
  "tokio",
+]
+
+[[package]]
+name = "sp-block-producer-metadata"
+version = "0.1.0"
+dependencies = [
+ "hex-literal",
+ "parity-scale-codec",
+ "secp256k1 0.28.2",
+ "sidechain-domain",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10268,7 +10268,7 @@ dependencies = [
 
 [[package]]
 name = "sp-block-producer-metadata"
-version = "0.1.0"
+version = "1.6.0"
 dependencies = [
  "hex-literal",
  "parity-scale-codec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
 	"toolkit/pallets/address-associations",
 	"toolkit/pallets/block-participation",
 	"toolkit/primitives/block-participation",
+	"toolkit/primitives/block-producer-metadata",
 ]
 resolver = "2"
 
@@ -237,3 +238,4 @@ partner-chains-smart-contracts-commands = { path = "toolkit/cli/smart-contracts-
 pallet-address-associations = { path = "toolkit/pallets/address-associations", default-features = false }
 pallet-block-participation = { path = "toolkit/pallets/block-participation", default-features = false }
 sp-block-participation = { path = "toolkit/primitives/block-participation", default-features = false }
+sp-block-producer-metadata = { path = "toolkit/primitives/block-producer-metadata", default-features = false }

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,8 @@ Its functionality was merged into `pallet-partner-chains-session` under the feat
 
 ## Added
 
+* `sign-block-producer-metadata` command to `cli-commands` for signing block producer metadata upsert message
+
 # v1.6.0
 
 ## Changed

--- a/node/node/src/command/mod.rs
+++ b/node/node/src/command/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
-use sidechain_runtime::Block;
+use sidechain_runtime::{Block, BlockProducerMetadata};
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -71,7 +71,11 @@ pub fn run() -> sc_cli::Result<()> {
 					components.other.3.authority_selection,
 				))
 			};
-			partner_chains_node_commands::run(&cli, make_dependencies, cmd.clone())
+			partner_chains_node_commands::run::<_, _, _, _, BlockProducerMetadata>(
+				&cli,
+				make_dependencies,
+				cmd.clone(),
+			)
 		},
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -31,7 +31,9 @@ use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier
 use parity_scale_codec::MaxEncodedLen;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
+use serde::Deserialize;
 use session_manager::ValidatorManagementSessionManager;
+use sidechain_domain::byte_string::SizedByteString;
 use sidechain_domain::{
 	DelegatorKey, MainchainKeyHash, PermissionedCandidateData, RegistrationData, ScEpochNumber,
 	ScSlotNumber, StakeDelegation, StakePoolPublicKey, UtxoId,
@@ -457,6 +459,27 @@ impl AsCardanoSPO for BlockAuthor {
 			BlockAuthor::ProBono(_) => None,
 		}
 	}
+}
+
+pub const MAX_METADATA_URL_LENGTH: u32 = 512;
+
+#[derive(Clone, Debug, MaxEncodedLen, Encode)]
+pub struct MetadataUrl(BoundedVec<u8, ConstU32<MAX_METADATA_URL_LENGTH>>);
+impl<'a> Deserialize<'a> for MetadataUrl {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'a>,
+	{
+		Ok(Self(BoundedVec::truncate_from(
+			alloc::string::String::deserialize(deserializer)?.as_bytes().to_vec(),
+		)))
+	}
+}
+
+#[derive(Clone, Debug, MaxEncodedLen, Encode, Deserialize)]
+pub struct BlockProducerMetadata {
+	pub url: MetadataUrl,
+	pub hash: SizedByteString<32>,
 }
 
 #[cfg(feature = "runtime-benchmarks")]

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -33,7 +33,7 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::Deserialize;
 use session_manager::ValidatorManagementSessionManager;
-use sidechain_domain::byte_string::SizedByteString;
+use sidechain_domain::byte_string::{SizedByteString, SizedString};
 use sidechain_domain::{
 	DelegatorKey, MainchainKeyHash, PermissionedCandidateData, RegistrationData, ScEpochNumber,
 	ScSlotNumber, StakeDelegation, StakePoolPublicKey, UtxoId,
@@ -463,22 +463,9 @@ impl AsCardanoSPO for BlockAuthor {
 
 pub const MAX_METADATA_URL_LENGTH: u32 = 512;
 
-#[derive(Clone, Debug, MaxEncodedLen, Encode)]
-pub struct MetadataUrl(BoundedVec<u8, ConstU32<MAX_METADATA_URL_LENGTH>>);
-impl<'a> Deserialize<'a> for MetadataUrl {
-	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-	where
-		D: serde::Deserializer<'a>,
-	{
-		Ok(Self(BoundedVec::truncate_from(
-			alloc::string::String::deserialize(deserializer)?.as_bytes().to_vec(),
-		)))
-	}
-}
-
 #[derive(Clone, Debug, MaxEncodedLen, Encode, Deserialize)]
 pub struct BlockProducerMetadata {
-	pub url: MetadataUrl,
+	pub url: SizedString<MAX_METADATA_URL_LENGTH>,
 	pub hash: SizedByteString<32>,
 }
 

--- a/node/runtime/src/lib.rs
+++ b/node/runtime/src/lib.rs
@@ -33,7 +33,7 @@ use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use serde::Deserialize;
 use session_manager::ValidatorManagementSessionManager;
-use sidechain_domain::byte_string::{SizedByteString, SizedString};
+use sidechain_domain::byte_string::{BoundedString, SizedByteString};
 use sidechain_domain::{
 	DelegatorKey, MainchainKeyHash, PermissionedCandidateData, RegistrationData, ScEpochNumber,
 	ScSlotNumber, StakeDelegation, StakePoolPublicKey, UtxoId,
@@ -465,7 +465,7 @@ pub const MAX_METADATA_URL_LENGTH: u32 = 512;
 
 #[derive(Clone, Debug, MaxEncodedLen, Encode, Deserialize)]
 pub struct BlockProducerMetadata {
-	pub url: SizedString<MAX_METADATA_URL_LENGTH>,
+	pub url: BoundedString<MAX_METADATA_URL_LENGTH>,
 	pub hash: SizedByteString<32>,
 }
 

--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -14,7 +14,7 @@ hex = { workspace = true }
 hex-literal = { workspace = true }
 plutus = { workspace = true, default-features = true }
 plutus-datum-derive = { workspace = true, default-features = true }
-secp256k1 = { workspace = true, features = ["std", "global-context"] }
+secp256k1 = { workspace = true, features = ["std", "global-context", "hashes"] }
 sidechain-domain = { workspace = true, default-features = true, features = [
 	"std",
 ] }
@@ -24,6 +24,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 pallet-address-associations = { workspace = true, features = ["std"] }
 parity-scale-codec = { workspace = true }
+sp-block-producer-metadata = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }
+pretty_assertions = { workspace = true }

--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -14,7 +14,7 @@ hex = { workspace = true }
 hex-literal = { workspace = true }
 plutus = { workspace = true, default-features = true }
 plutus-datum-derive = { workspace = true, default-features = true }
-secp256k1 = { workspace = true, features = ["std", "global-context", "hashes"] }
+secp256k1 = { workspace = true, features = ["std", "global-context"] }
 sidechain-domain = { workspace = true, default-features = true, features = [
 	"std",
 ] }

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -1,21 +1,12 @@
-#![allow(unused_imports)]
-use crate::key_params::{
-	CrossChainSigningKeyParam, SidechainSigningKeyParam, StakePoolSigningKeyParam,
-};
+use crate::key_params::CrossChainSigningKeyParam;
 use byte_string::ByteString;
 use clap::Parser;
 use parity_scale_codec::Encode;
-use plutus_datum_derive::*;
-use secp256k1::{hashes::sha256, Message, SecretKey};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde::de::DeserializeOwned;
 use serde_json::{self, json};
-use sidechain_domain::{crypto::*, *};
+use sidechain_domain::*;
 use sp_block_producer_metadata::MetadataSignedMessage;
-use std::{
-	fmt::{Display, Formatter},
-	io::{BufReader, Read},
-	marker::PhantomData,
-};
+use std::io::{BufReader, Read};
 
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -68,13 +59,9 @@ mod tests {
 	use crate::key_params::CrossChainSigningKeyParam;
 	use hex_literal::hex;
 	use pretty_assertions::assert_eq;
-	use serde::{Deserialize, Serialize};
+	use serde::Deserialize;
 	use serde_json::json;
 	use sidechain_domain::UtxoId;
-	use std::{
-		io::{BufReader, BufWriter},
-		str::FromStr,
-	};
 
 	#[derive(Deserialize, Encode)]
 	struct TestMetadata {
@@ -106,8 +93,8 @@ mod tests {
 		let output = cmd.get_output::<TestMetadata>(metadata_reader).unwrap();
 
 		let expected_output = json!({
-			"cross_chain_pub_key": "0x0a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a12da8d65fae6d63a4abca410b7e50d50cd95d36001c28712fd2adf944adb03b12",
-			"signature": "0x304502210085bbfc2df4e11bf6f6c5fa496b37fab97392dd59601a30dcf9c45aa40fc0fa65022079d7f692bc72e04a16dc3f1676cc17c5709859aa03204115432f6f88362e4831",
+			"cross_chain_pub_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1",
+			"signature": "0x3045022100f86d3aa75a6a8bda35dfdd2472b8e5f2f95446e4542ab0adb6f3e7681f01b740022060082c0debfb9616a54f88cf42b88e1a2f43c75dc4394bfdde33972deb491fcb",
 			"encoded_metadata": "0x48687474703a2f2f6578616d706c652e636f6d1031323334"
 		});
 

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -1,0 +1,116 @@
+#![allow(unused_imports)]
+use crate::key_params::{
+	CrossChainSigningKeyParam, SidechainSigningKeyParam, StakePoolSigningKeyParam,
+};
+use byte_string::ByteString;
+use clap::Parser;
+use parity_scale_codec::Encode;
+use plutus_datum_derive::*;
+use secp256k1::{hashes::sha256, Message, SecretKey};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::{self, json};
+use sidechain_domain::{crypto::*, *};
+use sp_block_producer_metadata::MetadataSignedMessage;
+use std::{
+	fmt::{Display, Formatter},
+	io::{BufReader, Read},
+	marker::PhantomData,
+};
+
+#[derive(Clone, Debug, Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct BlockProducerMetadataSignatureCmd {
+	/// Genesis UTXO of the target Partner Chain
+	#[arg(long)]
+	pub genesis_utxo: UtxoId,
+	/// Path of the file containing the metadata in JSON format
+	#[arg(long)]
+	pub metadata_file: String,
+	/// ECDSA signing key of the
+	#[arg(long)]
+	pub cross_chain_signing_key: CrossChainSigningKeyParam,
+}
+
+impl BlockProducerMetadataSignatureCmd {
+	pub fn execute<M: Send + Sync + DeserializeOwned + Encode>(&self) -> anyhow::Result<()> {
+		let metadata_reader = BufReader::new(std::fs::File::open(self.metadata_file.clone())?);
+		let output = self.get_output::<M>(metadata_reader)?;
+
+		println!("{}", serde_json::to_string_pretty(&output)?);
+
+		Ok(())
+	}
+
+	pub fn get_output<M: Send + Sync + DeserializeOwned + Encode>(
+		&self,
+		metadata_reader: impl Read,
+	) -> anyhow::Result<serde_json::Value> {
+		let metadata: M = serde_json::from_reader(metadata_reader)?;
+		let encoded_metadata = metadata.encode();
+		let message = MetadataSignedMessage {
+			cross_chain_pub_key: self.cross_chain_signing_key.vkey(),
+			metadata,
+			genesis_utxo: self.genesis_utxo.clone(),
+		};
+		let signature = message.sign_with_key(&self.cross_chain_signing_key.0);
+
+		Ok(json!({
+			"signature": signature,
+			"cross_chain_pub_key": self.cross_chain_signing_key.vkey(),
+			"encoded_metadata": ByteString(encoded_metadata)
+		}))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::key_params::CrossChainSigningKeyParam;
+	use hex_literal::hex;
+	use pretty_assertions::assert_eq;
+	use serde::{Deserialize, Serialize};
+	use serde_json::json;
+	use sidechain_domain::UtxoId;
+	use std::{
+		io::{BufReader, BufWriter},
+		str::FromStr,
+	};
+
+	#[derive(Deserialize, Encode)]
+	struct TestMetadata {
+		url: String,
+		hash: String,
+	}
+
+	#[test]
+	fn produces_correct_json_output_with_signature_and_pubkey() {
+		let cmd = BlockProducerMetadataSignatureCmd {
+			genesis_utxo: UtxoId::new([1; 32], 1),
+			metadata_file: "unused".to_string(),
+			cross_chain_signing_key: CrossChainSigningKeyParam(
+				secp256k1::SecretKey::from_slice(
+					// Alice cross-chain key
+					&hex!("cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854"),
+				)
+				.unwrap(),
+			),
+		};
+
+		let metadata_json = json!({
+			"url": "http://example.com",
+			"hash": "1234"
+		});
+		let metadata = serde_json::to_string(&metadata_json).unwrap();
+		let metadata_reader = BufReader::new(metadata.as_bytes());
+
+		let output = cmd.get_output::<TestMetadata>(metadata_reader).unwrap();
+
+		let expected_output = json!({
+			"cross_chain_pub_key": "0x0a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a12da8d65fae6d63a4abca410b7e50d50cd95d36001c28712fd2adf944adb03b12",
+			"signature": "0x304502210085bbfc2df4e11bf6f6c5fa496b37fab97392dd59601a30dcf9c45aa40fc0fa65022079d7f692bc72e04a16dc3f1676cc17c5709859aa03204115432f6f88362e4831",
+			"encoded_metadata": "0x48687474703a2f2f6578616d706c652e636f6d1031323334"
+		});
+
+		assert_eq!(output, expected_output)
+	}
+}

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -1,4 +1,5 @@
 use crate::key_params::CrossChainSigningKeyParam;
+use anyhow::anyhow;
 use byte_string::ByteString;
 use clap::Parser;
 use parity_scale_codec::Encode;
@@ -24,7 +25,9 @@ pub struct BlockProducerMetadataSignatureCmd {
 
 impl BlockProducerMetadataSignatureCmd {
 	pub fn execute<M: Send + Sync + DeserializeOwned + Encode>(&self) -> anyhow::Result<()> {
-		let metadata_reader = BufReader::new(std::fs::File::open(self.metadata_file.clone())?);
+		let file = std::fs::File::open(self.metadata_file.clone())
+			.map_err(|err| anyhow!("Failed to open file {}: {err:?}", self.metadata_file))?;
+		let metadata_reader = BufReader::new(file);
 		let output = self.get_output::<M>(metadata_reader)?;
 
 		println!("{}", serde_json::to_string_pretty(&output)?);

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -18,7 +18,7 @@ pub struct BlockProducerMetadataSignatureCmd {
 	/// Path of the file containing the metadata in JSON format
 	#[arg(long)]
 	pub metadata_file: String,
-	/// ECDSA signing key of the
+	/// ECDSA signing key of the block producer, corresponding to the public key that will be associated with new metadata
 	#[arg(long)]
 	pub cross_chain_signing_key: CrossChainSigningKeyParam,
 }

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -105,4 +105,25 @@ mod tests {
 
 		assert_eq!(output, expected_output)
 	}
+
+	#[test]
+	fn retuns_error_for_invalid_json() {
+		let cmd = BlockProducerMetadataSignatureCmd {
+			genesis_utxo: UtxoId::new([1; 32], 1),
+			metadata_file: "unused".to_string(),
+			cross_chain_signing_key: CrossChainSigningKeyParam(
+				secp256k1::SecretKey::from_slice(
+					// Alice cross-chain key
+					&hex!("cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854"),
+				)
+				.unwrap(),
+			),
+		};
+
+		let metadata_reader = BufReader::new("{ invalid json }".as_bytes());
+
+		let output = cmd.get_output::<TestMetadata>(metadata_reader);
+
+		assert!(output.is_err(), "{:?} should be Err", output);
+	}
 }

--- a/toolkit/cli/commands/src/key_params.rs
+++ b/toolkit/cli/commands/src/key_params.rs
@@ -135,13 +135,6 @@ impl FromStr for CrossChainSigningKeyParam {
 
 impl CrossChainSigningKeyParam {
 	pub fn vkey(&self) -> CrossChainPublicKey {
-		CrossChainPublicKey(
-			self.0
-				.public_key(&Secp256k1::new())
-				.serialize_uncompressed()
-				.into_iter()
-				.skip(1)
-				.collect(),
-		)
+		CrossChainPublicKey(self.0.public_key(&Secp256k1::new()).serialize().to_vec())
 	}
 }

--- a/toolkit/cli/commands/src/key_params.rs
+++ b/toolkit/cli/commands/src/key_params.rs
@@ -1,5 +1,5 @@
-use secp256k1::{PublicKey, SecretKey};
-use sidechain_domain::{SidechainPublicKey, StakePoolPublicKey, StakePublicKey};
+use secp256k1::{PublicKey, Secp256k1, SecretKey};
+use sidechain_domain::*;
 use std::convert::Infallible;
 use std::fmt::Display;
 use std::io;
@@ -119,5 +119,29 @@ impl FromStr for StakeSigningKeyParam {
 impl StakeSigningKeyParam {
 	pub fn vkey(&self) -> StakePublicKey {
 		StakePublicKey(ed25519_zebra::VerificationKey::from(&self.0).into())
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct CrossChainSigningKeyParam(pub secp256k1::SecretKey);
+
+impl FromStr for CrossChainSigningKeyParam {
+	type Err = anyhow::Error;
+
+	fn from_str(s: &str) -> Result<Self, Self::Err> {
+		Ok(Self(secp256k1::SecretKey::from_slice(&hex::decode(s)?)?))
+	}
+}
+
+impl CrossChainSigningKeyParam {
+	pub fn vkey(&self) -> CrossChainPublicKey {
+		CrossChainPublicKey(
+			self.0
+				.public_key(&Secp256k1::new())
+				.serialize_uncompressed()
+				.into_iter()
+				.skip(1)
+				.collect(),
+		)
 	}
 }

--- a/toolkit/cli/commands/src/lib.rs
+++ b/toolkit/cli/commands/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod address_association_signatures;
+pub mod block_producer_metadata_signatures;
 pub mod key_params;
 pub mod registration_signatures;

--- a/toolkit/primitives/block-producer-metadata/Cargo.toml
+++ b/toolkit/primitives/block-producer-metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sp-block-producer-metadata"
-version = "0.1.0"
+version = "1.6.0"
 edition = "2021"
 license = "Apache-2.0"
 description = "Primitives for the block producer on-chain metadata feature"

--- a/toolkit/primitives/block-producer-metadata/Cargo.toml
+++ b/toolkit/primitives/block-producer-metadata/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "sp-block-producer-metadata"
+version = "0.1.0"
+edition = "2021"
+license = "Apache-2.0"
+description = "Primitives for the block producer on-chain metadata feature"
+
+[dependencies]
+sidechain-domain = { workspace = true }
+parity-scale-codec = { workspace = true }
+secp256k1 = { workspace = true, features = ["global-context", "hashes"] }
+
+[dev-dependencies]
+hex-literal = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+    "sidechain-domain/std",
+    "secp256k1/std",
+]

--- a/toolkit/primitives/block-producer-metadata/src/lib.rs
+++ b/toolkit/primitives/block-producer-metadata/src/lib.rs
@@ -1,0 +1,60 @@
+use parity_scale_codec::Encode;
+use secp256k1::{hashes::sha256, Message, Secp256k1};
+use sidechain_domain::*;
+
+#[derive(Debug, Clone, Encode)]
+pub struct MetadataSignedMessage<Metadata> {
+	pub cross_chain_pub_key: CrossChainPublicKey,
+	pub metadata: Metadata,
+	pub genesis_utxo: UtxoId,
+}
+
+impl<M: Encode> MetadataSignedMessage<M> {
+	pub fn sign_with_key(&self, skey: &secp256k1::SecretKey) -> CrossChainSignature {
+		let data = self.encode();
+		let data_hash = Message::from_hashed_data::<sha256::Hash>(&data);
+		CrossChainSignature(skey.sign_ecdsa(data_hash).serialize_der().into_iter().collect())
+	}
+
+	pub fn verify_signature(
+		&self,
+		vkey: &secp256k1::PublicKey,
+		signature: CrossChainSignature,
+	) -> bool {
+		let data = self.encode();
+		let data_hash = Message::from_hashed_data::<sha256::Hash>(&data);
+
+		println!("{}", signature.0.len());
+		let signature = secp256k1::ecdsa::Signature::from_der(&signature.0)
+			.or_else(|_| secp256k1::ecdsa::Signature::from_compact(&signature.0))
+			.expect("ecdsa::Signature from CrossChainSignature should always succeed");
+
+		vkey.verify(&Secp256k1::new(), &data_hash, &signature).is_ok()
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use hex_literal::hex;
+
+	#[test]
+	fn round_trip() {
+		let message = MetadataSignedMessage {
+			cross_chain_pub_key: CrossChainPublicKey(vec![1; 32]),
+			metadata: "metadata".to_string(),
+			genesis_utxo: UtxoId::new([2; 32], 0),
+		};
+
+		// Alice cross-chain key
+		let skey = secp256k1::SecretKey::from_slice(&hex!(
+			"cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854"
+		))
+		.unwrap();
+		let vkey = skey.public_key(&Secp256k1::new());
+
+		let signature = message.sign_with_key(&skey);
+
+		assert!(message.verify_signature(&vkey, signature));
+	}
+}

--- a/toolkit/primitives/domain/src/byte_string.rs
+++ b/toolkit/primitives/domain/src/byte_string.rs
@@ -23,7 +23,7 @@ impl From<Vec<u8>> for ByteString {
 #[byte_string(debug)]
 #[byte_string(to_hex_string)]
 #[cfg_attr(feature = "std", byte_string(decode_hex))]
-#[cfg_attr(feature = "serde", byte_string(hex_serialize))]
+#[cfg_attr(feature = "serde", byte_string(hex_serialize, hex_deserialize))]
 pub struct SizedByteString<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> From<[u8; N]> for SizedByteString<N> {

--- a/toolkit/primitives/domain/src/byte_string.rs
+++ b/toolkit/primitives/domain/src/byte_string.rs
@@ -52,7 +52,7 @@ impl<const N: usize> Default for SizedByteString<N> {
 	}
 }
 
-/// Byte-encoded text string with c
+/// Byte-encoded text string with bounded length
 #[derive(Eq, Clone, PartialEq, TypeInfo, Default, Encode, Decode, MaxEncodedLen)]
 pub struct BoundedString<const N: u32>(pub BoundedVec<u8, ConstU32<N>>);
 

--- a/toolkit/primitives/domain/src/byte_string.rs
+++ b/toolkit/primitives/domain/src/byte_string.rs
@@ -1,7 +1,13 @@
+use core::fmt::{Debug, Display};
+
 use alloc::vec::Vec;
 use byte_string_derive::byte_string;
 use parity_scale_codec::{Decode, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
+use serde::de::Error;
+use serde::Deserialize;
+use sp_core::bounded::BoundedVec;
+use sp_core::ConstU32;
 
 /// Wrapper for bytes that is serialized as hex string
 /// To be used for binary data that we want to display nicely but
@@ -43,5 +49,45 @@ impl<const N: usize> TryFrom<Vec<u8>> for SizedByteString<N> {
 impl<const N: usize> Default for SizedByteString<N> {
 	fn default() -> Self {
 		Self([0; N])
+	}
+}
+
+/// Byte-encoded text string with c
+#[derive(Eq, Clone, PartialEq, TypeInfo, Default, Encode, Decode, MaxEncodedLen)]
+pub struct SizedString<const N: u32>(pub BoundedVec<u8, ConstU32<N>>);
+
+impl<const N: u32> TryFrom<Vec<u8>> for SizedString<N> {
+	type Error = <BoundedVec<u8, ConstU32<N>> as TryFrom<Vec<u8>>>::Error;
+
+	fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+		Ok(Self(value.try_into()?))
+	}
+}
+
+impl<'a, const N: u32> Deserialize<'a> for SizedString<N> {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'a>,
+	{
+		Ok(Self(
+			BoundedVec::try_from(
+				alloc::string::String::deserialize(deserializer)?.as_bytes().to_vec(),
+			)
+			.map_err(|_| D::Error::custom("Size limit exceeded"))?,
+		))
+	}
+}
+
+impl<const N: u32> Display for SizedString<N> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.write_str(
+			&alloc::string::String::from_utf8(self.0.to_vec()).map_err(|_| core::fmt::Error)?,
+		)
+	}
+}
+
+impl<const N: u32> Debug for SizedString<N> {
+	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+		f.write_str(&alloc::format!("SizedString<{N}>({self:?})"))
 	}
 }

--- a/toolkit/primitives/domain/src/byte_string.rs
+++ b/toolkit/primitives/domain/src/byte_string.rs
@@ -54,9 +54,9 @@ impl<const N: usize> Default for SizedByteString<N> {
 
 /// Byte-encoded text string with c
 #[derive(Eq, Clone, PartialEq, TypeInfo, Default, Encode, Decode, MaxEncodedLen)]
-pub struct SizedString<const N: u32>(pub BoundedVec<u8, ConstU32<N>>);
+pub struct BoundedString<const N: u32>(pub BoundedVec<u8, ConstU32<N>>);
 
-impl<const N: u32> TryFrom<Vec<u8>> for SizedString<N> {
+impl<const N: u32> TryFrom<Vec<u8>> for BoundedString<N> {
 	type Error = <BoundedVec<u8, ConstU32<N>> as TryFrom<Vec<u8>>>::Error;
 
 	fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
@@ -64,7 +64,7 @@ impl<const N: u32> TryFrom<Vec<u8>> for SizedString<N> {
 	}
 }
 
-impl<'a, const N: u32> Deserialize<'a> for SizedString<N> {
+impl<'a, const N: u32> Deserialize<'a> for BoundedString<N> {
 	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
 	where
 		D: serde::Deserializer<'a>,
@@ -78,7 +78,7 @@ impl<'a, const N: u32> Deserialize<'a> for SizedString<N> {
 	}
 }
 
-impl<const N: u32> Display for SizedString<N> {
+impl<const N: u32> Display for BoundedString<N> {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
 		f.write_str(
 			&alloc::string::String::from_utf8(self.0.to_vec()).map_err(|_| core::fmt::Error)?,
@@ -86,8 +86,8 @@ impl<const N: u32> Display for SizedString<N> {
 	}
 }
 
-impl<const N: u32> Debug for SizedString<N> {
+impl<const N: u32> Debug for BoundedString<N> {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		f.write_str(&alloc::format!("SizedString<{N}>({self:?})"))
+		f.write_str(&alloc::format!("BoundedString<{N}>({self:?})"))
 	}
 }


### PR DESCRIPTION
# Description

- adds a `sign-block-producer-metadata` command
- adds a `BoundedString` type for storing strings in the runtime
- adds a `BlockProducerMetadata` to the demo runtime, containing a URL bounded string and hash

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
