### PR TITLE
feat: prevent spending transaction inputs by introducing temporary wallet

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * `governance update` command now accepts multiple governance authority key hashes, not just one. It also takes `new-governance-threshold` parameter, which is the number of signatures required to perform governance action.
 * `governance init` and `governance update` will set Multisig policy implemented with ALeastN Native Script, instead of custom policy implemented as Plutus Script in partner-chains-smart-contracts. This policy doesn't require to set `required_signers` field in the transaction making it more user friendly.
 * Extracted the "Ariadne" committee selection algorithm to the `selection` crate.
+* `governance update` and `upsert-permissioned-candidates` commands are now protected from spending transaction inputs while transaction is being signed.
 
 ## Removed
 

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -9,10 +9,10 @@ use crate::setup_main_chain_state::SetupMainChainStateCmd;
 use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
 use crate::{verify_json, CmdRun};
 use hex_literal::hex;
+use partner_chains_cardano_offchain::multisig::MultiSigSmartContractResult;
 use serde_json::json;
 use sidechain_domain::{
-	AuraPublicKey, DParameter, GrandpaPublicKey, McSmartContractResult, McTxHash,
-	SidechainPublicKey, UtxoId,
+	AuraPublicKey, DParameter, GrandpaPublicKey, McTxHash, SidechainPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 
@@ -48,7 +48,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			genesis_utxo(),
 			&initial_permissioned_candidates(),
 			payment_signing_key(),
-			Ok(Some(McSmartContractResult::tx_hash([2; 32]))),
+			Ok(Some(MultiSigSmartContractResult::tx_submitted([2; 32]))),
 		);
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
@@ -102,7 +102,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			genesis_utxo(),
 			&initial_permissioned_candidates(),
 			payment_signing_key(),
-			Ok(Some(McSmartContractResult::tx_hash([2; 32]))),
+			Ok(Some(MultiSigSmartContractResult::tx_submitted([2; 32]))),
 		);
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -3,14 +3,14 @@ use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 use anyhow::anyhow;
 use partner_chains_cardano_offchain::d_param::UpsertDParam;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
+use partner_chains_cardano_offchain::multisig::MultiSigSmartContractResult;
 use partner_chains_cardano_offchain::permissioned_candidates::UpsertPermissionedCandidates;
 use partner_chains_cardano_offchain::register::{Deregister, Register};
 use partner_chains_cardano_offchain::scripts_data::{GetScriptsData, ScriptsData};
 use partner_chains_cardano_offchain::{cardano_keys::CardanoPaymentSigningKey, OffchainError};
 use pretty_assertions::assert_eq;
 use sidechain_domain::{
-	CandidateRegistration, DParameter, MainchainKeyHash, McSmartContractResult, McTxHash,
-	StakePoolPublicKey, UtxoId,
+	CandidateRegistration, DParameter, MainchainKeyHash, McTxHash, StakePoolPublicKey, UtxoId,
 };
 use sp_core::offchain::Timestamp;
 use std::collections::HashMap;
@@ -238,7 +238,7 @@ pub struct OffchainMock {
 		HashMap<(UtxoId, DParameter, PrivateKeyBytes), Result<Option<McTxHash>, String>>,
 	pub upsert_permissioned_candidates: HashMap<
 		(UtxoId, Vec<sidechain_domain::PermissionedCandidateData>, PrivateKeyBytes),
-		Result<Option<McSmartContractResult>, String>,
+		Result<Option<MultiSigSmartContractResult>, String>,
 	>,
 	pub register: HashMap<
 		(UtxoId, CandidateRegistration, PrivateKeyBytes),
@@ -322,7 +322,7 @@ impl OffchainMock {
 		genesis_utxo: UtxoId,
 		candidates: &[sidechain_domain::PermissionedCandidateData],
 		payment_key: PrivateKeyBytes,
-		result: Result<Option<McSmartContractResult>, String>,
+		result: Result<Option<MultiSigSmartContractResult>, String>,
 	) -> Self {
 		Self {
 			upsert_permissioned_candidates: [(
@@ -423,7 +423,7 @@ impl UpsertPermissionedCandidates for OffchainMock {
 		genesis_utxo: UtxoId,
 		candidates: &[sidechain_domain::PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<McSmartContractResult>> {
+	) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
 		self.upsert_permissioned_candidates
 			.get(&(genesis_utxo, candidates.to_vec(), payment_signing_key.to_bytes()))
 			.cloned()

--- a/toolkit/sidechain/domain/src/lib.rs
+++ b/toolkit/sidechain/domain/src/lib.rs
@@ -602,18 +602,6 @@ impl TryFrom<Vec<u8>> for McTxHash {
 	}
 }
 
-#[derive(Clone, Debug)]
-pub enum McSmartContractResult {
-	TxHash(McTxHash),
-	TxCBOR(Vec<u8>),
-}
-
-impl McSmartContractResult {
-	pub fn tx_hash(hash: [u8; 32]) -> Self {
-		Self::TxHash(McTxHash(hash))
-	}
-}
-
 #[derive(Default, Clone, Decode, Encode, PartialEq, Eq, TypeInfo, ToDatum, MaxEncodedLen, Hash)]
 #[byte_string(debug, decode_hex, hex_serialize, hex_deserialize)]
 pub struct McBlockHash(pub [u8; 32]);

--- a/toolkit/smart-contracts/commands/src/governance.rs
+++ b/toolkit/smart-contracts/commands/src/governance.rs
@@ -85,7 +85,7 @@ impl UpdateGovernanceCmd {
 		let payment_key = self.payment_key_file.read_key()?;
 		let client = self.common_arguments.get_ogmios_client().await?;
 
-		run_update_governance(
+		let result = run_update_governance(
 			&self.new_governance_authority,
 			self.new_governance_threshold,
 			&payment_key,
@@ -94,7 +94,7 @@ impl UpdateGovernanceCmd {
 			FixedDelayRetries::two_minutes(),
 		)
 		.await?;
-
+		println!("{}", serde_json::to_value(result)?);
 		Ok(())
 	}
 }

--- a/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
@@ -43,7 +43,7 @@ impl UpsertPermissionedCandidatesCmd {
 
 		let client = self.common_arguments.get_ogmios_client().await?;
 
-		upsert_permissioned_candidates(
+		let result = upsert_permissioned_candidates(
 			self.genesis_utxo,
 			&permissioned_candidates,
 			&payment_key,
@@ -51,6 +51,10 @@ impl UpsertPermissionedCandidatesCmd {
 			&FixedDelayRetries::two_minutes(),
 		)
 		.await?;
+		match result {
+			Some(result) => println!("{}", serde_json::to_value(result)?),
+			None => println!("{{}}"),
+		}
 
 		Ok(())
 	}

--- a/toolkit/smart-contracts/offchain/src/d_param/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/d_param/tests.rs
@@ -335,6 +335,7 @@ fn test_tx_context() -> TransactionContext {
 		],
 		network: NetworkIdKind::Testnet,
 		protocol_parameters: protocol_parameters(),
+		change_address: payment_addr(),
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -1,5 +1,5 @@
 use crate::cardano_keys::CardanoPaymentSigningKey;
-use crate::csl::{Costs, OgmiosUtxoExt};
+use crate::csl::Costs;
 use crate::{
 	await_tx::{AwaitTx, FixedDelayRetries},
 	csl::key_hash_address,

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -1,5 +1,5 @@
 use crate::cardano_keys::CardanoPaymentSigningKey;
-use crate::csl::Costs;
+use crate::csl::{Costs, OgmiosUtxoExt};
 use crate::{
 	await_tx::{AwaitTx, FixedDelayRetries},
 	csl::key_hash_address,

--- a/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
@@ -6,7 +6,7 @@ use crate::init_governance::run_init_governance;
 use crate::scripts_data;
 use crate::test_values::protocol_parameters;
 use crate::{csl::TransactionContext, ogmios_mock::MockOgmiosClient};
-use cardano_serialization_lib::{ExUnits, NetworkIdKind, PrivateKey};
+use cardano_serialization_lib::{Address, ExUnits, NetworkIdKind, PrivateKey};
 use hex_literal::*;
 use ogmios_client::transactions::{
 	OgmiosBudget, OgmiosEvaluateTransactionResponse, OgmiosValidatorIndex,
@@ -216,12 +216,17 @@ fn payment_key() -> PrivateKey {
 	PrivateKey::from_normal_bytes(&PAYMENT_KEY_BYTES).unwrap()
 }
 
+fn payment_address() -> Address {
+	Address::from_bech32("addr_test1vpmd59ajuvm34d723r8q2qzyz9ylq0x9pygqn7vun8qgpkgs7y5hw").unwrap()
+}
+
 fn tx_context() -> TransactionContext {
 	TransactionContext {
 		payment_key: payment_key(),
 		payment_key_utxos: vec![payment_utxo()],
 		network: NetworkIdKind::Testnet,
 		protocol_parameters: protocol_parameters(),
+		change_address: payment_address(),
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/src/lib.rs
+++ b/toolkit/smart-contracts/offchain/src/lib.rs
@@ -13,6 +13,8 @@ pub mod d_param;
 pub mod governance;
 /// Supports governance initialization
 pub mod init_governance;
+/// Types and functions related to smart-contracts that support MultiSig governance
+pub mod multisig;
 #[cfg(test)]
 pub mod ogmios_mock;
 /// Supports Permissioned Candidates upsert

--- a/toolkit/smart-contracts/offchain/src/multisig.rs
+++ b/toolkit/smart-contracts/offchain/src/multisig.rs
@@ -1,0 +1,160 @@
+use crate::{
+	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
+	csl::{get_builder_config, key_hash_address, Costs, TransactionBuilderExt, TransactionContext},
+	governance::GovernanceData,
+};
+use cardano_serialization_lib::{
+	PrivateKey, Transaction, TransactionBuilder, TransactionOutput, Value,
+};
+use ogmios_client::{
+	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
+	query_network::QueryNetwork,
+	transactions::Transactions,
+};
+use serde::{Serialize, Serializer};
+use sidechain_domain::{byte_string::ByteString, McTxHash, UtxoId, UtxoIndex};
+
+/// Successfull smart contracts offchain results in either transaction submission or creating transaction that has to be signed by the governance authorities
+#[derive(Clone, Debug, Serialize)]
+pub enum MultiSigSmartContractResult {
+	TransactionSubmitted(McTxHash),
+	TransactionToSign(MultiSigTransactionData),
+}
+
+/// MultiSig transactions awaiting for signatures use temporary wallets where funds are stored until the transaction is signed and submitted.
+/// This prevents payment utxo from being spend when the signatures for MultiSig are being collected.
+#[derive(Clone, Debug, Serialize)]
+pub struct MultiSigTransactionData {
+	pub temporary_wallet: TemporaryWalletData,
+	#[serde(serialize_with = "serialize_as_conway_tx")]
+	pub tx_cbor: Vec<u8>,
+}
+
+/// To be used only for manual re-claim of the funds if transaction has not been submitted
+#[derive(Clone, Debug, Serialize)]
+pub struct TemporaryWalletData {
+	pub address: String,
+	pub private_key: ByteString,
+	pub funded_by_tx: McTxHash,
+}
+
+pub(crate) struct TemporaryWallet {
+	pub address: cardano_serialization_lib::Address,
+	pub private_key: CardanoPaymentSigningKey,
+	pub funded_by_tx: [u8; 32],
+}
+
+impl From<TemporaryWallet> for TemporaryWalletData {
+	fn from(value: TemporaryWallet) -> Self {
+		TemporaryWalletData {
+			address: value.address.to_bech32(None).unwrap(),
+			private_key: value.private_key.to_bytes().into(),
+			funded_by_tx: McTxHash(value.funded_by_tx),
+		}
+	}
+}
+
+fn serialize_as_conway_tx<S>(tx_bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	let json = serde_json::json!({
+		"type": "Tx ConwayEra",
+		"description": "",
+		"cborHex": hex::encode(tx_bytes)
+	});
+	json.serialize(serializer)
+}
+
+impl MultiSigSmartContractResult {
+	pub fn tx_submitted(hash: [u8; 32]) -> Self {
+		Self::TransactionSubmitted(McTxHash(hash))
+	}
+}
+
+pub(crate) async fn create_temporary_wallet<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	ctx: &TransactionContext,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<TemporaryWallet> {
+	let private_key = CardanoPaymentSigningKey(PrivateKey::generate_ed25519()?);
+	log::info!(
+		"Temporary wallet private key: {}. Store this key for eventual re-claim of tokens",
+		private_key.0.to_hex()
+	);
+	let address = key_hash_address(&private_key.0.to_public().hash(), ctx.network);
+
+	let mut funding_tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	// TODO: ETCM-9627 - estimate tokens needed for the transaction
+	funding_tx_builder
+		.add_output(&TransactionOutput::new(&address, &Value::new(&5_000_000u32.into())))?;
+	let funding_tx = funding_tx_builder.balance_update_and_build(ctx)?;
+	let funding_tx_result = client.submit_transaction(&ctx.sign(&funding_tx).to_bytes()).await?;
+	let funded_by_tx = funding_tx_result.transaction.id;
+	await_tx.await_tx_output(client, UtxoId::new(funded_by_tx, 0)).await?;
+	let address_str: String = address.to_bech32(None)?;
+	log::info!(
+		"Founded temporary wallet {} with 5 ADA in transaction: {}",
+		&address_str,
+		&hex::encode(funded_by_tx)
+	);
+	Ok(TemporaryWallet { address, private_key, funded_by_tx })
+}
+
+/// If the chain has real MultiSig governance it:
+/// * creates a temporary wallet
+/// * sends 5 ADA from the payment wallet (subject of change)
+/// * creates a transaction that would be paid from the temporary wallet, signed by both wallets.
+/// If the chain has single key governance it creates and submits transaction paid by and signed by the payment wallet.
+pub(crate) async fn multisig_process<F, T, A>(
+	governance_data: &GovernanceData,
+	payment_ctx: &TransactionContext,
+	make_tx: F,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<MultiSigSmartContractResult>
+where
+	F: Fn(Costs, &TransactionContext) -> anyhow::Result<Transaction>,
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+{
+	if governance_data.policy.is_single_key_policy_for(&payment_ctx.payment_key_hash()) {
+		let tx = Costs::calculate_costs(|c| make_tx(c, &payment_ctx), client).await?;
+		let signed_tx = payment_ctx.sign(&tx).to_bytes();
+		let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+			anyhow::anyhow!(
+				"Submit governance update transaction request failed: {}, bytes: {}",
+				e,
+				hex::encode(signed_tx)
+			)
+		})?;
+		let tx_id = McTxHash(res.transaction.id);
+		log::info!("Update Governance transaction submitted: {}", hex::encode(tx_id.0));
+		await_tx
+			.await_tx_output(
+				client,
+				UtxoId { tx_hash: McTxHash(res.transaction.id), index: UtxoIndex(0) },
+			)
+			.await?;
+		Ok(MultiSigSmartContractResult::TransactionSubmitted(tx_id))
+	} else {
+		let temporary_wallet = create_temporary_wallet(&payment_ctx, client, await_tx).await?;
+		let temp_wallet_ctx = TransactionContext::for_payment_key_with_change_address(
+			&temporary_wallet.private_key,
+			&payment_ctx.change_address,
+			client,
+		)
+		.await?;
+		let tx = Costs::calculate_costs(|c| make_tx(c, &temp_wallet_ctx), client).await?;
+		let signed_tx_by_caller = payment_ctx.sign(&tx);
+		let signed_tx = temp_wallet_ctx.sign(&signed_tx_by_caller);
+		Ok(MultiSigSmartContractResult::TransactionToSign(MultiSigTransactionData {
+			temporary_wallet: temporary_wallet.into(),
+			tx_cbor: signed_tx.to_bytes(),
+		}))
+	}
+}

--- a/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
@@ -12,7 +12,7 @@ use crate::csl::{
 	TransactionBuilderExt, TransactionContext, TransactionExt,
 };
 use crate::governance::GovernanceData;
-use crate::multisig::{multisig_process, MultiSigSmartContractResult};
+use crate::multisig::{submit_or_create_tx_to_sign, MultiSigSmartContractResult};
 use crate::plutus_script::PlutusScript;
 use crate::{cardano_keys::CardanoPaymentSigningKey, scripts_data};
 use anyhow::anyhow;
@@ -162,7 +162,7 @@ where
 	C: Transactions + QueryLedgerState + QueryNetwork + QueryUtxoByUtxoId,
 	A: AwaitTx,
 {
-	multisig_process(
+	submit_or_create_tx_to_sign(
 		governance_data,
 		&payment_ctx,
 		|costs, ctx| {
@@ -175,6 +175,7 @@ where
 				&ctx,
 			)
 		},
+		"Insert Permissioned Candidates",
 		client,
 		await_tx,
 	)
@@ -195,7 +196,7 @@ where
 	C: Transactions + QueryNetwork + QueryLedgerState + QueryUtxoByUtxoId,
 	A: AwaitTx,
 {
-	multisig_process(
+	submit_or_create_tx_to_sign(
 		governance_data,
 		&payment_ctx,
 		|costs, ctx| {
@@ -209,6 +210,7 @@ where
 				&ctx,
 			)
 		},
+		"Update Permissioned Candidates",
 		client,
 		await_tx,
 	)

--- a/toolkit/smart-contracts/offchain/src/register.rs
+++ b/toolkit/smart-contracts/offchain/src/register.rs
@@ -366,6 +366,7 @@ mod tests {
 			payment_key_utxos: payment_key_utxos.clone(),
 			network: NetworkIdKind::Testnet,
 			protocol_parameters: protocol_parameters(),
+			change_address: payment_addr(),
 		};
 		let own_registration_utxos = vec![payment_key_utxos.get(1).unwrap().clone()];
 		let registration_utxo = payment_key_utxos.first().unwrap();
@@ -412,6 +413,7 @@ mod tests {
 			payment_key_utxos: payment_key_utxos.clone(),
 			network: NetworkIdKind::Testnet,
 			protocol_parameters: protocol_parameters(),
+			change_address: payment_addr(),
 		};
 		let registration_utxo = payment_key_utxos.first().unwrap();
 		let candidate_registration = candidate_registration(registration_utxo.utxo_id());

--- a/toolkit/smart-contracts/offchain/src/reserve/init.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/init.rs
@@ -435,6 +435,7 @@ mod tests {
 			payment_key_utxos: vec![make_utxo(121u8, 3, 996272387, &payment_addr())],
 			network: NetworkIdKind::Testnet,
 			protocol_parameters: protocol_parameters(),
+			change_address: payment_addr(),
 		}
 	}
 

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -189,7 +189,7 @@ mod tests {
 		plutus_script::PlutusScript,
 		reserve::{release::OgmiosUtxoExt, ReserveData, ReserveUtxo},
 		scripts_data::ReserveScripts,
-		test_values::protocol_parameters,
+		test_values::{payment_addr, protocol_parameters},
 	};
 	use cardano_serialization_lib::{
 		Int, Language, NetworkIdKind, PolicyID, PrivateKey, Transaction,
@@ -240,6 +240,7 @@ mod tests {
 			payment_key_utxos: vec![payment_utxo()],
 			network: NetworkIdKind::Testnet,
 			protocol_parameters: protocol_parameters(),
+			change_address: payment_addr(),
 		}
 	}
 

--- a/toolkit/smart-contracts/offchain/src/update_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/mod.rs
@@ -7,7 +7,7 @@
 //!    Plutus datum attached that contains the script ID (32) and policy hash.
 use crate::csl::{Costs, TransactionExt};
 use crate::governance::{GovernanceData, SimpleAtLeastN};
-use crate::multisig::{multisig_process, MultiSigSmartContractResult};
+use crate::multisig::{submit_or_create_tx_to_sign, MultiSigSmartContractResult};
 use crate::{
 	await_tx::AwaitTx,
 	cardano_keys::CardanoPaymentSigningKey,
@@ -45,7 +45,7 @@ pub async fn run_update_governance<
 	let payment_ctx = TransactionContext::for_payment_key(payment_key, client).await?;
 	let governance_data = GovernanceData::get(genesis_utxo_id, client).await?;
 
-	multisig_process(
+	submit_or_create_tx_to_sign(
 		&governance_data,
 		&payment_ctx,
 		|costs, ctx| {
@@ -60,6 +60,7 @@ pub async fn run_update_governance<
 				ctx,
 			)
 		},
+		"Update Governance",
 		client,
 		&await_tx,
 	)

--- a/toolkit/smart-contracts/offchain/src/update_governance/test.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/test.rs
@@ -1,5 +1,5 @@
 use super::{test_values, update_governance_tx};
-use crate::csl::{empty_asset_name, Costs, TransactionContext};
+use crate::csl::{empty_asset_name, key_hash_address, Costs, OgmiosUtxoExt, TransactionContext};
 use crate::governance::GovernanceData;
 use crate::test_values::{protocol_parameters, test_governance_policy};
 use cardano_serialization_lib::*;
@@ -13,6 +13,10 @@ fn payment_key() -> PrivateKey {
 		"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
 	))
 	.unwrap()
+}
+
+fn payment_key_address() -> Address {
+	key_hash_address(&payment_key().to_public().hash(), NetworkIdKind::Testnet)
 }
 
 fn test_address_bech32() -> String {
@@ -70,6 +74,7 @@ fn tx_context() -> TransactionContext {
 		payment_key_utxos: vec![payment_utxo()],
 		network: NetworkIdKind::Testnet,
 		protocol_parameters: protocol_parameters(),
+		change_address: payment_key_address(),
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/src/update_governance/test.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/test.rs
@@ -1,5 +1,5 @@
 use super::{test_values, update_governance_tx};
-use crate::csl::{empty_asset_name, key_hash_address, Costs, OgmiosUtxoExt, TransactionContext};
+use crate::csl::{empty_asset_name, key_hash_address, Costs, TransactionContext};
 use crate::governance::GovernanceData;
 use crate::test_values::{protocol_parameters, test_governance_policy};
 use cardano_serialization_lib::*;

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -658,6 +658,7 @@ async fn run_assemble_and_sign<
 	client: &T,
 ) -> Option<McTxHash> {
 	if let MultiSigSmartContractResult::TransactionToSign(MultiSigTransactionData {
+		tx_name: _,
 		temporary_wallet: _,
 		tx_cbor,
 	}) = multisig_result

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -18,7 +18,9 @@ use partner_chains_cardano_offchain::{
 	assemble_tx,
 	await_tx::{AwaitTx, FixedDelayRetries},
 	cardano_keys::CardanoPaymentSigningKey,
-	d_param, init_governance, permissioned_candidates,
+	d_param, init_governance,
+	multisig::{MultiSigSmartContractResult, MultiSigTransactionData},
+	permissioned_candidates,
 	register::Register,
 	reserve::{self, release::release_reserve_funds},
 	scripts_data, update_governance,
@@ -26,10 +28,10 @@ use partner_chains_cardano_offchain::{
 use partner_chains_plutus_data::reserve::ReserveDatum;
 use sidechain_domain::{
 	AdaBasedStaking, AssetId, AssetName, AuraPublicKey, CandidateRegistration, DParameter,
-	GrandpaPublicKey, MainchainKeyHash, MainchainSignature, McSmartContractResult, McTxHash,
-	PermissionedCandidateData, PolicyId, SidechainPublicKey, SidechainSignature,
-	StakePoolPublicKey, UtxoId, UtxoIndex,
+	GrandpaPublicKey, MainchainKeyHash, MainchainSignature, McTxHash, PermissionedCandidateData,
+	PolicyId, SidechainPublicKey, SidechainSignature, StakePoolPublicKey, UtxoId, UtxoIndex,
 };
+
 use std::time::Duration;
 use testcontainers::{clients::Cli, Container, GenericImage};
 use tokio_retry::{strategy::FixedInterval, Retry};
@@ -94,26 +96,38 @@ async fn governance_flow() {
 	let container = cli.run(image);
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_goveranance(&client).await;
-	let _ = run_update_goveranance(&client, genesis_utxo).await;
-	let await_tx = FixedDelayRetries::new(Duration::from_millis(500), 100);
-	// TODO: ETCM-9576 run upsert for permissioned candidates and then d-param and sign and submit both later, to prove they can interleve
-	let upsert_result = permissioned_candidates::upsert_permissioned_candidates(
-		genesis_utxo,
-		&vec![],
-		&governance_authority_payment_key(),
+	let _ = run_update_governance(&client, genesis_utxo).await;
+
+	let upsert_candidates_1_result =
+		run_upsert_permissioned_candidates(genesis_utxo, 1u8, &client).await;
+
+	let update_authorities_result = run_update_governance(&client, genesis_utxo).await;
+
+	run_assemble_and_sign(
+		upsert_candidates_1_result.unwrap(),
+		&[EVE_PAYMENT_KEY, GOVERNANCE_AUTHORITY_KEY],
 		&client,
-		&await_tx,
 	)
 	.await
 	.unwrap();
-	if let Some(McSmartContractResult::TxCBOR(tx_cbor)) = upsert_result {
-		let result =
-			run_assemble_and_sign(&tx_cbor, &[EVE_PAYMENT_KEY, GOVERNANCE_AUTHORITY_KEY], &client)
-				.await;
-		assert!(result.is_some())
-	} else {
-		panic!("Expected transaction cbor, because governance policy is not '1 of 1'")
-	}
+
+	run_assemble_and_sign(
+		update_authorities_result,
+		&[EVE_PAYMENT_KEY, GOVERNANCE_AUTHORITY_KEY],
+		&client,
+	)
+	.await
+	.unwrap();
+
+	let upsert_candidates_2_result =
+		run_upsert_permissioned_candidates(genesis_utxo, 2u8, &client).await;
+	run_assemble_and_sign(
+		upsert_candidates_2_result.unwrap(),
+		&[EVE_PAYMENT_KEY, GOVERNANCE_AUTHORITY_KEY],
+		&client,
+	)
+	.await
+	.unwrap();
 }
 
 #[tokio::test]
@@ -313,13 +327,13 @@ async fn run_init_goveranance<
 	genesis_utxo
 }
 
-async fn run_update_goveranance<
+async fn run_update_governance<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 >(
 	client: &T,
 	genesis_utxo: UtxoId,
-) {
-	let _ = update_governance::run_update_governance(
+) -> MultiSigSmartContractResult {
+	update_governance::run_update_governance(
 		&vec![EVE_PUBLIC_KEY_HASH, GOVERNANCE_AUTHORITY],
 		2,
 		&governance_authority_payment_key(),
@@ -328,7 +342,7 @@ async fn run_update_goveranance<
 		FixedDelayRetries::new(Duration::from_millis(500), 100),
 	)
 	.await
-	.unwrap();
+	.unwrap()
 }
 
 async fn run_upsert_d_param<
@@ -357,7 +371,7 @@ async fn run_upsert_permissioned_candidates<
 	genesis_utxo: UtxoId,
 	candidate: u8,
 	client: &T,
-) -> Option<McSmartContractResult> {
+) -> Option<MultiSigSmartContractResult> {
 	let candidates = vec![PermissionedCandidateData {
 		sidechain_public_key: SidechainPublicKey([candidate; 33].to_vec()),
 		aura_public_key: AuraPublicKey([candidate; 32].to_vec()),
@@ -639,14 +653,22 @@ async fn assert_illiquid_supply<T: QueryLedgerState>(
 async fn run_assemble_and_sign<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 >(
-	tx_bytes: &[u8],
+	multisig_result: MultiSigSmartContractResult,
 	signatories: &[[u8; 32]],
 	client: &T,
 ) -> Option<McTxHash> {
-	let tx = Transaction::from_bytes(tx_bytes.to_vec()).unwrap();
-	let witnesses: Vec<_> = signatories.iter().map(|s| sign(&tx, s)).collect();
-	let await_tx = FixedDelayRetries::new(Duration::from_millis(500), 100);
-	assemble_tx::assemble_tx(tx, witnesses, client, &await_tx).await.unwrap()
+	if let MultiSigSmartContractResult::TransactionToSign(MultiSigTransactionData {
+		temporary_wallet: _,
+		tx_cbor,
+	}) = multisig_result
+	{
+		let tx = Transaction::from_bytes(tx_cbor).unwrap();
+		let witnesses: Vec<_> = signatories.iter().map(|s| sign(&tx, s)).collect();
+		let await_tx = FixedDelayRetries::new(Duration::from_millis(500), 100);
+		assemble_tx::assemble_tx(tx, witnesses, client, &await_tx).await.unwrap()
+	} else {
+		panic!("Expected transaction cbor, because governance policy is not '1 of 1'")
+	}
 }
 
 fn sign(tx: &Transaction, private_key: &[u8; 32]) -> Vkeywitness {


### PR DESCRIPTION
# Description

Implements temporary wallet to prevent spending Transaction Inputs while the transaction is being signed.

For now it simply sends 5 ADA to temporary wallet and it seems to be enough. Change is sent back to payment address.

Potentially something more sophisticated will be required for smart contracts that spend some MultiAssets from payment address - I'm looking at reserve create/deposit, but this will come later.

Other thing that is now apparent is that `TransactionContext` binds quite few items and is passed by reference. In principle any transaction submission makes it invalid, because the set of available UTXOs on Cardano differs. This PR does not solve this problem.

REF: ETCM-9576

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff