### PR TITLE
fix: Remove all IP addressing from repo

### DIFF
--- a/e2e-tests/config/substrate/ci_nodes.json
+++ b/e2e-tests/config/substrate/ci_nodes.json
@@ -7,8 +7,8 @@
   "nodes_config": {
     "nodes": {
       "validator-1": {
-        "host": "10.0.10.7",
-        "port": "30621",
+        "host": "ci-preview-validator-1-service.ci-preview.svc.cluster.local",
+        "port": "9933",
         "aura_ss58_address": "5GHLr2zBDNPXno9XdKgh541uRSiTxnZyzFcr4jK6HUbHMpit",
         "pool_id": "da74fc8256d15c7ab3370a6ca28398986cb97c32e9ef66026ac61e99",
         "public_key": "0x03b827f4da9711bab7292e5695576a841a4d20af9a07b1ba7a230168d2a78e9df4",
@@ -25,8 +25,8 @@
         "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000201"
       },
       "validator-2": {
-        "host": "10.0.11.26",
-        "port": "30622",
+        "host": "ci-preview-validator-2-service.ci-preview.svc.cluster.local",
+        "port": "9933",
         "aura_ss58_address": "5DHbxU687f1Y3x8yBCWMtqSiJ5qt2yrxQPXNXZNNDaFtmXKv",
         "pool_id": "eaed153a8b046770cfd094ee72d080ea682188e63ac11937e3f7f827",
         "public_key": "0x02ef5bcd94d54a18ad199559782cd72ac3ccd850976aaaafbca8f9d2625afbf7c4",
@@ -43,8 +43,8 @@
         "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000202"
       },
       "validator-3": {
-        "host": "10.0.12.51",
-        "port": "30623",
+        "host": "ci-preview-validator-3-service.ci-preview.svc.cluster.local",
+        "port": "9933",
         "aura_ss58_address": "5FYtL6HccYhk6KZeFP7hNnkMaXrAwVpTHJWsfnNJcu8AM6in",
         "pool_id": "7dfba85597a867fffa59037df7f6adcd50e745dcceac2b48eda94b20",
         "public_key": "0x02f2762ab6e1a125dc03908a7b738f8023d13763f28a11d7633c6c8bc463478430",
@@ -61,8 +61,8 @@
         "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000203"
       },
       "validator-4": {
-        "host": "10.0.10.188",
-        "port": "30624",
+        "host": "ci-preview-validator-4-service.ci-preview.svc.cluster.local",
+        "port": "9933",
         "aura_ss58_address": "5GVpqdtqjxqUjuVKMkmh8ehSwcs2nXjpvzHqjouZXMJAyC4b",
         "pool_id": "2a3f5dd02da1310e081f2367412e02b72baad3e2a5045f62df2c78c5",
         "public_key": "0x025e19f82c5e2bac5e8869d49ff26359e442628bc5cfa38eeb5275f43d04015da8",
@@ -79,8 +79,8 @@
         "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000204"
       },
       "validator-5": {
-        "host": "10.0.11.239",
-        "port": "30625",
+        "host": "ci-preview-validator-5-service.ci-preview.svc.cluster.local",
+        "port": "9933",
         "aura_ss58_address": "5DsfhT7HJe6i5LYeKBzefrXijW5UgPsn2Cuyw5WMa4uEktTn",
         "pool_id": "ae81beee7a6c3fa13bba811f91f63ebdd7eb25dd8a62476d4996de10",
         "public_key": "0x03f38a062a4b372c045c1dddc4fe98a2c9cb1d6eec8bf02f973fd29b1096cd8155",

--- a/e2e-tests/config/substrate/ci_stack.json
+++ b/e2e-tests/config/substrate/ci_stack.json
@@ -2,7 +2,7 @@
     "stack_config": {
         "ogmios_host": "devnet-services-service",
         "ogmios_port": 1337,
-        "tools_host": "10.0.12.65",
+        "tools_host": "binary-host-service",
         "ssh": {
             "username": "root",
             "host": "${stack_config[tools_host]}",

--- a/e2e-tests/config/substrate/ci_stack.json
+++ b/e2e-tests/config/substrate/ci_stack.json
@@ -2,7 +2,7 @@
     "stack_config": {
         "ogmios_host": "devnet-services-service",
         "ogmios_port": 1337,
-        "tools_host": "binary-host-service",
+        "tools_host": "binary-host-service.sc.svc.cluster.local",
         "ssh": {
             "username": "root",
             "host": "${stack_config[tools_host]}",

--- a/e2e-tests/config/substrate/devnet_nodes.json
+++ b/e2e-tests/config/substrate/devnet_nodes.json
@@ -8,8 +8,8 @@
     "nodes_config": {
         "nodes": {
             "alice": {
-                "host": "10.0.10.13",
-                "port": "30021",
+                "host": "alice-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
                 "pool_id": "17a3e09033f190cdcddd11350f095d3ae11f1a61c65731366750177a",
                 "public_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1",
@@ -19,8 +19,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000001"
             },
             "bob": {
-                "host": "10.0.10.13",
-                "port": "30022",
+                "host": "bob-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
                 "pool_id": "dd67a558342e53c9ef9528124e44e43a34b2ae3b432aa5144ffec24d",
                 "public_key": "0x0390084fdbf27d2b79d26a4f13f0ccd982cb755a661969143c37cbc49ef5b91f27",
@@ -30,8 +30,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000002"
             },
             "charlie": {
-                "host": "10.0.10.13",
-                "port": "30023",
+                "host": "charlie-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
                 "pool_id": "f824ff53b6a71522bb9f8db18fffd2469d957a56cf00e0cb0bdc8a08",
                 "public_key": "0x0389411795514af1627765eceffcbd002719f031604fadd7d188e2dc585b4e1afb",
@@ -41,8 +41,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000003"
             },
             "dave": {
-                "host": "10.0.10.13",
-                "port": "30024",
+                "host": "dave-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy",
                 "pool_id": "2e36e13ad5665685f163e4fa3d32ccf0a333fda0a67c93cbac99f7a2",
                 "public_key": "0x03bc9d0ca094bd5b8b3225d7651eac5d18c1c04bf8ae8f8b263eebca4e1410ed0c",
@@ -51,8 +51,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000004"
             },
             "eve": {
-                "host": "10.0.10.13",
-                "port": "30025",
+                "host": "eve-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5HGjWAeFDfFCWPsjFQdVV2Msvz2XtMktvgocEZcCj68kUMaw",
                 "pool_id": "54512ccbdf3a6912bf4da983a4aa46e9c46eb0fd19a2b3f5341c5366",
                 "public_key": "0x031d10105e323c4afce225208f71a6441ee327a65b9e646e772500c74d31f669aa",
@@ -69,8 +69,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000005"
             },
             "ferdie": {
-                "host": "10.0.10.13",
-                "port": "30026",
+                "host": "ferdie-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5CiPPseXPECbkjWCa6MnjNokrgYjMqmKndv2rSnekmSK2DjL",
                 "pool_id": "9ad70551d17317e44866850f9827f6464f0867e50bff5a87b1f9e3c0",
                 "public_key": "0x0291f1217d5a04cb83312ee3d88a6e6b33284e053e6ccfc3a90339a0299d12967c",
@@ -87,8 +87,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000006"
             },
             "greg": {
-                "host": "10.0.10.13",
-                "port": "30027",
+                "host": "greg-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5D4oNr3wasgzxt7KdoHBjnxUthfoM93kWMav63aoYmPHfkBW",
                 "pool_id": "",
                 "public_key": "0x02dacce90fca29ca80404d9b4e8ff3d9dabd03def6a82e412acb2ad04dd734dbfc",
@@ -98,8 +98,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000007"
             },
             "henry": {
-                "host": "10.0.10.13",
-                "port": "30028",
+                "host": "henry-service.sc.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5FcTxwLAQ8L23HvTa6Y6UUMBKJkYRG42Vg9wVVpZDpE2ZnTZ",
                 "pool_id": "",
                 "public_key": "0x0263c9cdabbef76829fe5b35f0bbf3051bd1c41b80f58b5d07c271d0dd04de2a4e",

--- a/e2e-tests/config/substrate/devnet_stack.json
+++ b/e2e-tests/config/substrate/devnet_stack.json
@@ -2,7 +2,7 @@
     "stack_config": {
         "ogmios_host": "devnet-services-service",
         "ogmios_port": 1337,
-        "tools_host": "10.0.12.65",
+        "tools_host": "binary-host-service.sc.svc.cluster.local",
         "ssh": {
             "username": "root",
             "host": "${stack_config[tools_host]}",

--- a/e2e-tests/config/substrate/known_hosts
+++ b/e2e-tests/config/substrate/known_hosts
@@ -1,2 +1,1 @@
 binary-host-service.sc.svc.cluster.local ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINevlKvq/nBitkudwLWGB2mzuCWfsZGcBOhGLg/JvsLT
-10.0.12.65 ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINevlKvq/nBitkudwLWGB2mzuCWfsZGcBOhGLg/JvsLT

--- a/e2e-tests/config/substrate/staging_nodes.json
+++ b/e2e-tests/config/substrate/staging_nodes.json
@@ -7,8 +7,8 @@
     "nodes_config": {
         "nodes": {
             "validator-1": {
-                "host": "10.0.10.90",
-                "port": "30321",
+                "host": "staging-preview-validator-1-service.staging-preview.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5GHLr2zBDNPXno9XdKgh541uRSiTxnZyzFcr4jK6HUbHMpit",
                 "pool_id": "da74fc8256d15c7ab3370a6ca28398986cb97c32e9ef66026ac61e99",
                 "public_key": "0x03b827f4da9711bab7292e5695576a841a4d20af9a07b1ba7a230168d2a78e9df4",
@@ -25,8 +25,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000201"
             },
             "validator-2": {
-                "host": "10.0.10.90",
-                "port": "30322",
+                "host": "staging-preview-validator-2-service.staging-preview.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5DHbxU687f1Y3x8yBCWMtqSiJ5qt2yrxQPXNXZNNDaFtmXKv",
                 "pool_id": "eaed153a8b046770cfd094ee72d080ea682188e63ac11937e3f7f827",
                 "public_key": "0x02ef5bcd94d54a18ad199559782cd72ac3ccd850976aaaafbca8f9d2625afbf7c4",
@@ -43,8 +43,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000202"
             },
             "validator-3": {
-                "host": "10.0.10.90",
-                "port": "30323",
+                "host": "staging-preview-validator-3-service.staging-preview.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5FYtL6HccYhk6KZeFP7hNnkMaXrAwVpTHJWsfnNJcu8AM6in",
                 "pool_id": "7dfba85597a867fffa59037df7f6adcd50e745dcceac2b48eda94b20",
                 "public_key": "0x02f2762ab6e1a125dc03908a7b738f8023d13763f28a11d7633c6c8bc463478430",
@@ -61,8 +61,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000203"
             },
             "validator-4": {
-                "host": "10.0.10.90",
-                "port": "30324",
+                "host": "staging-preview-validator-4-service.staging-preview.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5GVpqdtqjxqUjuVKMkmh8ehSwcs2nXjpvzHqjouZXMJAyC4b",
                 "pool_id": "2a3f5dd02da1310e081f2367412e02b72baad3e2a5045f62df2c78c5",
                 "public_key": "0x025e19f82c5e2bac5e8869d49ff26359e442628bc5cfa38eeb5275f43d04015da8",
@@ -79,8 +79,8 @@
                 "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000204"
             },
             "validator-5": {
-                "host": "10.0.10.90",
-                "port": "30325",
+                "host": "staging-preview-validator-5-service.staging-preview.svc.cluster.local",
+                "port": "9933",
                 "aura_ss58_address": "5DsfhT7HJe6i5LYeKBzefrXijW5UgPsn2Cuyw5WMa4uEktTn",
                 "pool_id": "ae81beee7a6c3fa13bba811f91f63ebdd7eb25dd8a62476d4996de10",
                 "public_key": "0x03f38a062a4b372c045c1dddc4fe98a2c9cb1d6eec8bf02f973fd29b1096cd8155",

--- a/e2e-tests/config/substrate/staging_stack.json
+++ b/e2e-tests/config/substrate/staging_stack.json
@@ -2,7 +2,7 @@
     "stack_config": {
         "ogmios_host": "staging-preview-services-service.staging-preview.svc.cluster.local",
         "ogmios_port": 1337,
-        "tools_host": "10.0.12.65",
+        "tools_host": "binary-host-service.sc.svc.cluster.local",
         "ssh": {
             "username": "root",
             "host": "${stack_config[tools_host]}",

--- a/e2e-tests/utils/check_network_sync.py
+++ b/e2e-tests/utils/check_network_sync.py
@@ -1,12 +1,12 @@
 from substrateinterface import SubstrateInterface
 import json
 
-alice = 'ws://10.0.11.120:30021'
-bob = 'ws://10.0.11.120:30022'
-charlie = 'ws://10.0.11.120:30023'
-dave = 'ws://10.0.11.120:30024'
-eve = 'ws://10.0.11.120:30025'
-ferdie = 'ws://10.0.11.120:30026'
+alice = 'ws://alice-service.sc.svc.cluster.local:9933'
+bob = 'ws://bob-service.sc.svc.cluster.local:9933'
+charlie = 'ws://charlie-service.sc.svc.cluster.local:9933'
+dave = 'ws://dave-service.sc.svc.cluster.local:9933'
+eve = 'ws://eve-service.sc.svc.cluster.local:9933'
+ferdie = 'ws://ferdie-service.sc.svc.cluster.local:9933'
 
 
 def get_latest_pc_block_number(node_api, custom_type_registry):

--- a/e2e-tests/utils/find_block_range_of_sc_epoch.py
+++ b/e2e-tests/utils/find_block_range_of_sc_epoch.py
@@ -10,8 +10,8 @@ from config.api_config import ApiConfig
 from src.substrate_api import SubstrateApi
 from pc_block_finder import BlockFinder
 
-STAGING_NODE = 'http://10.0.11.16:9933'  # staging
-DEVNET_NODE = 'http://10.0.10.13:30023'  # devnet charlie
+STAGING_NODE = 'http://staging-preview-validator-1-service.staging-preview.svc.cluster.local:9933'  # staging
+DEVNET_NODE = 'http://charlie-service.sc.svc.cluster.local:9933'  # devnet charlie
 LOCAL_NODE = 'http://localhost:9945'  # local alice
 
 STAGING_CONFIG = 'config/substrate/staging_nodes.json'

--- a/e2e-tests/utils/get_ariadne_committee_ratio.py
+++ b/e2e-tests/utils/get_ariadne_committee_ratio.py
@@ -84,10 +84,10 @@ staging_keysdict = {
 TARGET_ENV = 'staging'
 if TARGET_ENV == 'devnet':
     keysdict = devnet_keysdict
-    NODE = 'http://10.0.10.13:30023'  # devnet charlie
+    NODE = 'http://charlie-service.sc.svc.cluster.local:9933'  # devnet charlie
 elif TARGET_ENV == 'staging':
     keysdict = staging_keysdict
-    NODE = 'http://10.0.11.16:9933'  # staging
+    NODE = 'http://staging-preview-validator-1-service.staging-preview.svc.cluster.local:9933'  # staging
 elif TARGET_ENV == 'local':
     keysdict = devnet_keysdict
     NODE = 'http://localhost:9945'  # local alice

--- a/e2e-tests/utils/get_past_committees.py
+++ b/e2e-tests/utils/get_past_committees.py
@@ -22,8 +22,8 @@ partner_chain = {
     "slots_in_epoch": 60,
 }
 
-devnet_rpc_url = "http://10.0.10.233:30023"  # devnet
-staging_rpc_url = "http://10.0.10.84:9933"  # staging
+devnet_rpc_url = "http://charlie-service.sc.svc.cluster.local:9933"  # devnet
+staging_rpc_url = "http://staging-preview-validator-1-service.staging-preview.svc.cluster.local:9933"  # staging
 halo2-qa_rpc_url = "http://node-01.halo2-qa.dev.platform.midnight.network:9944"  # halo2-qa
 
 # first_epoch_to_get_committee_since_chain_wipe = 4706032

--- a/e2e-tests/utils/substrate_helpers.py
+++ b/e2e-tests/utils/substrate_helpers.py
@@ -8,8 +8,8 @@ def get_pc_balance(substrate, address):
     return balance.value
 
 
-# NODE = 'ws://10.0.10.13:30023'  # charlie devnet
-NODE = 'ws://10.0.10.55:9933'  # validator 1 staging
+# NODE = 'ws://charlie-service.sc.svc.cluster.local:9933'  # charlie devnet
+NODE = 'ws://staging-preview-validator-1-service.staging-preview.svc.cluster.local:9933'  # validator 1 staging
 
 
 def _keypair_name_to_type(type_name):


### PR DESCRIPTION
AWS IP addresses are subject to change, we should not be using them anywhere in tests. 

K8s service FQDNs are fixed and reliable
