### PR TITLE
fix: use regular inputs, because key inputs lead to insufficient fee in case of scripts attached to UTXOs

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,8 @@ the feature `pallet-session-compat`.
 
 ## Fixed
 
+* `governance init` when genesis utxo had a script attached, then transaction fee was sometimes calculated incorrectly
+
 ## Added
 
 

--- a/toolkit/smart-contracts/offchain/src/csl.rs
+++ b/toolkit/smart-contracts/offchain/src/csl.rs
@@ -742,10 +742,9 @@ pub(crate) trait InputsBuilderExt: Sized {
 	) -> Result<(), JsError>;
 
 	/// Adds ogmios inputs to the tx inputs builder.
-	fn add_key_inputs(&mut self, utxos: &[OgmiosUtxo], key: &Ed25519KeyHash)
-		-> Result<(), JsError>;
+	fn add_regular_inputs(&mut self, utxos: &[OgmiosUtxo]) -> Result<(), JsError>;
 
-	fn with_key_inputs(utxos: &[OgmiosUtxo], key: &Ed25519KeyHash) -> Result<Self, JsError>;
+	fn with_regular_inputs(utxos: &[OgmiosUtxo]) -> Result<Self, JsError>;
 }
 
 impl InputsBuilderExt for TxInputsBuilder {
@@ -772,20 +771,16 @@ impl InputsBuilderExt for TxInputsBuilder {
 		Ok(())
 	}
 
-	fn add_key_inputs(
-		&mut self,
-		utxos: &[OgmiosUtxo],
-		key: &Ed25519KeyHash,
-	) -> Result<(), JsError> {
+	fn add_regular_inputs(&mut self, utxos: &[OgmiosUtxo]) -> Result<(), JsError> {
 		for utxo in utxos.iter() {
-			self.add_key_input(key, &utxo.to_csl_tx_input(), &utxo.value.to_csl()?);
+			self.add_regular_utxo(&utxo.to_csl()?)?;
 		}
 		Ok(())
 	}
 
-	fn with_key_inputs(utxos: &[OgmiosUtxo], key: &Ed25519KeyHash) -> Result<Self, JsError> {
+	fn with_regular_inputs(utxos: &[OgmiosUtxo]) -> Result<Self, JsError> {
 		let mut tx_input_builder = Self::new();
-		tx_input_builder.add_key_inputs(utxos, key)?;
+		tx_input_builder.add_regular_inputs(utxos)?;
 		Ok(tx_input_builder)
 	}
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/tests.rs
@@ -4,7 +4,7 @@ use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::Costs;
 use crate::init_governance::run_init_governance;
 use crate::scripts_data;
-use crate::test_values::protocol_parameters;
+use crate::test_values::{ogmios_native_1_of_1_script, ogmios_plutus_script, protocol_parameters};
 use crate::{csl::TransactionContext, ogmios_mock::MockOgmiosClient};
 use cardano_serialization_lib::{Address, ExUnits, NetworkIdKind};
 use hex_literal::*;
@@ -163,6 +163,54 @@ fn transaction_creation() {
 	assert_eq!(transaction, expected_transaction())
 }
 
+#[test]
+fn plutus_script_attached_to_genesis_utxo_increases_fee() {
+	let fee_when_genesis_utxo_has_no_script = &init_governance_transaction(
+		governance_authority(),
+		genesis_utxo(),
+		test_costs(),
+		&tx_context(),
+	)
+	.unwrap()
+	.body()
+	.fee();
+
+	let fee_when_genesis_utxo_has_plutus_script = &init_governance_transaction(
+		governance_authority(),
+		genesis_utxo_with_plutus_script(),
+		test_costs(),
+		&tx_context(),
+	)
+	.unwrap()
+	.body()
+	.fee();
+	assert!(fee_when_genesis_utxo_has_no_script < fee_when_genesis_utxo_has_plutus_script);
+}
+
+#[test]
+fn native_attached_to_genesis_utxo_increases_fee() {
+	let fee_when_genesis_utxo_has_no_script = &init_governance_transaction(
+		governance_authority(),
+		genesis_utxo(),
+		test_costs(),
+		&tx_context(),
+	)
+	.unwrap()
+	.body()
+	.fee();
+
+	let fee_when_genesis_utxo_has_native_script = &init_governance_transaction(
+		governance_authority(),
+		genesis_utxo_with_native_script(),
+		test_costs(),
+		&tx_context(),
+	)
+	.unwrap()
+	.body()
+	.fee();
+	assert!(fee_when_genesis_utxo_has_no_script < fee_when_genesis_utxo_has_native_script);
+}
+
 #[tokio::test]
 async fn transaction_run() {
 	let transaction_id = [2; 32];
@@ -201,6 +249,32 @@ fn genesis_utxo() -> OgmiosUtxo {
 		value: OgmiosValue::new_lovelace(10000),
 		address: test_address_bech32(),
 
+		..Default::default()
+	}
+}
+
+fn genesis_utxo_with_plutus_script() -> OgmiosUtxo {
+	OgmiosUtxo {
+		transaction: OgmiosTx {
+			id: hex!("992a24e743a522eb3adf0bc39820a9a52093525f91ed6205b72fd4087c13b4ac"),
+		},
+		index: 1,
+		value: OgmiosValue::new_lovelace(10000),
+		address: test_address_bech32(),
+		script: Some(ogmios_plutus_script()),
+		..Default::default()
+	}
+}
+
+fn genesis_utxo_with_native_script() -> OgmiosUtxo {
+	OgmiosUtxo {
+		transaction: OgmiosTx {
+			id: hex!("992a24e743a522eb3adf0bc39820a9a52093525f91ed6205b72fd4087c13b4ac"),
+		},
+		index: 1,
+		value: OgmiosValue::new_lovelace(10000),
+		address: test_address_bech32(),
+		script: Some(ogmios_native_1_of_1_script()),
 		..Default::default()
 	}
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/transaction.rs
@@ -34,9 +34,7 @@ pub(crate) fn init_governance_transaction(
 		ctx,
 	)?)?;
 
-	tx_builder.set_inputs(&{
-		TxInputsBuilder::with_key_inputs(&[genesis_utxo], &ctx.payment_key_hash())?
-	});
+	tx_builder.set_inputs(&{ TxInputsBuilder::with_regular_inputs(&[genesis_utxo])? });
 
 	Ok(tx_builder.balance_update_and_build(ctx)?)
 }

--- a/toolkit/smart-contracts/offchain/src/register.rs
+++ b/toolkit/smart-contracts/offchain/src/register.rs
@@ -249,7 +249,7 @@ fn register_tx(
 				&costs.get_one_spend(),
 			)?;
 		}
-		inputs.add_key_inputs(&[registration_utxo.clone()], &ctx.payment_key_hash())?;
+		inputs.add_regular_inputs(&[registration_utxo.clone()])?;
 		tx_builder.set_inputs(&inputs);
 	}
 

--- a/toolkit/smart-contracts/offchain/src/test_values.rs
+++ b/toolkit/smart-contracts/offchain/src/test_values.rs
@@ -9,7 +9,7 @@ use ogmios_client::{
 	query_ledger_state::{
 		PlutusCostModels, ProtocolParametersResponse, ReferenceScriptsCosts, ScriptExecutionPrices,
 	},
-	types::{OgmiosBytesSize, OgmiosTx, OgmiosUtxo, OgmiosValue},
+	types::{NativeScript, OgmiosBytesSize, OgmiosScript, OgmiosTx, OgmiosUtxo, OgmiosValue},
 };
 use sidechain_domain::StakePoolPublicKey;
 
@@ -115,5 +115,27 @@ pub(crate) fn make_utxo(id_byte: u8, index: u16, lovelace: u64, addr: &Address) 
 		value: OgmiosValue::new_lovelace(lovelace),
 		address: addr.to_bech32(None).unwrap(),
 		..Default::default()
+	}
+}
+
+pub(crate) fn ogmios_native_1_of_1_script() -> OgmiosScript {
+	OgmiosScript {
+		language: "native".into(),
+		cbor: hex!("830301818200581ce8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b")
+			.to_vec(),
+		json: Some(NativeScript::Some {
+			from: vec![NativeScript::Signature {
+				from: hex!("e8c300330fe315531ca89d4a2e7d0c80211bc70b473b1ed4979dff2b"),
+			}],
+			at_least: 1,
+		}),
+	}
+}
+
+pub(crate) fn ogmios_plutus_script() -> OgmiosScript {
+	OgmiosScript {
+		language: "plutus:v2".into(),
+		cbor: raw_scripts::MULTI_SIG_POLICY.to_vec(),
+		json: None,
 	}
 }


### PR DESCRIPTION
# Description

Scripts present in the inputs influence transaction cost. The bug was that `genesis_utxo` was added as "key input", and CSL (as documented) doesn't look for scripts and they don't affect the fee. Therefore Ogmios/Cardano node rejected transaction with insufficient fee.

REF: ETCM-9632
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
