### PR TITLE
delegator-rewards-e2e-tests

### DIFF
--- a/e2e-tests/config/api_config.py
+++ b/e2e-tests/config/api_config.py
@@ -41,7 +41,6 @@ class Node:
     permissioned_candidate: bool = False
     cardano_payment_addr: str = MISSING
     keys_files: Optional[KeysFiles] = None
-    block_rewards_id: str = MISSING
 
 
 @dataclass

--- a/e2e-tests/config/substrate/ci_nodes.json
+++ b/e2e-tests/config/substrate/ci_nodes.json
@@ -21,8 +21,7 @@
           "spo_signing_key": "./secrets/substrate/staging/keys/validator-1/cold.skey.json.decrypted",
           "spo_public_key": "./secrets/substrate/staging/keys/validator-1/cold.vkey.json.decrypted",
           "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-1/partner_chain.skey.json.decrypted"
-        },
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000201"
+        }
       },
       "validator-2": {
         "host": "10.0.11.26",
@@ -39,8 +38,7 @@
           "spo_signing_key": "./secrets/substrate/staging/keys/validator-2/cold.skey.json.decrypted",
           "spo_public_key": "./secrets/substrate/staging/keys/validator-2/cold.vkey.json.decrypted",
           "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-2/partner_chain.skey.json.decrypted"
-        },
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000202"
+        }
       },
       "validator-3": {
         "host": "10.0.12.51",
@@ -57,8 +55,7 @@
           "spo_signing_key": "./secrets/substrate/staging/keys/validator-3/cold.skey.json.decrypted",
           "spo_public_key": "./secrets/substrate/staging/keys/validator-3/cold.vkey.json.decrypted",
           "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-3/partner_chain.skey.json.decrypted"
-        },
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000203"
+        }
       },
       "validator-4": {
         "host": "10.0.10.188",
@@ -75,8 +72,7 @@
           "spo_signing_key": "./secrets/substrate/staging/keys/validator-4/cold.skey.json.decrypted",
           "spo_public_key": "./secrets/substrate/staging/keys/validator-4/cold.vkey.json.decrypted",
           "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-4/partner_chain.skey.json.decrypted"
-        },
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000204"
+        }
       },
       "validator-5": {
         "host": "10.0.11.239",
@@ -93,8 +89,7 @@
           "spo_signing_key": "./secrets/substrate/staging/keys/validator-5/cold.skey.json.decrypted",
           "spo_public_key": "./secrets/substrate/staging/keys/validator-5/cold.vkey.json.decrypted",
           "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-5/partner_chain.skey.json.decrypted"
-        },
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000205"
+        }
       }
     },
     "governance_authority": {

--- a/e2e-tests/config/substrate/devnet_nodes.json
+++ b/e2e-tests/config/substrate/devnet_nodes.json
@@ -15,8 +15,7 @@
                 "public_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1",
                 "aura_public_key": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
                 "grandpa_public_key": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee",
-                "permissioned_candidate": true,
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000001"
+                "permissioned_candidate": true
             },
             "bob": {
                 "host": "10.0.10.13",
@@ -26,8 +25,7 @@
                 "public_key": "0x0390084fdbf27d2b79d26a4f13f0ccd982cb755a661969143c37cbc49ef5b91f27",
                 "aura_public_key": "0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
                 "grandpa_public_key": "0xd17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69",
-                "permissioned_candidate": true,
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000002"
+                "permissioned_candidate": true
             },
             "charlie": {
                 "host": "10.0.10.13",
@@ -37,8 +35,7 @@
                 "public_key": "0x0389411795514af1627765eceffcbd002719f031604fadd7d188e2dc585b4e1afb",
                 "aura_public_key": "0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22",
                 "grandpa_public_key": "0x439660b36c6c03afafca027b910b4fecf99801834c62a5e6006f27d978de234f",
-                "permissioned_candidate": true,
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000003"
+                "permissioned_candidate": true
             },
             "dave": {
                 "host": "10.0.10.13",
@@ -47,8 +44,7 @@
                 "pool_id": "2e36e13ad5665685f163e4fa3d32ccf0a333fda0a67c93cbac99f7a2",
                 "public_key": "0x03bc9d0ca094bd5b8b3225d7651eac5d18c1c04bf8ae8f8b263eebca4e1410ed0c",
                 "aura_public_key": "0x306721211d5404bd9da88e0204360a1a9ab8b87c66c1bc2fcdd37f3c2222cc20",
-                "grandpa_public_key": "0x5e639b43e0052c47447dac87d6fd2b6ec50bdd4d0f614e4299c665249bbd09d9",
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000004"
+                "grandpa_public_key": "0x5e639b43e0052c47447dac87d6fd2b6ec50bdd4d0f614e4299c665249bbd09d9"
             },
             "eve": {
                 "host": "10.0.10.13",
@@ -65,8 +61,7 @@
                     "spo_signing_key": "./secrets/substrate/devnet/keys/eve/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/devnet/keys/eve/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/devnet/keys/eve/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000005"
+                }
             },
             "ferdie": {
                 "host": "10.0.10.13",
@@ -83,8 +78,7 @@
                     "spo_signing_key": "./secrets/substrate/devnet/keys/ferdie/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/devnet/keys/ferdie/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/devnet/keys/ferdie/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000006"
+                }
             },
             "greg": {
                 "host": "10.0.10.13",
@@ -94,8 +88,7 @@
                 "public_key": "0x02dacce90fca29ca80404d9b4e8ff3d9dabd03def6a82e412acb2ad04dd734dbfc",
                 "aura_public_key": "0x2c4ed1038f6e4131c21b6b89885ed232c5b81bae09009376e9079cc8aa518a1c",
                 "grandpa_public_key": "0xfa41bacb202b0529288b05af1b324f85fe561091c2d29d9df1df37c3aa687c23",
-                "permissioned_candidate": false,
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000007"
+                "permissioned_candidate": false
             },
             "henry": {
                 "host": "10.0.10.13",
@@ -105,8 +98,7 @@
                 "public_key": "0x0263c9cdabbef76829fe5b35f0bbf3051bd1c41b80f58b5d07c271d0dd04de2a4e",
                 "aura_public_key": "0x9cedc9f7b926191f64d68ee77dd90c834f0e73c0f53855d77d3b0517041d5640",
                 "grandpa_public_key": "0xde21d8171821fc29a43a1ed90ee75623edc3794012010f165b6afc3483a569aa",
-                "permissioned_candidate": true,
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000008"
+                "permissioned_candidate": true
             }
         },
         "governance_authority": {

--- a/e2e-tests/config/substrate/local_nodes.json
+++ b/e2e-tests/config/substrate/local_nodes.json
@@ -7,7 +7,7 @@
     "slot_length": 1,
     "active_slots_coeff": 0.4,
     "security_param": 5,
-    "init_timestamp": 1730141520,
+    "init_timestamp": 1742993000,
     "block_stability_margin": 0,
     "native_token": {
       "total_accrued_function_script_hash": "ef1eb7b85327a8460799025a5affd0a8d8015731e9aacd5d1106a82b",

--- a/e2e-tests/config/substrate/local_nodes.json
+++ b/e2e-tests/config/substrate/local_nodes.json
@@ -25,8 +25,7 @@
         "public_key": "0x020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1",
         "aura_public_key": "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d",
         "grandpa_public_key": "0x88dc3417d5058ec4b4503e0c12ea1a0a89be200fe98922423d4334014fa6b0ee",
-        "permissioned_candidate": true,
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000001"
+        "permissioned_candidate": true
       },
       "bob": {
         "host": "127.0.0.1",
@@ -35,8 +34,7 @@
         "public_key": "0x0390084fdbf27d2b79d26a4f13f0ccd982cb755a661969143c37cbc49ef5b91f27",
         "aura_public_key": "0x8eaf04151687736326c9fea17e25fc5287613693c912909cb226aa4794f26a48",
         "grandpa_public_key": "0xd17c2d7823ebf260fd138f2d7e27d114c0145d968b5ff5006125f2414fadae69",
-        "permissioned_candidate": true,
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000002"
+        "permissioned_candidate": true
       },
       "charlie": {
         "host": "127.0.0.1",
@@ -45,8 +43,7 @@
         "public_key": "0x0389411795514af1627765eceffcbd002719f031604fadd7d188e2dc585b4e1afb",
         "aura_public_key": "0x90b5ab205c6974c9ea841be688864633dc9ca8a357843eeacf2314649965fe22",
         "grandpa_public_key": "0x439660b36c6c03afafca027b910b4fecf99801834c62a5e6006f27d978de234f",
-        "permissioned_candidate": true,
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000003"
+        "permissioned_candidate": true
       },
       "dave": {
         "host": "127.0.0.1",
@@ -57,7 +54,6 @@
         "rotation_candidate": true,
         "cardano_payment_addr": "addr_test1vphpcf32drhhznv6rqmrmgpuwq06kug0lkg22ux777rtlqst2er0r",
         "aura_ss58_address": "5HKLH5ErLMNHReWGFGtrDPRdNqdKP56ArQA6DFmgANzunK7A",
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000004",
         "keys_files": {
           "cardano_payment_key": "/partner-chains-nodes/partner-chains-node-4/keys/payment.skey",
           "spo_signing_key": "./secrets/substrate/local/keys/dave/cold.skey",
@@ -73,7 +69,6 @@
         "aura_public_key": "0xb0eb82cbdf9f92c384d88ea14de34aa38f7d05b0131b7b9bc21bb3f395920c22",
         "grandpa_public_key": "0x83c5eea08f80a64d7abf4c15a8a19d9f186aa62fc14389a7c6d6042bcc971daf",
         "rotation_candidate": true,
-        "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000005",
         "cardano_payment_addr": "addr_test1vzzt5pwz3pum9xdgxalxyy52m3aqur0n43pcl727l37ggscl8h7v8",
         "keys_files": {
           "cardano_payment_key": "/partner-chains-nodes/partner-chains-node-5/keys/payment.skey",

--- a/e2e-tests/config/substrate/staging_nodes.json
+++ b/e2e-tests/config/substrate/staging_nodes.json
@@ -21,8 +21,7 @@
                     "spo_signing_key": "./secrets/substrate/staging/keys/validator-1/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/staging/keys/validator-1/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-1/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000201"
+                }
             },
             "validator-2": {
                 "host": "10.0.10.90",
@@ -39,8 +38,7 @@
                     "spo_signing_key": "./secrets/substrate/staging/keys/validator-2/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/staging/keys/validator-2/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-2/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000202"
+                }
             },
             "validator-3": {
                 "host": "10.0.10.90",
@@ -57,8 +55,7 @@
                     "spo_signing_key": "./secrets/substrate/staging/keys/validator-3/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/staging/keys/validator-3/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-3/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000203"
+                }
             },
             "validator-4": {
                 "host": "10.0.10.90",
@@ -75,8 +72,7 @@
                     "spo_signing_key": "./secrets/substrate/staging/keys/validator-4/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/staging/keys/validator-4/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-4/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000204"
+                }
             },
             "validator-5": {
                 "host": "10.0.10.90",
@@ -93,8 +89,7 @@
                     "spo_signing_key": "./secrets/substrate/staging/keys/validator-5/cold.skey.json.decrypted",
                     "spo_public_key": "./secrets/substrate/staging/keys/validator-5/cold.vkey.json.decrypted",
                     "partner_chain_signing_key": "./secrets/substrate/staging/keys/validator-5/partner_chain.skey.json.decrypted"
-                },
-                "block_rewards_id": "0x0000000000000000000000000000000000000000000000000000000000000205"
+                }
             }
         },
         "governance_authority": {

--- a/e2e-tests/docs/run-tests-on-new-env.md
+++ b/e2e-tests/docs/run-tests-on-new-env.md
@@ -61,7 +61,6 @@ Add payment signing key of the governance authority as `init.skey` to `secrets/<
   - `permissioned_candidate` - set to true if you want this node to participate in block production as permissioned candidate (true|false)
                                random candidate will be removed each execution to test rotation
                                use with caution, tests may alter your permissioned candidates resulting in not achieving consensus
-  - `block_reward_id` - reward id configured at the partner chain startup
   - `key_files` - a set of keys for registered candidates
     - `cardano_payment_key` - path to payment key of registered candidate (payment.skey from step 1)
     - `spo_signing_key` - path to signing key of registered candidate (cold.skey form step 1)
@@ -110,7 +109,6 @@ E.g. for Cardano Preview it will be:
                 "aura_public_key": <STRING>,
                 "grandpa_public_key": <STRING>",
                 "permissioned_candidate": <BOOLEAN>,
-                "block_rewards_id": <STRING>
                 "key_files": {
                     "cardano_payment_key": <STRING>,
                     "spo_signing_key": <STRING>,

--- a/e2e-tests/pytest.ini
+++ b/e2e-tests/pytest.ini
@@ -5,7 +5,7 @@ markers =
     candidate_status: active or inactive, used in test_registrations.py
     ariadne: run tests for Ariadne feature
     probability: run non deterministic tests
-    block_reward: run tests for Block Rewards feature
+    delegator_rewards: run tests for ADA Delegator Rewards feature
     registration: run tests for Registration feature (permissioned and trustless)
     committee_distribution: run tests for Committee Distribution feature
     committee_rotation: run tests for Committee Rotation feature

--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -1,6 +1,7 @@
 omegaconf==2.3.0
 pytest==8.3.4
 pytest-xdist==3.6.1
+pytest-dependency==0.6.0
 substrate-interface==1.7.11
 sqlalchemy==2.0.38
 psycopg2-binary==2.9.10

--- a/e2e-tests/src/blockchain_api.py
+++ b/e2e-tests/src/blockchain_api.py
@@ -399,7 +399,9 @@ class BlockchainApi(ABC):
         pass
 
     @abstractmethod
-    def sign_block_producer_metadata(self, metadata: dict, cross_chain_signing_key: str) -> BlockProducerMetadataSignature:
+    def sign_block_producer_metadata(
+        self, metadata: dict, cross_chain_signing_key: str
+    ) -> BlockProducerMetadataSignature:
         """
         Creates a signature for block procuder metadata.
 
@@ -485,7 +487,7 @@ class BlockchainApi(ABC):
         """
         Calls testHelperPallet for block participation data. This helper pallet returns raw inherent data that can be
         used by chain builders to implement rewards distribution logic.
-        Helper pallet releases data every 30 slots.
+        Helper pallet releases data in a block produced in a slot divisible by 30.
 
         Arguments:
             block_hash {str} -- PC block hash

--- a/e2e-tests/src/blockchain_api.py
+++ b/e2e-tests/src/blockchain_api.py
@@ -479,3 +479,28 @@ class BlockchainApi(ABC):
             block production log
         """
         pass
+
+    @abstractmethod
+    def get_block_participation_data(self, block_hash=None):
+        """
+        Calls testHelperPallet for block participation data. This helper pallet returns raw inherent data that can be
+        used by chain builders to implement rewards distribution logic.
+        Helper pallet releases data every 30 slots.
+
+        Arguments:
+            block_hash {str} -- PC block hash
+
+        Returns:
+            block participation data
+        """
+        pass
+
+    @abstractmethod
+    def get_initial_pc_epoch(self) -> int:
+        """
+        Returns initial PC epoch
+
+        Returns:
+            int -- initial PC epoch
+        """
+        pass

--- a/e2e-tests/src/cardano_cli.py
+++ b/e2e-tests/src/cardano_cli.py
@@ -59,12 +59,9 @@ class CardanoCli:
                             ]
         return tokensDict
 
-    def get_stake_pool_id(self, cold_vkey_file, cold_vkey=None):
+    def get_stake_pool_id(self, cold_vkey, output_format="hex"):
         logger.info("Getting Stake Pool Id")
-        if cold_vkey:
-            cmd = f'{self.cli} latest stake-pool id --stake-pool-verification-key {cold_vkey} --output-format "hex"'
-        else:
-            cmd = f'{self.cli} latest stake-pool id --cold-verification-key-file {cold_vkey_file} --output-format "hex"'
+        cmd = f'{self.cli} latest stake-pool id --stake-pool-verification-key {cold_vkey} --output-format "{output_format}"'
         result = self.run_command.run(cmd)
         if result.stderr:
             logger.error(result.stderr)

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -687,3 +687,17 @@ class SubstrateApi(BlockchainApi):
         result = self.substrate.query("BlockProductionLog", "Log", block_hash=block_hash)
         logger.debug(f"Block production log: {result}")
         return result.value
+
+    def get_block_participation_data(self, block_hash=None):
+        result = self.substrate.query("TestHelperPallet", "LatestParticipationData", block_hash=block_hash)
+        logger.debug(f"Block participation data: {result}")
+        return result.value
+
+    def get_initial_pc_epoch(self):
+        block = self.get_block()
+        block_hash = block["header"]["hash"]
+        session_index_result = self.substrate.query("Session", "CurrentIndex", block_hash=block_hash)
+        epoch_result = self.substrate.query("Sidechain", "EpochNumber", block_hash=block_hash)
+        logger.debug(f"Current session index: {session_index_result}, epoch number: {epoch_result}")
+        initial_epoch = epoch_result.value - session_index_result.value
+        return initial_epoch

--- a/e2e-tests/tests/committee/conftest.py
+++ b/e2e-tests/tests/committee/conftest.py
@@ -334,9 +334,7 @@ def update_db_with_active_candidates(db: Session, api: BlockchainApi) -> int:
                         candidate_db = StakeDistributionCommittee()
                         candidate_db.mc_epoch = mc_epoch
                         candidate_db.mc_vkey = active_candidate[2:]
-                        candidate_db.pool_id = api.cardano_cli.get_stake_pool_id(
-                            cold_vkey_file=None, cold_vkey=active_candidate[2:]
-                        )
+                        candidate_db.pool_id = api.cardano_cli.get_stake_pool_id(cold_vkey=active_candidate[2:])
                         candidate_db.stake_delegation = api.cardano_cli.get_stake_snapshot_of_pool(
                             candidate_db.pool_id
                         )["pools"][candidate_db.pool_id]["stakeGo"]

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -6,36 +6,16 @@ import logging as logger
 COMMITTEE_REPETITIONS_IN_PC_EPOCH = 2
 
 
-@mark.block_reward
-@mark.xdist_group("faucet_tx")
-def test_delegator_can_associate_pc_address(api: BlockchainApi, new_wallet: Wallet, get_wallet: Wallet):
-    logger.info("Signing address association...")
-    stake_skey, stake_vkey = api.cardano_cli.generate_stake_keys()
-    skey_hex = stake_skey["cborHex"][4:]
-    vkey_hex = stake_vkey["cborHex"][4:]
-    signature = api.sign_address_association(new_wallet.public_key, skey_hex)
-    assert signature.partner_chain_address == new_wallet.address
-    assert signature.signature, "Signature is empty"
-    assert signature.stake_public_key == f"0x{vkey_hex}"
-
-    logger.info("Submitting address association...")
-    tx = api.submit_address_association(signature, wallet=get_wallet)
-    assert tx.hash, "Could not submit address association"
-
-    logger.info("Verifying address association...")
-    vkey_hash = api.cardano_cli.get_stake_key_hash(vkey_hex)
-    logger.info(f"Stake public key hash: {vkey_hash}")
-    address_association = api.get_address_association(vkey_hash)
-    assert address_association == new_wallet.address, "Address association not found"
-
-@mark.block_reward
 @mark.xdist_group("faucet_tx")
 def test_block_producer_can_update_their_metadata(api: BlockchainApi, new_wallet: Wallet, get_wallet: Wallet):
     logger.info("Signing block producer metadata...")
     skey, vkey_hex, vkey_hash = api.cardano_cli.generate_cross_chain_keys()
 
     logger.info("Starting first upsert")
-    metadata = { "url": "http://test.example", "hash": "0x0000000000000000000000000000000000000000000000000000000000000001" }
+    metadata = {
+        "url": "http://test.example",
+        "hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
+    }
     signature = api.sign_block_producer_metadata(metadata, skey)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
@@ -54,7 +34,10 @@ def test_block_producer_can_update_their_metadata(api: BlockchainApi, new_wallet
     assert rpc_metadata == metadata, "RPC did not return block producer metadata or it is incorrect"
 
     logger.info("Starting second upsert")
-    metadata = { "url": "http://test.example", "hash": "0x0000000000000000000000000000000000000000000000000000000000000002" }
+    metadata = {
+        "url": "http://test.example",
+        "hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
+    }
     signature = api.sign_block_producer_metadata(metadata, skey)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
@@ -174,43 +157,3 @@ def test_block_headers_have_mc_hash(api: BlockchainApi, config: ApiConfig, pc_ep
 
         if latest_stable_block_diff < config.main_chain.security_param + config.main_chain.block_stability_margin:
             logger.warning(f"Unexpected (but within offset) stable block number saved in header of block {block_no}")
-
-
-@mark.block_production_log
-def test_block_production_log_pallet(api: BlockchainApi, config: ApiConfig):
-    block = api.get_block()
-    block_no = block["header"]["number"]
-    block_hash = block["header"]["hash"]
-    block_production_log = api.get_block_production_log(block_hash=block_hash)
-    assert block_production_log
-    block_range = range(block_no - len(block_production_log), block_no)
-    logger.info(
-        f"Verifying block authors for slots {block_production_log[0][0]}..{block_production_log[-1][0]} "
-        f"(blocks {block_range})"
-    )
-    block_production_log.reverse()
-    for slot, block_producer_id in block_production_log:
-        committee = api.get_validator_set(block).value
-        author_index = slot % len(committee)
-        expected_node = next(
-            x for x in config.nodes_config.nodes.values() if x.aura_public_key == committee[author_index][1]["aura"]
-        )
-        if "Incentivized" in block_producer_id:
-            cross_chain_public, stake_pool_public_key = block_producer_id["Incentivized"]
-            assert (
-                cross_chain_public == expected_node.public_key
-            ), f"Incorrect author: block {block_no} ({block_hash}) was authored by non-committee member"
-            expected_spo_key = api.read_cardano_key_file(expected_node["keys_files"]["spo_public_key"])
-            assert (
-                stake_pool_public_key[2:] == expected_spo_key
-            ), f"Incorrect SPO: block {block_no} ({block_hash}) author has incorrect SPO"
-        elif "ProBono" in block_producer_id:
-            cross_chain_public = block_producer_id["ProBono"]
-            assert (
-                cross_chain_public == expected_node.public_key
-            ), f"Incorrect author: block {block_no} ({block_hash}) was authored by non-committee member"
-        else:
-            assert False, f"Invalid block producer id: {block_producer_id}"
-        block_no = block_no - 1
-        block = api.get_block(block_no)
-        block_hash = block["header"]["hash"]

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -177,14 +177,17 @@ def test_block_headers_have_mc_hash(api: BlockchainApi, config: ApiConfig, pc_ep
 
 
 @mark.block_production_log
-def test_block_production_log_pallet(
-    api: BlockchainApi,
-    config: ApiConfig,
-):
+def test_block_production_log_pallet(api: BlockchainApi, config: ApiConfig):
     block = api.get_block()
     block_no = block["header"]["number"]
     block_hash = block["header"]["hash"]
     block_production_log = api.get_block_production_log(block_hash=block_hash)
+    assert block_production_log
+    block_range = range(block_no - len(block_production_log), block_no)
+    logger.info(
+        f"Verifying block authors for slots {block_production_log[0][0]}..{block_production_log[-1][0]} "
+        f"(blocks {block_range})"
+    )
     block_production_log.reverse()
     for slot, block_producer_id in block_production_log:
         committee = api.get_validator_set(block).value

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -448,6 +448,21 @@ def current_pc_epoch(api: BlockchainApi) -> int:
 
 
 @fixture(scope="session")
+def initial_pc_epoch(api: BlockchainApi, config: ApiConfig) -> int:
+    initial_pc_epoch = api.get_initial_pc_epoch()
+    if not config.initial_pc_epoch:
+        logging.info(f"Setting initial SC epoch {initial_pc_epoch}.")
+        config.initial_pc_epoch = initial_pc_epoch
+    elif config.initial_pc_epoch != initial_pc_epoch:
+        logging.error(
+            f"Initial epoch in config {config.initial_pc_epoch} doesn't match the actual one {initial_pc_epoch}. "
+            "Overriding."
+        )
+        config.initial_pc_epoch = initial_pc_epoch
+    return initial_pc_epoch
+
+
+@fixture(scope="session")
 def pc_epoch_calculator(config: ApiConfig) -> PartnerChainEpochCalculator:
     return PartnerChainEpochCalculator(config)
 

--- a/e2e-tests/tests/delegator_rewards/conftest.py
+++ b/e2e-tests/tests/delegator_rewards/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+
+def pytest_collection_modifyitems(items):
+    for item in items:
+        # mark all tests in `tests/delegator_rewards` directory with `delegator_rewards` marker
+        if "tests/delegator_rewards" in item.nodeid:
+            item.add_marker(pytest.mark.delegator_rewards)

--- a/e2e-tests/tests/delegator_rewards/test_block_production_log.py
+++ b/e2e-tests/tests/delegator_rewards/test_block_production_log.py
@@ -1,0 +1,44 @@
+from pytest import mark
+from src.blockchain_api import BlockchainApi
+from config.api_config import ApiConfig
+import logging
+
+
+@mark.block_production_log
+def test_block_production_log_pallet(api: BlockchainApi, config: ApiConfig):
+    block = api.get_block()
+    block_no = block["header"]["number"]
+    block_hash = block["header"]["hash"]
+    block_production_log = api.get_block_production_log(block_hash=block_hash)
+    assert block_production_log
+    block_range = range(block_no - len(block_production_log), block_no)
+    logging.info(
+        f"Verifying block authors for slots {block_production_log[0][0]}..{block_production_log[-1][0]} "
+        f"(blocks {block_range})"
+    )
+    block_production_log.reverse()
+    for slot, block_producer_id in block_production_log:
+        committee = api.get_validator_set(block).value
+        author_index = slot % len(committee)
+        expected_node = next(
+            x for x in config.nodes_config.nodes.values() if x.aura_public_key == committee[author_index][1]["aura"]
+        )
+        if "Incentivized" in block_producer_id:
+            cross_chain_public, stake_pool_public_key = block_producer_id["Incentivized"]
+            assert (
+                cross_chain_public == expected_node.public_key
+            ), f"Incorrect author: block {block_no} ({block_hash}) was authored by non-committee member"
+            expected_spo_key = api.read_cardano_key_file(expected_node["keys_files"]["spo_public_key"])
+            assert (
+                stake_pool_public_key[2:] == expected_spo_key
+            ), f"Incorrect SPO: block {block_no} ({block_hash}) author has incorrect SPO"
+        elif "ProBono" in block_producer_id:
+            cross_chain_public = block_producer_id["ProBono"]
+            assert (
+                cross_chain_public == expected_node.public_key
+            ), f"Incorrect author: block {block_no} ({block_hash}) was authored by non-committee member"
+        else:
+            assert False, f"Invalid block producer id: {block_producer_id}"
+        block_no = block_no - 1
+        block = api.get_block(block_no)
+        block_hash = block["header"]["hash"]

--- a/e2e-tests/tests/delegator_rewards/test_delegator_journey.py
+++ b/e2e-tests/tests/delegator_rewards/test_delegator_journey.py
@@ -1,0 +1,25 @@
+from src.blockchain_api import BlockchainApi, Wallet
+import logging
+from pytest import mark
+
+
+@mark.xdist_group("faucet_tx")
+def test_delegator_can_associate_pc_address(api: BlockchainApi, new_wallet: Wallet, get_wallet: Wallet):
+    logging.info("Signing address association...")
+    stake_skey, stake_vkey = api.cardano_cli.generate_stake_keys()
+    skey_hex = stake_skey["cborHex"][4:]
+    vkey_hex = stake_vkey["cborHex"][4:]
+    signature = api.sign_address_association(new_wallet.public_key, skey_hex)
+    assert signature.partner_chain_address == new_wallet.address
+    assert signature.signature, "Signature is empty"
+    assert signature.stake_public_key == f"0x{vkey_hex}"
+
+    logging.info("Submitting address association...")
+    tx = api.submit_address_association(signature, wallet=get_wallet)
+    assert tx.hash, "Could not submit address association"
+
+    logging.info("Verifying address association...")
+    vkey_hash = api.cardano_cli.get_stake_key_hash(vkey_hex)
+    logging.info(f"Stake public key hash: {vkey_hash}")
+    address_association = api.get_address_association(vkey_hash)
+    assert address_association == new_wallet.address, "Address association not found"

--- a/e2e-tests/tests/test_delegator_rewards.py
+++ b/e2e-tests/tests/test_delegator_rewards.py
@@ -1,0 +1,196 @@
+import logging
+from config.api_config import ApiConfig
+from src.blockchain_api import BlockchainApi
+from src.pc_epoch_calculator import PartnerChainEpochCalculator
+from sqlalchemy.orm import Session
+from sqlalchemy.sql import text
+from pytest import fixture, mark, skip
+
+PARTICIPATION_DATA_SLOT_RANGE = 30
+
+
+@fixture(scope="module")
+def block_to_query_storage(api: BlockchainApi):
+    block = api.get_block()
+    block_no = block["header"]["number"]
+    if block_no <= PARTICIPATION_DATA_SLOT_RANGE:
+        skip(f"Participation data is released after {PARTICIPATION_DATA_SLOT_RANGE} slots, current block {block_no}.")
+    logging.info(f"Block to query storage: {block['header']['number']}")
+    return block
+
+
+@fixture(scope="module")
+def block_participation(block_to_query_storage, api: BlockchainApi):
+    block_participation = api.get_block_participation_data(block_hash=block_to_query_storage["header"]["hash"])
+    return block_participation
+
+
+@fixture(scope="module")
+def block_production_log(block_to_query_storage, api: BlockchainApi):
+    block_no = block_to_query_storage["header"]["number"]
+    block_no_matching_participation_data = block_no - len(
+        api.get_block_production_log(block_hash=block_to_query_storage["header"]["hash"])
+    )
+    logging.info(f"Block number matching participation data slots range: {block_no_matching_participation_data}")
+    block_matching_participation_data = api.get_block(block_no_matching_participation_data)
+    block_production_log = api.get_block_production_log(block_hash=block_matching_participation_data["header"]["hash"])
+    return block_production_log
+
+
+@fixture(scope="module")
+def pc_epochs(block_participation, config: ApiConfig, initial_pc_epoch):
+    up_to_slot = block_participation["up_to_slot"]
+    logging.info(f"Participation data up to slot: {up_to_slot}")
+    start_pc_epoch = (up_to_slot - PARTICIPATION_DATA_SLOT_RANGE) // config.nodes_config.slots_in_epoch
+    stop_pc_epoch = up_to_slot // config.nodes_config.slots_in_epoch
+    epochs = range(start_pc_epoch, stop_pc_epoch + 1)
+    logging.info(f"Participation data spans PC epochs: {epochs}")
+    if initial_pc_epoch in epochs:
+        epochs = range(initial_pc_epoch, stop_pc_epoch + 1)
+        logging.info(f"Initial PC epoch is greater than the first PC epoch. Adjusting... New range is: {epochs}")
+    return epochs
+
+
+@fixture(scope="module")
+def mc_epochs(pc_epochs: range, pc_epoch_calculator: PartnerChainEpochCalculator, current_mc_epoch: int):
+    start_mc_epoch = pc_epoch_calculator.find_mc_epoch(pc_epochs.start, current_mc_epoch)
+    stop_mc_epoch = pc_epoch_calculator.find_mc_epoch(pc_epochs.stop - 1, current_mc_epoch)
+    logging.info(f"Participation data spans MC epochs: {start_mc_epoch} to {stop_mc_epoch}")
+    return range(start_mc_epoch, stop_mc_epoch + 1)
+
+
+@fixture(scope="module")
+def initial_pc_epoch_included(initial_pc_epoch: int, pc_epoch_calculator: PartnerChainEpochCalculator):
+    def _inner(mc_epoch):
+        pc_epochs = pc_epoch_calculator.find_pc_epochs(mc_epoch, start_from_initial_pc_epoch=True)
+        if initial_pc_epoch in pc_epochs:
+            logging.info("Initial PC epoch is in the range of participation data slots.")
+            return initial_pc_epoch
+        return False
+
+    return _inner
+
+
+@fixture(scope="module")
+def count_blocks(pc_epoch_calculator: PartnerChainEpochCalculator, config: ApiConfig, block_production_log):
+    slots_in_epoch = config.nodes_config.slots_in_epoch
+    mc_epoch_to_pc_slots = {}
+
+    def _mc_epoch_to_pc_slots(mc_epoch):
+        if mc_epoch_to_pc_slots.get(mc_epoch):
+            return mc_epoch_to_pc_slots[mc_epoch]
+
+        pc_epochs = pc_epoch_calculator.find_pc_epochs(mc_epoch, start_from_initial_pc_epoch=False)
+        first_slot = pc_epochs.start * slots_in_epoch
+        last_slot = pc_epochs.stop * slots_in_epoch
+        slots = range(first_slot, last_slot)
+        logging.info(f"MC epoch {mc_epoch} PC slots: {slots}")
+        mc_epoch_to_pc_slots[mc_epoch] = slots
+        return slots
+
+    def _count_blocks(mc_epoch, producer):
+        slots = _mc_epoch_to_pc_slots(mc_epoch)
+        block_count = 0
+        for slot, producer_info in block_production_log:
+            if slots.start <= slot < slots.stop:
+                if producer == producer_info:
+                    block_count += 1
+        return block_count
+
+    return _count_blocks
+
+
+@mark.dependency(name="participation_data")
+@mark.xdist_group("block_participation")
+def test_block_participation_data_is_not_empty(block_participation):
+    assert block_participation
+    assert block_participation["up_to_slot"]
+    assert block_participation["producer_participation"]
+
+
+@mark.dependency(name="pro_bono_participation")
+@mark.xdist_group("block_participation")
+def test_pro_bono_participation(
+    mc_epochs: range, api: BlockchainApi, initial_pc_epoch_included, count_blocks: int, block_participation
+):
+    for mc_epoch in mc_epochs:
+        logging.info(f"Verifying ProBono participation in MC epoch {mc_epoch}")
+        permissioned_candidates = api.get_permissioned_candidates(mc_epoch, valid_only=True)
+
+        initial_pc_epoch = initial_pc_epoch_included(mc_epoch)
+        if initial_pc_epoch:
+            logging.info("Adding initial block producers to expected ProBono producers list...")
+            initial_block_producers = api.get_epoch_committee(initial_pc_epoch).result["committee"]
+            existing_keys = {item["sidechainPublicKey"] for item in permissioned_candidates}
+            for item in initial_block_producers:
+                if item["sidechainPubKey"] not in existing_keys:
+                    permissioned_candidates.append({"sidechainPublicKey": item["sidechainPubKey"]})
+
+        for permissioned_candidate in permissioned_candidates:
+            expected_producer = {}
+            expected_producer["block_producer"] = {"ProBono": permissioned_candidate["sidechainPublicKey"]}
+            expected_producer["block_count"] = count_blocks(mc_epoch, expected_producer["block_producer"])
+            if expected_producer["block_count"] == 0:
+                logging.info(f"No blocks produced by ProBono producer {permissioned_candidate['sidechainPublicKey']}")
+                continue
+            # expected_producer["mc_epoch"] = mc_epoch - 2
+            expected_producer["delegator_total_shares"] = 0
+            expected_producer["delegators"] = []
+            logging.info(f"Expected ProBono Producer: {expected_producer}")
+
+            assert expected_producer in block_participation["producer_participation"]
+            block_participation["producer_participation"].remove(expected_producer)
+
+
+@mark.dependency(name="spo_participation")
+@mark.xdist_group("block_participation")
+def test_spo_participation(
+    mc_epochs: range, api: BlockchainApi, count_blocks: int, block_participation, db_sync: Session
+):
+    for mc_epoch in mc_epochs:
+        registered_candidates = api.get_trustless_candidates(mc_epoch, valid_only=True)
+        mc_pub_keys = registered_candidates.keys()
+        logging.info(f"Verifying SPO participation in MC epoch {mc_epoch}")
+        for mc_pub_key in mc_pub_keys:
+            expected_spo = {}
+            assert len(registered_candidates[mc_pub_key]) == 1, "Multiple registrations with the same MC public key"
+
+            pc_pub_key = registered_candidates[mc_pub_key][0]["sidechainPubKey"]
+            expected_spo["block_producer"] = {"Incentivized": (pc_pub_key, mc_pub_key)}
+            expected_spo["block_count"] = count_blocks(mc_epoch, expected_spo["block_producer"])
+            if expected_spo["block_count"] == 0:
+                logging.info(f"No blocks produced by SPO producer {mc_pub_key}")
+                continue
+
+            mc_epoch_for_stake = mc_epoch - 2
+            # expected_spo["mc_epoch"] = mc_epoch_for_stake
+            stake_pool_id = api.cardano_cli.get_stake_pool_id(cold_vkey=mc_pub_key[2:], output_format="bech32")
+            query = text(
+                "SELECT sa.view AS stake_address, encode(sa.hash_raw, 'hex') AS stake_hash, es.amount AS stake_amount "
+                "FROM epoch_stake es "
+                "JOIN stake_address sa ON es.addr_id = sa.id "
+                f"WHERE es.pool_id = (SELECT id FROM pool_hash WHERE view = '{stake_pool_id}') "
+                f"AND es.epoch_no = {mc_epoch_for_stake};"
+            )
+            spdd = db_sync.execute(query)
+            expected_spo["delegators"] = []
+            expected_spo["delegator_total_shares"] = 0
+            for delegator in spdd:
+                logging.info(f"SPO: {mc_pub_key}, Delegator: {delegator}")
+                expected_delegator = {}
+                stake_key_hash = delegator._mapping["stake_hash"][2:]
+                expected_delegator["id"] = {"StakeKeyHash": f"0x{stake_key_hash}"}
+                expected_delegator["share"] = int(delegator._mapping["stake_amount"])
+                expected_spo["delegators"].append(expected_delegator)
+                expected_spo["delegator_total_shares"] += int(delegator._mapping["stake_amount"])
+
+            logging.info(f"Expected SPO: {expected_spo}")
+
+            assert expected_spo in block_participation["producer_participation"]
+            block_participation["producer_participation"].remove(expected_spo)
+
+
+@mark.dependency(depends=["pro_bono_participation", "spo_participation"])
+@mark.xdist_group("block_participation")
+def test_no_unexpected_producers(block_participation):
+    assert not block_participation["producer_participation"], "Unexpected producer participation data"

--- a/e2e-tests/utils/pc_epoch_calc.py
+++ b/e2e-tests/utils/pc_epoch_calc.py
@@ -6,7 +6,7 @@ from src.pc_epoch_calculator import PartnerChainEpochCalculator
 with open('config/config.json', 'r') as f:
     config_json = json.load(f)
 
-with open('config/substrate/devnet_nodes.json', 'r') as f:
+with open('config/substrate/local_nodes.json', 'r') as f:
     nodes_config_json = json.load(f)
 
 with open('config/substrate/local_stack.json', 'r') as f:


### PR DESCRIPTION
added:
- new test for delegator rewards in `test_delegator_rewards.py` 
to verify raw inherent data

changed:
- refactored `get_stake_pool_id` method in `cardano_cli.py` to simplify its parameters
- moved all delegator rewards tests into the same directory

removed:
- `block_rewards_id` config field has been removed