### PR TITLE
add: ETCM-9618 db-sync-sqlx crate with db-sync primitive types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,7 +1920,7 @@ dependencies = [
 
 [[package]]
 name = "db-sync-sqlx"
-version = "0.1.0"
+version = "1.6.0"
 dependencies = [
  "num-traits",
  "sidechain-domain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1891,6 +1891,7 @@ dependencies = [
  "cardano-serialization-lib",
  "chrono",
  "ctor",
+ "db-sync-sqlx",
  "derive-new",
  "figment",
  "futures",
@@ -1900,7 +1901,6 @@ dependencies = [
  "log",
  "lru",
  "num-bigint",
- "num-traits",
  "pallet-sidechain-rpc",
  "partner-chains-plutus-data",
  "serde",
@@ -1916,6 +1916,15 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-test",
+]
+
+[[package]]
+name = "db-sync-sqlx"
+version = "0.1.0"
+dependencies = [
+ "num-traits",
+ "sidechain-domain",
+ "sqlx",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ members = [
 	"toolkit/pallets/block-participation",
 	"toolkit/primitives/block-participation",
 	"toolkit/primitives/block-producer-metadata",
+	"toolkit/utils/db-sync-sqlx",
 ]
 resolver = "2"
 
@@ -124,6 +125,14 @@ parking_lot = { version = "0.12.3", default-features = false }
 envy = { version = "0.4.2" }
 log4rs = { version = "1.3.0" }
 bech32 = { version = "0.9.1", default-features = false }
+sqlx = { version = "0.7.4", default-features = false, features = [
+    "runtime-tokio-rustls",
+    "postgres",
+    "macros",
+    "chrono",
+    "migrate",
+    "bigdecimal",
+] }
 
 # substrate dependencies
 frame-benchmarking = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2412-1" }
@@ -237,3 +246,4 @@ pallet-address-associations = { path = "toolkit/pallets/address-associations", d
 pallet-block-participation = { path = "toolkit/pallets/block-participation", default-features = false }
 sp-block-participation = { path = "toolkit/primitives/block-participation", default-features = false }
 sp-block-producer-metadata = { path = "toolkit/primitives/block-producer-metadata", default-features = false }
+db-sync-sqlx = { path = "toolkit/utils/db-sync-sqlx" }

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ the feature `pallet-session-compat`.
 ## Added
 
 * `sign-block-producer-metadata` command to `cli-commands` for signing block producer metadata upsert message
+* `db-sync-sqlx` crate containing Rust types representing Cardano primitives present in postgress tables populated by Db-Sync
 
 # v1.6.0
 

--- a/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
@@ -6,14 +6,8 @@ license = "Apache-2.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
-sqlx = { version = "0.7.4", default-features = false, features = [
-    "runtime-tokio-rustls",
-    "postgres",
-    "macros",
-    "chrono",
-    "migrate",
-    "bigdecimal",
-] }
+sqlx = { workspace = true }
+db-sync-sqlx = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
 chrono = "0.4.31"
@@ -25,7 +19,6 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 bigdecimal = { workspace = true }
 async-trait = { workspace = true }
-num-traits = { workspace = true }
 num-bigint = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }

--- a/toolkit/mainchain-follower/db-sync-follower/src/db_model.rs
+++ b/toolkit/mainchain-follower/db-sync-follower/src/db_model.rs
@@ -2,91 +2,14 @@ use crate::db_datum::DbDatum;
 use crate::SqlxError;
 use cardano_serialization_lib::PlutusData;
 use chrono::NaiveDateTime;
+pub use db_sync_sqlx::*;
 use log::info;
-use num_traits::ToPrimitive;
-use sidechain_domain::*;
-use sqlx::database::{HasArguments, HasValueRef};
-use sqlx::encode::IsNull;
-use sqlx::error::BoxDynError;
-use sqlx::postgres::PgTypeInfo;
-use sqlx::{Decode, Encode, Pool, Postgres};
+use sidechain_domain::{
+	MainchainBlock, McBlockHash, McBlockNumber, McEpochNumber, McSlotNumber, McTxHash, UtxoId,
+	UtxoIndex,
+};
+use sqlx::{Pool, Postgres};
 use std::str::FromStr;
-
-/// Generates sqlx implementations for an unsigned wrapper of types that are signed.
-/// We expect that values will have always 0 as the most significant bit.
-/// For example TxIndex is in range of [0, 2^15-1], it will be u16 in domain,
-/// but it requires encoding and decoding like i16.
-/// See txindex, word31 and word63 types in db-sync schema definition.
-macro_rules! sqlx_implementations_for_wrapper {
-	($WRAPPED:ty, $DBTYPE:expr, $NAME:ty, $DOMAIN:ty) => {
-		impl sqlx::Type<Postgres> for $NAME {
-			fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
-				PgTypeInfo::with_name($DBTYPE)
-			}
-		}
-
-		impl<'r> Decode<'r, Postgres> for $NAME
-		where
-			$WRAPPED: Decode<'r, Postgres>,
-		{
-			fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
-				let decoded: $WRAPPED = <$WRAPPED as Decode<Postgres>>::decode(value)?;
-				Ok(Self(decoded.try_into()?))
-			}
-		}
-
-		#[cfg(test)]
-		impl From<$WRAPPED> for $NAME {
-			fn from(value: $WRAPPED) -> Self {
-				Self(value.try_into().expect("value from domain fits in type db type"))
-			}
-		}
-
-		impl<'q> Encode<'q, Postgres> for $NAME {
-			fn encode_by_ref(
-				&self,
-				buf: &mut <Postgres as HasArguments<'q>>::ArgumentBuffer,
-			) -> IsNull {
-				buf.extend(&self.0.to_be_bytes());
-				IsNull::No
-			}
-		}
-
-		impl From<$NAME> for $DOMAIN {
-			fn from(value: $NAME) -> Self {
-				Self(value.0)
-			}
-		}
-
-		impl From<$DOMAIN> for $NAME {
-			fn from(value: $DOMAIN) -> Self {
-				Self(value.0)
-			}
-		}
-	};
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct Asset {
-	pub policy_id: PolicyId,
-	pub asset_name: AssetName,
-}
-
-impl Asset {
-	/// Creates an Asset with empty asset_name.
-	pub(crate) fn new(policy_id: sidechain_domain::PolicyId) -> Self {
-		Self { policy_id: PolicyId(policy_id.0.to_vec()), asset_name: AssetName(vec![]) }
-	}
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct AssetName(pub Vec<u8>);
-
-impl From<sidechain_domain::AssetName> for AssetName {
-	fn from(name: sidechain_domain::AssetName) -> Self {
-		Self(name.0.to_vec())
-	}
-}
 
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct Block {
@@ -109,39 +32,6 @@ impl From<Block> for MainchainBlock {
 		}
 	}
 }
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct BlockNumber(pub u32);
-sqlx_implementations_for_wrapper!(i32, "INT4", BlockNumber, McBlockNumber);
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct EpochNumber(pub u32);
-sqlx_implementations_for_wrapper!(i32, "INT4", EpochNumber, McEpochNumber);
-
-#[derive(Debug, Copy, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct EpochNumberRow(pub EpochNumber);
-
-impl From<EpochNumberRow> for EpochNumber {
-	fn from(r: EpochNumberRow) -> Self {
-		r.0
-	}
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct Address(pub String);
-
-impl From<MainchainAddress> for Address {
-	fn from(addr: MainchainAddress) -> Self {
-		Self(addr.to_string())
-	}
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct MainchainEpochNonce(pub Vec<u8>);
-
-#[derive(Debug, Copy, Clone, PartialEq)]
-pub(crate) struct SlotNumber(pub u64);
-sqlx_implementations_for_wrapper!(i64, "INT8", SlotNumber, McSlotNumber);
 
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct MainchainTxOutput {
@@ -200,15 +90,6 @@ pub(crate) struct MintAction {
 }
 
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
-pub(crate) struct PolicyId(pub Vec<u8>);
-
-impl From<sidechain_domain::PolicyId> for PolicyId {
-	fn from(id: sidechain_domain::PolicyId) -> Self {
-		Self(id.0.to_vec())
-	}
-}
-
-#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub(crate) struct StakePoolEntry {
 	pub pool_hash: [u8; 28],
 	pub stake: StakeDelegation,
@@ -223,73 +104,6 @@ pub(crate) struct TokenTxOutput {
 	pub tx_slot_no: SlotNumber,
 	pub tx_block_index: TxIndexInBlock,
 	pub datum: Option<DbDatum>,
-}
-
-/// CREATE DOMAIN txindex AS smallint CONSTRAINT txindex_check CHECK ((VALUE >= 0));
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TxIndex(pub u16);
-sqlx_implementations_for_wrapper!(i16, "INT2", TxIndex, UtxoIndex);
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TxIndexInBlock(pub u32);
-sqlx_implementations_for_wrapper!(i32, "INT4", TxIndexInBlock, McTxIndexInBlock);
-
-/// CREATE DOMAIN int65type AS numeric (20, 0) CHECK (VALUE >= -18446744073709551615 AND VALUE <= 18446744073709551615);
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct TxValue(pub i128);
-
-impl sqlx::Type<Postgres> for TxValue {
-	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
-		PgTypeInfo::with_name("NUMERIC")
-	}
-}
-
-impl<'r> Decode<'r, Postgres> for TxValue {
-	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
-		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
-		let i = decoded.to_i128().ok_or("TxValue is always an integer".to_string())?;
-		Ok(Self(i))
-	}
-}
-
-/// CREATE DOMAIN "lovelace" AS numeric(20,0) CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct StakeDelegation(pub u64);
-
-impl sqlx::Type<Postgres> for StakeDelegation {
-	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
-		PgTypeInfo::with_name("NUMERIC")
-	}
-}
-
-impl<'r> Decode<'r, Postgres> for StakeDelegation {
-	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
-		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
-		let i = decoded.to_u64().ok_or("StakeDelegation is always a u64".to_string())?;
-		Ok(Self(i))
-	}
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub(crate) struct NativeTokenAmount(pub u128);
-impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
-	fn from(value: NativeTokenAmount) -> Self {
-		Self(value.0)
-	}
-}
-
-impl sqlx::Type<Postgres> for NativeTokenAmount {
-	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
-		PgTypeInfo::with_name("NUMERIC")
-	}
-}
-
-impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
-	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
-		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
-		let i = decoded.to_u128().ok_or("NativeTokenQuantity is always a u128".to_string())?;
-		Ok(Self(i))
-	}
 }
 
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]

--- a/toolkit/utils/db-sync-sqlx/Cargo.toml
+++ b/toolkit/utils/db-sync-sqlx/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db-sync-sqlx"
-version = "0.1.0"
+version = "1.6.0"
 edition = "2021"
 description = "sqlx support for Cardano Db-Sync queries"
 license = "Apache-2.0"

--- a/toolkit/utils/db-sync-sqlx/Cargo.toml
+++ b/toolkit/utils/db-sync-sqlx/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "db-sync-sqlx"
+version = "0.1.0"
+edition = "2021"
+description = "sqlx support for Cardano Db-Sync queries"
+license = "Apache-2.0"
+
+[dependencies]
+sqlx = { workspace = true }
+sidechain-domain = { workspace = true, features = ["std"] }
+num-traits = { workspace = true }

--- a/toolkit/utils/db-sync-sqlx/src/lib.rs
+++ b/toolkit/utils/db-sync-sqlx/src/lib.rs
@@ -1,0 +1,193 @@
+use num_traits::ToPrimitive;
+use sidechain_domain::*;
+use sqlx::database::{HasArguments, HasValueRef};
+use sqlx::encode::IsNull;
+use sqlx::error::BoxDynError;
+use sqlx::postgres::PgTypeInfo;
+use sqlx::*;
+
+/// Generates sqlx implementations for an unsigned wrapper of types that are signed.
+/// We expect that values will have always 0 as the most significant bit.
+/// For example TxIndex is in range of [0, 2^15-1], it will be u16 in domain,
+/// but it requires encoding and decoding like i16.
+/// See txindex, word31 and word63 types in db-sync schema definition.
+#[macro_export]
+macro_rules! sqlx_implementations_for_wrapper {
+	($WRAPPED:ty, $DBTYPE:expr, $NAME:ty, $DOMAIN:ty) => {
+		impl sqlx::Type<Postgres> for $NAME {
+			fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+				PgTypeInfo::with_name($DBTYPE)
+			}
+		}
+
+		impl<'r> Decode<'r, Postgres> for $NAME
+		where
+			$WRAPPED: Decode<'r, Postgres>,
+		{
+			fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+				let decoded: $WRAPPED = <$WRAPPED as Decode<Postgres>>::decode(value)?;
+				Ok(Self(decoded.try_into()?))
+			}
+		}
+
+		#[cfg(test)]
+		impl From<$WRAPPED> for $NAME {
+			fn from(value: $WRAPPED) -> Self {
+				Self(value.try_into().expect("value from domain fits in type db type"))
+			}
+		}
+
+		impl<'q> Encode<'q, Postgres> for $NAME {
+			fn encode_by_ref(
+				&self,
+				buf: &mut <Postgres as HasArguments<'q>>::ArgumentBuffer,
+			) -> IsNull {
+				buf.extend(&self.0.to_be_bytes());
+				IsNull::No
+			}
+		}
+
+		impl From<$NAME> for $DOMAIN {
+			fn from(value: $NAME) -> Self {
+				Self(value.0)
+			}
+		}
+
+		impl From<$DOMAIN> for $NAME {
+			fn from(value: $DOMAIN) -> Self {
+				Self(value.0)
+			}
+		}
+	};
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct BlockNumber(pub u32);
+sqlx_implementations_for_wrapper!(i32, "INT4", BlockNumber, McBlockNumber);
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct EpochNumber(pub u32);
+sqlx_implementations_for_wrapper!(i32, "INT4", EpochNumber, McEpochNumber);
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub struct SlotNumber(pub u64);
+sqlx_implementations_for_wrapper!(i64, "INT8", SlotNumber, McSlotNumber);
+
+/// CREATE DOMAIN txindex AS smallint CONSTRAINT txindex_check CHECK ((VALUE >= 0));
+#[derive(Debug, Clone, PartialEq)]
+pub struct TxIndex(pub u16);
+sqlx_implementations_for_wrapper!(i16, "INT2", TxIndex, UtxoIndex);
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TxIndexInBlock(pub u32);
+sqlx_implementations_for_wrapper!(i32, "INT4", TxIndexInBlock, McTxIndexInBlock);
+
+/// CREATE DOMAIN int65type AS numeric (20, 0) CHECK (VALUE >= -18446744073709551615 AND VALUE <= 18446744073709551615);
+#[derive(Debug, Clone, PartialEq)]
+pub struct TxValue(pub i128);
+
+impl sqlx::Type<Postgres> for TxValue {
+	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+		PgTypeInfo::with_name("NUMERIC")
+	}
+}
+
+impl<'r> Decode<'r, Postgres> for TxValue {
+	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
+		let i = decoded.to_i128().ok_or("TxValue is always an integer".to_string())?;
+		Ok(Self(i))
+	}
+}
+
+/// CREATE DOMAIN "lovelace" AS numeric(20,0) CONSTRAINT flyway_needs_this CHECK (VALUE >= 0::numeric AND VALUE <= '18446744073709551615'::numeric);
+#[derive(Debug, Clone, PartialEq)]
+pub struct StakeDelegation(pub u64);
+
+impl sqlx::Type<Postgres> for StakeDelegation {
+	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+		PgTypeInfo::with_name("NUMERIC")
+	}
+}
+
+impl<'r> Decode<'r, Postgres> for StakeDelegation {
+	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
+		let i = decoded.to_u64().ok_or("StakeDelegation is always a u64".to_string())?;
+		Ok(Self(i))
+	}
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct NativeTokenAmount(pub u128);
+impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
+	fn from(value: NativeTokenAmount) -> Self {
+		Self(value.0)
+	}
+}
+
+impl sqlx::Type<Postgres> for NativeTokenAmount {
+	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+		PgTypeInfo::with_name("NUMERIC")
+	}
+}
+
+impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
+	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
+		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
+		let i = decoded.to_u128().ok_or("NativeTokenQuantity is always a u128".to_string())?;
+		Ok(Self(i))
+	}
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct AssetName(pub Vec<u8>);
+
+impl From<sidechain_domain::AssetName> for AssetName {
+	fn from(name: sidechain_domain::AssetName) -> Self {
+		Self(name.0.to_vec())
+	}
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct PolicyId(pub Vec<u8>);
+
+impl From<sidechain_domain::PolicyId> for PolicyId {
+	fn from(id: sidechain_domain::PolicyId) -> Self {
+		Self(id.0.to_vec())
+	}
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct Asset {
+	pub policy_id: PolicyId,
+	pub asset_name: AssetName,
+}
+
+impl Asset {
+	/// Creates an Asset with empty asset_name.
+	pub fn new(policy_id: sidechain_domain::PolicyId) -> Self {
+		Self { policy_id: PolicyId(policy_id.0.to_vec()), asset_name: AssetName(vec![]) }
+	}
+}
+
+#[derive(Debug, Copy, Clone, sqlx::FromRow, PartialEq)]
+pub struct EpochNumberRow(pub EpochNumber);
+
+impl From<EpochNumberRow> for EpochNumber {
+	fn from(r: EpochNumberRow) -> Self {
+		r.0
+	}
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct Address(pub String);
+
+impl From<MainchainAddress> for Address {
+	fn from(addr: MainchainAddress) -> Self {
+		Self(addr.to_string())
+	}
+}
+
+#[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
+pub struct MainchainEpochNonce(pub Vec<u8>);

--- a/toolkit/utils/db-sync-sqlx/src/lib.rs
+++ b/toolkit/utils/db-sync-sqlx/src/lib.rs
@@ -118,28 +118,6 @@ impl<'r> Decode<'r, Postgres> for StakeDelegation {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct NativeTokenAmount(pub u128);
-impl From<NativeTokenAmount> for sidechain_domain::NativeTokenAmount {
-	fn from(value: NativeTokenAmount) -> Self {
-		Self(value.0)
-	}
-}
-
-impl sqlx::Type<Postgres> for NativeTokenAmount {
-	fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
-		PgTypeInfo::with_name("NUMERIC")
-	}
-}
-
-impl<'r> Decode<'r, Postgres> for NativeTokenAmount {
-	fn decode(value: <Postgres as HasValueRef<'r>>::ValueRef) -> Result<Self, BoxDynError> {
-		let decoded = <sqlx::types::BigDecimal as Decode<Postgres>>::decode(value)?;
-		let i = decoded.to_u128().ok_or("NativeTokenQuantity is always a u128".to_string())?;
-		Ok(Self(i))
-	}
-}
-
 #[derive(Debug, Clone, sqlx::FromRow, PartialEq)]
 pub struct AssetName(pub Vec<u8>);
 


### PR DESCRIPTION
# Description

Moves some db-sync types from `db-sync-follower` to a new crate `db-sync-sqlx`, so they can be more safely shared. These are only "primitive" types, because `db-sync-follower` types representing table rows do not have all columns. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
