### PR TITLE
refactor: don't use Ogmios types where domain types are enough

### DIFF
--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -3,17 +3,16 @@ use crate::{
 	config::{config_fields, ServiceConfig},
 	IOContext,
 };
-use ogmios_client::types::OgmiosTx;
 use partner_chains_cardano_offchain::{
 	cardano_keys::CardanoPaymentSigningKey, init_governance::InitGovernance,
 };
-use sidechain_domain::{MainchainKeyHash, UtxoId};
+use sidechain_domain::{MainchainKeyHash, McTxHash, UtxoId};
 
 pub(crate) fn run_init_governance<C: IOContext>(
 	genesis_utxo: UtxoId,
 	ogmios_config: &ServiceConfig,
 	context: &C,
-) -> anyhow::Result<OgmiosTx> {
+) -> anyhow::Result<McTxHash> {
 	let offchain = context.offchain_impl(ogmios_config)?;
 	let (payment_key, governance_authority) = get_private_key_and_key_hash(context)?;
 	let runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
@@ -46,9 +45,8 @@ mod tests {
 		verify_json,
 	};
 	use hex_literal::hex;
-	use ogmios_client::types::OgmiosTx;
 	use serde_json::{json, Value};
-	use sidechain_domain::{MainchainKeyHash, UtxoId};
+	use sidechain_domain::{MainchainKeyHash, McTxHash, UtxoId};
 
 	#[test]
 	fn happy_path() {
@@ -95,9 +93,7 @@ mod tests {
 			TEST_GENESIS_UTXO,
 			MainchainKeyHash(hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b")),
 			hex!("d0a6c5c921266d15dc8d1ce1e51a01e929a686ed3ec1a9be1145727c224bf386").to_vec(),
-			Ok(OgmiosTx {
-				id: hex!("0000000000000000000000000000000000000000000000000000000000000000"),
-			}),
+			Ok(McTxHash(hex!("0000000000000000000000000000000000000000000000000000000000000000"))),
 		);
 		OffchainMocks::new_with_mock("http://localhost:1337", mock)
 	}

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -1,7 +1,6 @@
 use crate::io::IOContext;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 use anyhow::anyhow;
-use ogmios_client::types::OgmiosTx;
 use partner_chains_cardano_offchain::d_param::UpsertDParam;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
 use partner_chains_cardano_offchain::permissioned_candidates::UpsertPermissionedCandidates;
@@ -234,7 +233,7 @@ impl OffchainMocks {
 pub struct OffchainMock {
 	pub scripts_data: HashMap<UtxoId, Result<ScriptsData, OffchainError>>,
 	pub init_governance:
-		HashMap<(UtxoId, MainchainKeyHash, PrivateKeyBytes), Result<OgmiosTx, OffchainError>>,
+		HashMap<(UtxoId, MainchainKeyHash, PrivateKeyBytes), Result<McTxHash, OffchainError>>,
 	pub upsert_d_param:
 		HashMap<(UtxoId, DParameter, PrivateKeyBytes), Result<Option<McTxHash>, String>>,
 	pub upsert_permissioned_candidates: HashMap<
@@ -271,7 +270,7 @@ impl OffchainMock {
 		genesis_utxo: UtxoId,
 		governance: MainchainKeyHash,
 		payment_key: PrivateKeyBytes,
-		result: Result<OgmiosTx, OffchainError>,
+		result: Result<McTxHash, OffchainError>,
 	) -> Self {
 		Self {
 			init_governance: vec![((genesis_utxo, governance, payment_key), result)]
@@ -350,7 +349,7 @@ impl InitGovernance for OffchainMock {
 		governance_authority: MainchainKeyHash,
 		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
-	) -> Result<OgmiosTx, OffchainError> {
+	) -> Result<McTxHash, OffchainError> {
 		self.init_governance
 			.get(&(genesis_utxo_id, governance_authority, payment_key.to_bytes()))
 			.cloned()

--- a/toolkit/smart-contracts/commands/src/governance.rs
+++ b/toolkit/smart-contracts/commands/src/governance.rs
@@ -43,7 +43,7 @@ impl InitGovernanceCmd {
 		let payment_key = self.payment_key_file.read_key()?;
 		let client = self.common_arguments.get_ogmios_client().await?;
 
-		run_init_governance(
+		let result = run_init_governance(
 			self.governance_authority,
 			&payment_key,
 			self.genesis_utxo,
@@ -51,6 +51,7 @@ impl InitGovernanceCmd {
 			FixedDelayRetries::two_minutes(),
 		)
 		.await?;
+		println!("{}", serde_json::to_string_pretty(&result)?);
 		Ok(())
 	}
 }

--- a/toolkit/smart-contracts/offchain/src/csl.rs
+++ b/toolkit/smart-contracts/offchain/src/csl.rs
@@ -307,8 +307,6 @@ pub(crate) trait OgmiosUtxoExt {
 	fn to_csl_tx_output(&self) -> Result<TransactionOutput, JsError>;
 	fn to_csl(&self) -> Result<TransactionUnspentOutput, JsError>;
 
-	fn to_domain(&self) -> sidechain_domain::UtxoId;
-
 	fn get_asset_amount(&self, asset: &AssetId) -> u64;
 
 	fn get_plutus_data(&self) -> Option<PlutusData>;
@@ -338,13 +336,6 @@ impl OgmiosUtxoExt for OgmiosUtxo {
 
 	fn to_csl(&self) -> Result<TransactionUnspentOutput, JsError> {
 		Ok(TransactionUnspentOutput::new(&self.to_csl_tx_input(), &self.to_csl_tx_output()?))
-	}
-
-	fn to_domain(&self) -> sidechain_domain::UtxoId {
-		sidechain_domain::UtxoId {
-			tx_hash: sidechain_domain::McTxHash(self.transaction.id),
-			index: sidechain_domain::UtxoIndex(self.index),
-		}
 	}
 
 	fn get_asset_amount(&self, asset_id: &AssetId) -> u64 {

--- a/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
@@ -1,7 +1,7 @@
 use super::transaction::*;
 use crate::await_tx::mock::ImmediateSuccess;
 use crate::cardano_keys::CardanoPaymentSigningKey;
-use crate::csl::{Costs, OgmiosUtxoExt};
+use crate::csl::Costs;
 use crate::init_governance::run_init_governance;
 use crate::scripts_data;
 use crate::test_values::protocol_parameters;
@@ -177,8 +177,8 @@ async fn transaction_run() {
 		}])
 		.with_submit_result(SubmitTransactionResponse { transaction });
 
-	let genesis_utxo = genesis_utxo().to_domain();
-	let (result_genesis_utxo, result_tx) = run_init_governance(
+	let genesis_utxo = genesis_utxo().utxo_id();
+	let result = run_init_governance(
 		governance_authority(),
 		&payment_key_domain(),
 		Some(genesis_utxo),
@@ -188,8 +188,8 @@ async fn transaction_run() {
 	.await
 	.expect("Should succeed");
 
-	assert_eq!(result_tx.id, transaction_id);
-	assert_eq!(result_genesis_utxo, genesis_utxo);
+	assert_eq!(result.tx_hash.0, transaction_id);
+	assert_eq!(result.genesis_utxo, genesis_utxo);
 }
 
 fn genesis_utxo() -> OgmiosUtxo {
@@ -239,7 +239,7 @@ fn test_costs() -> Costs {
 
 fn version_oracle_policy() -> crate::plutus_script::PlutusScript {
 	let (_, version_oracle_policy, _) =
-		scripts_data::version_scripts_and_address(genesis_utxo().to_domain(), tx_context().network)
+		scripts_data::version_scripts_and_address(genesis_utxo().utxo_id(), tx_context().network)
 			.unwrap();
 	version_oracle_policy
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
@@ -15,7 +15,7 @@ pub(crate) fn init_governance_transaction(
 	let multi_sig_policy =
 		SimpleAtLeastN { threshold: 1, key_hashes: vec![governance_authority.0] }
 			.to_csl_native_script();
-	let version_oracle = version_oracle(genesis_utxo.to_domain(), ctx.network)?;
+	let version_oracle = version_oracle(genesis_utxo.utxo_id(), ctx.network)?;
 	let config = crate::csl::get_builder_config(ctx)?;
 	let mut tx_builder = TransactionBuilder::new(&config);
 

--- a/toolkit/smart-contracts/offchain/src/register.rs
+++ b/toolkit/smart-contracts/offchain/src/register.rs
@@ -1,8 +1,7 @@
 use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::TransactionOutputAmountBuilderExt;
 use crate::csl::{
-	unit_plutus_data, CostStore, Costs, InputsBuilderExt, OgmiosUtxoExt, TransactionBuilderExt,
-	TransactionContext,
+	unit_plutus_data, CostStore, Costs, InputsBuilderExt, TransactionBuilderExt, TransactionContext,
 };
 use crate::{
 	await_tx::{AwaitTx, FixedDelayRetries},
@@ -72,7 +71,7 @@ pub async fn run_register<
 	let registration_utxo = ctx
 		.payment_key_utxos
 		.iter()
-		.find(|u| u.to_domain() == candidate_registration.registration_utxo)
+		.find(|u| u.utxo_id() == candidate_registration.registration_utxo)
 		.ok_or(anyhow!("registration utxo not found at payment address"))?;
 	let all_registration_utxos = client.query_utxos(&[validator_address]).await?;
 	let own_registrations = get_own_registrations(
@@ -370,7 +369,7 @@ mod tests {
 		};
 		let own_registration_utxos = vec![payment_key_utxos.get(1).unwrap().clone()];
 		let registration_utxo = payment_key_utxos.first().unwrap();
-		let candidate_registration = candidate_registration(registration_utxo.to_domain());
+		let candidate_registration = candidate_registration(registration_utxo.utxo_id());
 		let tx = register_tx(
 			&test_values::test_validator(),
 			&candidate_registration,
@@ -415,7 +414,7 @@ mod tests {
 			protocol_parameters: protocol_parameters(),
 		};
 		let registration_utxo = payment_key_utxos.first().unwrap();
-		let candidate_registration = candidate_registration(registration_utxo.to_domain());
+		let candidate_registration = candidate_registration(registration_utxo.utxo_id());
 		let own_registration_utxos = if payment_utxos.len() >= 2 {
 			vec![payment_utxos.get(1).unwrap().clone()]
 		} else {

--- a/toolkit/smart-contracts/offchain/src/update_governance/test.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/test.rs
@@ -1,5 +1,5 @@
 use super::{test_values, update_governance_tx};
-use crate::csl::{empty_asset_name, Costs, OgmiosUtxoExt, TransactionContext};
+use crate::csl::{empty_asset_name, Costs, TransactionContext};
 use crate::governance::GovernanceData;
 use crate::test_values::{protocol_parameters, test_governance_policy};
 use cardano_serialization_lib::*;
@@ -124,7 +124,7 @@ fn test_update_governance_tx() -> Transaction {
 	update_governance_tx(
 		test_values::VERSION_ORACLE_VALIDATOR,
 		test_values::VERSION_ORACLE_POLICY,
-		genesis_utxo().to_domain(),
+		genesis_utxo().utxo_id(),
 		&vec![new_governance_authority()],
 		1,
 		&governance_data(),


### PR DESCRIPTION
# Description

* prefer `McTxHash` to `OgmiosTx`
* remove `OgmiosUtxoExt::to_domain()`, because it is available without extension trait as `::utxo_id()`
* return struct instead of tuple in governance init
* print json to stdout

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
