### PR TITLE
feat: estimate funds required for temporary wallet

### DIFF
--- a/toolkit/sidechain/domain/src/byte_string.rs
+++ b/toolkit/sidechain/domain/src/byte_string.rs
@@ -88,6 +88,6 @@ impl<const N: u32> Display for BoundedString<N> {
 
 impl<const N: u32> Debug for BoundedString<N> {
 	fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-		f.write_str(&alloc::format!("BoundedString<{N}>({self:?})"))
+		f.write_str(&alloc::format!("BoundedString<{}>({:?})", N, self.0))
 	}
 }

--- a/toolkit/smart-contracts/offchain/src/assemble_tx.rs
+++ b/toolkit/smart-contracts/offchain/src/assemble_tx.rs
@@ -37,10 +37,10 @@ pub async fn assemble_tx<
 ) -> anyhow::Result<Option<McTxHash>> {
 	let mut witness_set = transaction.witness_set();
 
-	let mut vk = witness_set.vkeys().unwrap_or_else(|| Vkeywitnesses::new());
+	let mut vk = witness_set.vkeys().unwrap_or_else(Vkeywitnesses::new);
 
 	for w in witnesses.iter() {
-		vk.add(&w);
+		vk.add(w);
 	}
 	witness_set.set_vkeys(&vk);
 

--- a/toolkit/smart-contracts/offchain/src/d_param/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/d_param/mod.rs
@@ -195,7 +195,7 @@ fn mint_d_param_token_tx(
 		policy,
 		&empty_asset_name(),
 		&unit_plutus_data(),
-		&costs.get_mint(&policy.clone().into()),
+		&costs.get_mint(&policy.clone()),
 	)?;
 	tx_builder.add_output_with_one_script_token(
 		validator,

--- a/toolkit/smart-contracts/offchain/src/governance.rs
+++ b/toolkit/smart-contracts/offchain/src/governance.rs
@@ -43,12 +43,12 @@ impl GovernancePolicyScript {
 			Self::MultiSig(PartnerChainsMultisigPolicy { script: _, key_hashes, threshold }) => {
 				*threshold == 1
 					&& key_hashes.len() == 1
-					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(h.clone()) == key_hash)
+					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(*h) == key_hash)
 			},
 			Self::AtLeastNNativeScript(SimpleAtLeastN { threshold, key_hashes }) => {
 				*threshold == 1
 					&& key_hashes.len() == 1
-					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(h.clone()) == key_hash)
+					&& key_hashes.iter().any(|h| &Ed25519KeyHash::from(*h) == key_hash)
 			},
 		}
 	}

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -109,7 +109,7 @@ pub async fn run_init_governance<
 
 	let result = client.submit_transaction(&signed_transaction.to_bytes()).await?;
 	let tx_id = result.transaction.id;
-	log::info!("✅ Transaction submitted. ID: {}", hex::encode(&tx_id));
+	log::info!("✅ Transaction submitted. ID: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
 	Ok(InitGovernanceResult { tx_hash: McTxHash(tx_id), genesis_utxo: genesis_utxo.utxo_id() })
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
@@ -6,7 +6,7 @@ use crate::init_governance::run_init_governance;
 use crate::scripts_data;
 use crate::test_values::protocol_parameters;
 use crate::{csl::TransactionContext, ogmios_mock::MockOgmiosClient};
-use cardano_serialization_lib::{Address, ExUnits, NetworkIdKind, PrivateKey};
+use cardano_serialization_lib::{Address, ExUnits, NetworkIdKind};
 use hex_literal::*;
 use ogmios_client::transactions::{
 	OgmiosBudget, OgmiosEvaluateTransactionResponse, OgmiosValidatorIndex,
@@ -180,7 +180,7 @@ async fn transaction_run() {
 	let genesis_utxo = genesis_utxo().utxo_id();
 	let result = run_init_governance(
 		governance_authority(),
-		&payment_key_domain(),
+		&payment_key(),
 		Some(genesis_utxo),
 		&mock_client,
 		ImmediateSuccess,
@@ -208,12 +208,8 @@ fn genesis_utxo() -> OgmiosUtxo {
 const PAYMENT_KEY_BYTES: [u8; 32] =
 	hex!("94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04");
 
-fn payment_key_domain() -> CardanoPaymentSigningKey {
+fn payment_key() -> CardanoPaymentSigningKey {
 	CardanoPaymentSigningKey::from_normal_bytes(PAYMENT_KEY_BYTES).unwrap()
-}
-
-fn payment_key() -> PrivateKey {
-	PrivateKey::from_normal_bytes(&PAYMENT_KEY_BYTES).unwrap()
 }
 
 fn payment_address() -> Address {

--- a/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
@@ -23,7 +23,7 @@ pub(crate) fn init_governance_transaction(
 		&version_oracle.policy,
 		&version_oracle_asset_name(),
 		&mint_redeemer(&multi_sig_policy),
-		&costs.get_mint(&version_oracle.policy.clone().into()),
+		&costs.get_mint(&version_oracle.policy.clone()),
 	)?;
 
 	tx_builder.add_output(&version_oracle_datum_output(

--- a/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
@@ -120,9 +120,6 @@ pub async fn upsert_permissioned_candidates<
 			)
 		},
 	};
-	if let Some(MultiSigSmartContractResult::TransactionSubmitted(tx_hash)) = result_opt {
-		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
-	}
 	Ok(result_opt)
 }
 
@@ -172,7 +169,7 @@ where
 				candidates,
 				governance_data,
 				costs,
-				&ctx,
+				ctx,
 			)
 		},
 		"Insert Permissioned Candidates",
@@ -207,7 +204,7 @@ where
 				current_utxo,
 				governance_data,
 				costs,
-				&ctx,
+				ctx,
 			)
 		},
 		"Update Permissioned Candidates",
@@ -233,7 +230,7 @@ fn mint_permissioned_candidates_token_tx(
 			policy,
 			&empty_asset_name(),
 			&permissioned_candidates_policy_redeemer_data(),
-			&costs.get_mint(&policy.clone().into()),
+			&costs.get_mint(&policy.clone()),
 		)?;
 	}
 	tx_builder.add_output_with_one_script_token(

--- a/toolkit/smart-contracts/offchain/src/reserve/init.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/init.rs
@@ -162,7 +162,7 @@ fn init_script_tx(
 			&version_oracle.policy,
 			&version_oracle_asset_name(),
 			&witness,
-			&costs.get_mint(&version_oracle.policy.clone().into()),
+			&costs.get_mint(&version_oracle.policy.clone()),
 		)?;
 	}
 	{

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -186,14 +186,13 @@ fn v_function_from_utxo(utxo: &OgmiosUtxo) -> anyhow::Result<PlutusScript> {
 mod tests {
 	use super::{empty_asset_name, reserve_release_tx, AssetNameExt, Costs, TransactionContext};
 	use crate::{
+		cardano_keys::CardanoPaymentSigningKey,
 		plutus_script::PlutusScript,
 		reserve::{release::OgmiosUtxoExt, ReserveData, ReserveUtxo},
 		scripts_data::ReserveScripts,
 		test_values::{payment_addr, protocol_parameters},
 	};
-	use cardano_serialization_lib::{
-		Int, Language, NetworkIdKind, PolicyID, PrivateKey, Transaction,
-	};
+	use cardano_serialization_lib::{Int, Language, NetworkIdKind, PolicyID, Transaction};
 	use hex_literal::hex;
 	use ogmios_client::types::{Asset, OgmiosTx, OgmiosUtxo, OgmiosValue};
 	use partner_chains_plutus_data::reserve::{
@@ -202,8 +201,8 @@ mod tests {
 	use pretty_assertions::assert_eq;
 	use sidechain_domain::{AssetName, PolicyId};
 
-	fn payment_key() -> PrivateKey {
-		PrivateKey::from_normal_bytes(&hex!(
+	fn payment_key() -> CardanoPaymentSigningKey {
+		CardanoPaymentSigningKey::from_normal_bytes(hex!(
 			"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
 		))
 		.unwrap()

--- a/toolkit/smart-contracts/offchain/src/test_values.rs
+++ b/toolkit/smart-contracts/offchain/src/test_values.rs
@@ -1,8 +1,9 @@
 use crate::{
+	cardano_keys::CardanoPaymentSigningKey,
 	governance::{GovernancePolicyScript, PartnerChainsMultisigPolicy},
 	plutus_script::PlutusScript,
 };
-use cardano_serialization_lib::{Address, Language, PlutusData, PrivateKey};
+use cardano_serialization_lib::{Address, Language, PlutusData};
 use hex_literal::hex;
 use ogmios_client::{
 	query_ledger_state::{
@@ -12,8 +13,8 @@ use ogmios_client::{
 };
 use sidechain_domain::StakePoolPublicKey;
 
-pub(crate) fn payment_key() -> PrivateKey {
-	PrivateKey::from_normal_bytes(&hex!(
+pub(crate) fn payment_key() -> CardanoPaymentSigningKey {
+	CardanoPaymentSigningKey::from_normal_bytes(hex!(
 		"cf86dc85e4933424826e846c18d2695689bf65de1fc0c40fcd9389ba1cbdc069"
 	))
 	.unwrap()

--- a/toolkit/smart-contracts/offchain/src/update_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/mod.rs
@@ -35,7 +35,7 @@ pub async fn run_update_governance<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 	A: AwaitTx,
 >(
-	new_governance_authority: &Vec<MainchainKeyHash>,
+	new_governance_authority: &[MainchainKeyHash],
 	new_governance_threshold: u8,
 	payment_key: &CardanoPaymentSigningKey,
 	genesis_utxo_id: UtxoId,
@@ -71,7 +71,7 @@ fn update_governance_tx(
 	version_oracle_validator: &[u8],
 	version_oracle_policy: &[u8],
 	genesis_utxo: UtxoId,
-	new_governance_authority: &Vec<MainchainKeyHash>,
+	new_governance_authority: &[MainchainKeyHash],
 	new_governance_threshold: u8,
 	governance_data: &GovernanceData,
 	costs: Costs,

--- a/toolkit/smart-contracts/offchain/src/update_governance/test.rs
+++ b/toolkit/smart-contracts/offchain/src/update_governance/test.rs
@@ -1,4 +1,5 @@
 use super::{test_values, update_governance_tx};
+use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::{empty_asset_name, key_hash_address, Costs, TransactionContext};
 use crate::governance::GovernanceData;
 use crate::test_values::{protocol_parameters, test_governance_policy};
@@ -8,15 +9,15 @@ use ogmios_client::types::{Asset, Datum, OgmiosTx, OgmiosUtxo, OgmiosValue};
 use pretty_assertions::assert_eq;
 use sidechain_domain::MainchainKeyHash;
 
-fn payment_key() -> PrivateKey {
-	PrivateKey::from_normal_bytes(&hex!(
+fn payment_key() -> CardanoPaymentSigningKey {
+	CardanoPaymentSigningKey::from_normal_bytes(hex!(
 		"94f7531c9639654b77fa7e10650702b6937e05cd868f419f54bcb8368e413f04"
 	))
 	.unwrap()
 }
 
 fn payment_key_address() -> Address {
-	key_hash_address(&payment_key().to_public().hash(), NetworkIdKind::Testnet)
+	key_hash_address(&payment_key().0.to_public().hash(), NetworkIdKind::Testnet)
 }
 
 fn test_address_bech32() -> String {

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -100,9 +100,7 @@ async fn governance_flow() {
 
 	let upsert_candidates_1_result =
 		run_upsert_permissioned_candidates(genesis_utxo, 1u8, &client).await;
-
 	let update_authorities_result = run_update_governance(&client, genesis_utxo).await;
-
 	run_assemble_and_sign(
 		upsert_candidates_1_result.unwrap(),
 		&[EVE_PAYMENT_KEY, GOVERNANCE_AUTHORITY_KEY],


### PR DESCRIPTION
# Description

* Estimation of required temporary wallet funds is updated from `5 ADA` to `(inputs - change) + 5 ADA`. Difference of inputs and change alone is not enough because of presence of unrelated multi-assets tokens is relevant. Maybe there are other factors that I have failed to identify. This works with all our smart-contracts in integration tests. I have all reserve operations working on other branch.
* Approx 10 clippy changes

REF: ETCM-9627
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
