### PR TITLE
Added FindAccountFromAuthorIndex for pallet_partner_chains_session

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * `governance init` and `governance update` will set Multisig policy implemented with ALeastN Native Script, instead of custom policy implemented as Plutus Script in partner-chains-smart-contracts. This policy doesn't require to set `required_signers` field in the transaction making it more user friendly.
 * Extracted the "Ariadne" committee selection algorithm to the `selection` crate.
 * `governance update` and `upsert-permissioned-candidates` commands are now protected from spending transaction inputs while transaction is being signed.
+* Added implementation of `FindAccountFromAuthorIndex` trait for `pallet_partner_chains_session`.
 
 ## Removed
 


### PR DESCRIPTION
# Description

This PR extends `pallet_partner_chains_session` with implementation of `FindAccountFromAuthorIndex` trait with small adjustment to use `ValidatorsAndKeys`. Code is almost entirely copy-pasted from original `pallet-session`.

This trait will be later used as part of other pallet integrations like `im-online`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
