### PR TITLE
test: fix nightly running from branch

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -127,7 +127,8 @@ jobs:
           --plan="$TEST_PLAN" \
           --execution="$TEST_EXECUTION" \
           --report_to_xray=$REPORT_TO_XRAY \
-          --decrypt=true
+          --decrypt=true \
+          --markers="not active_flow and not passive_flow"
 
     - name: Archive Debug Log
       if: always()


### PR DESCRIPTION
fixes:
- workflow_dispatch always uses master, but we checkout v1.6 to run nightly tests, and active_flow tests are still there and we were trying to run them generating a bunch of false positives

Refs: ETCM-9616