### PR TITLE
fix: LLVM version for MacOS CI builds + Add Linux ARM64 builds to CI

### DIFF
--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -49,21 +49,15 @@ runs:
       if: startsWith(inputs.os, 'macos')
       shell: bash
       run: |
-        # Install specific LLVM version 19 to match working environment
         brew install llvm@19
         echo "LLVM_PATH=$(brew --prefix llvm@19)" >> $GITHUB_ENV
-        # Ensure LLVM is found first in PATH to avoid Apple's default version
         echo "$(brew --prefix llvm@19)/bin" >> $GITHUB_PATH
-        # Add to bash profile for any subshells
         echo 'export PATH="$(brew --prefix llvm@19)/bin:$PATH"' >> ~/.bash_profile
         source ~/.bash_profile
-        # Configure compiler flags
         echo "CC=$(brew --prefix llvm@19)/bin/clang" >> $GITHUB_ENV
         echo "CXX=$(brew --prefix llvm@19)/bin/clang++" >> $GITHUB_ENV
         echo "LLVM_CONFIG=$(brew --prefix llvm@19)/bin/llvm-config" >> $GITHUB_ENV
-        # Verify the version matches your working environment
         $(brew --prefix llvm@19)/bin/clang --version
-        # Create a configuration file like in your working environment
         mkdir -p /opt/homebrew/etc/clang
         echo "# clang configuration for GitHub Actions" > /opt/homebrew/etc/clang/arm64-apple-darwin24.cfg
     - name: Build partner-chains-node

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -45,11 +45,12 @@ runs:
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
     - name: Install cross-compilation dependencies for Linux ARM64
-      if: ${{ inputs.os == 'linux-arm64' }}
       shell: bash
       run: |
-        sudo apt-get update
-        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        if [[ "${{ inputs.os }}" == "linux-arm64" ]]; then
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        fi
     - name: Install LLVM for macOS
       if: startsWith(inputs.os, 'macos')
       shell: bash

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -1,5 +1,5 @@
 name: "Build and Upload PC Artifacts"
-description: "Build and upload partner-chains artifacts for Linux and MacOS"
+description: "Build and upload partner-chains artifacts for Linux, macOS x86_64, and macOS arm64"
 inputs:
   tag:
     description: "partner-chains release tag to append to artifact name"
@@ -44,6 +44,12 @@ runs:
           unzip protoc-21.3-osx-aarch_64.zip -d $HOME/protoc
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
+    - name: Install cross-compilation dependencies for Linux ARM64
+      if: inputs.os == 'linux-arm64'
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
     - name: Install LLVM for macOS
       if: startsWith(inputs.os, 'macos')
       shell: bash
@@ -68,6 +74,13 @@ runs:
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "linux-arm64" ]]; then
           rustup target add aarch64-unknown-linux-gnu
+          
+          # Configure cross-compilation environment variables
+          export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc
+          export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
+          export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
+          export PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig
+          
           cargo build -p partner-chains-node --locked --release --target aarch64-unknown-linux-gnu
           cp target/aarch64-unknown-linux-gnu/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -1,5 +1,5 @@
 name: "Build and Upload PC Artifacts"
-description: "Build and upload partner-chains artifacts for Linux, macOS x86_64, and macOS arm64"
+description: "Build and upload partner-chains artifacts for Linux and MacOS"
 inputs:
   tag:
     description: "partner-chains release tag to append to artifact name"
@@ -44,22 +44,19 @@ runs:
           unzip protoc-21.3-osx-aarch_64.zip -d $HOME/protoc
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
-    # Install LLVM for macOS builds - using specific version 19.1.7
     - name: Install LLVM for macOS
       if: startsWith(inputs.os, 'macos')
       shell: bash
       run: |
-        brew install llvm@19
-        echo "LLVM_PATH=$(brew --prefix llvm@19)" >> $GITHUB_ENV
-        echo "$(brew --prefix llvm@19)/bin" >> $GITHUB_PATH
-        echo 'export PATH="$(brew --prefix llvm@19)/bin:$PATH"' >> ~/.bash_profile
+        brew install llvm
+        echo "LLVM_PATH=$(brew --prefix llvm)" >> $GITHUB_ENV
+        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+        echo 'export PATH="$(brew --prefix llvm)/bin:$PATH"' >> ~/.bash_profile
         source ~/.bash_profile
-        echo "CC=$(brew --prefix llvm@19)/bin/clang" >> $GITHUB_ENV
-        echo "CXX=$(brew --prefix llvm@19)/bin/clang++" >> $GITHUB_ENV
-        echo "LLVM_CONFIG=$(brew --prefix llvm@19)/bin/llvm-config" >> $GITHUB_ENV
-        $(brew --prefix llvm@19)/bin/clang --version
-        mkdir -p /opt/homebrew/etc/clang
-        echo "# clang configuration for GitHub Actions" > /opt/homebrew/etc/clang/arm64-apple-darwin24.cfg
+        echo "CC=$(brew --prefix llvm)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm)/bin/clang++" >> $GITHUB_ENV
+        echo "LLVM_CONFIG=$(brew --prefix llvm)/bin/llvm-config" >> $GITHUB_ENV
+        clang --version
     - name: Build partner-chains-node
       shell: bash
       run: |
@@ -76,16 +73,12 @@ runs:
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           rustup target add x86_64-apple-darwin
-          # Environment variables are already set in the LLVM installation step
-          # Use RUST_FLAGS to ensure the right toolchain is used
           RUSTFLAGS="-C linker=${LLVM_PATH}/bin/clang" \
           cargo build -p partner-chains-node --locked --release --target x86_64-apple-darwin
           cp target/x86_64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
           rustup target add aarch64-apple-darwin
-          # Environment variables are already set in the LLVM installation step
-          # Use RUST_FLAGS to ensure the right toolchain is used
           RUSTFLAGS="-C linker=${LLVM_PATH}/bin/clang" \
           cargo build -p partner-chains-node --locked --release --target aarch64-apple-darwin
           cp target/aarch64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -10,10 +10,10 @@ inputs:
   os:
     description: "Operating system for the build (linux-x86_64, linux-arm64, macos-x86_64, macos-arm64)"
     required: true
-
 runs:
   using: "composite"
   steps:
+
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -47,6 +47,19 @@ runs:
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
 
+    - name: Install LLVM for macOS
+      if: startsWith(inputs.os, 'macos')
+      shell: bash
+      run: |
+        brew install llvm
+        echo "LLVM_PATH=$(brew --prefix llvm)" >> $GITHUB_ENV
+        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+        # Ensure LLVM is found first in PATH to avoid Apple's default version
+        echo 'export PATH="$(brew --prefix llvm)/bin:$PATH"' >> ~/.bash_profile
+        source ~/.bash_profile
+        # Verify LLVM version
+        clang --version
+
     - name: Build partner-chains-node
       shell: bash
       run: |
@@ -63,11 +76,19 @@ runs:
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           rustup target add x86_64-apple-darwin
+          # Set LLVM environment variables for Rust build
+          export LLVM_CONFIG="${LLVM_PATH}/bin/llvm-config"
+          export CC="${LLVM_PATH}/bin/clang"
+          export CXX="${LLVM_PATH}/bin/clang++"
           cargo build -p partner-chains-node --locked --release --target x86_64-apple-darwin
           cp target/x86_64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
           rustup target add aarch64-apple-darwin
+          # Set LLVM environment variables for Rust build
+          export LLVM_CONFIG="${LLVM_PATH}/bin/llvm-config"
+          export CC="${LLVM_PATH}/bin/clang"
+          export CXX="${LLVM_PATH}/bin/clang++"
           cargo build -p partner-chains-node --locked --release --target aarch64-apple-darwin
           cp target/aarch64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -13,7 +13,6 @@ inputs:
 runs:
   using: "composite"
   steps:
-
     - name: Checkout
       uses: actions/checkout@v4
       with:
@@ -30,7 +29,6 @@ runs:
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-aarch64-apple-darwin" >> $GITHUB_ENV
         fi
-
     - name: Install protoc
       shell: bash
       run: |
@@ -46,20 +44,28 @@ runs:
           unzip protoc-21.3-osx-aarch_64.zip -d $HOME/protoc
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
-
+    # Install LLVM for macOS builds - using specific version 19.1.7
     - name: Install LLVM for macOS
       if: startsWith(inputs.os, 'macos')
       shell: bash
       run: |
-        brew install llvm
-        echo "LLVM_PATH=$(brew --prefix llvm)" >> $GITHUB_ENV
-        echo "$(brew --prefix llvm)/bin" >> $GITHUB_PATH
+        # Install specific LLVM version 19 to match working environment
+        brew install llvm@19
+        echo "LLVM_PATH=$(brew --prefix llvm@19)" >> $GITHUB_ENV
         # Ensure LLVM is found first in PATH to avoid Apple's default version
-        echo 'export PATH="$(brew --prefix llvm)/bin:$PATH"' >> ~/.bash_profile
+        echo "$(brew --prefix llvm@19)/bin" >> $GITHUB_PATH
+        # Add to bash profile for any subshells
+        echo 'export PATH="$(brew --prefix llvm@19)/bin:$PATH"' >> ~/.bash_profile
         source ~/.bash_profile
-        # Verify LLVM version
-        clang --version
-
+        # Configure compiler flags
+        echo "CC=$(brew --prefix llvm@19)/bin/clang" >> $GITHUB_ENV
+        echo "CXX=$(brew --prefix llvm@19)/bin/clang++" >> $GITHUB_ENV
+        echo "LLVM_CONFIG=$(brew --prefix llvm@19)/bin/llvm-config" >> $GITHUB_ENV
+        # Verify the version matches your working environment
+        $(brew --prefix llvm@19)/bin/clang --version
+        # Create a configuration file like in your working environment
+        mkdir -p /opt/homebrew/etc/clang
+        echo "# clang configuration for GitHub Actions" > /opt/homebrew/etc/clang/arm64-apple-darwin24.cfg
     - name: Build partner-chains-node
       shell: bash
       run: |
@@ -76,24 +82,21 @@ runs:
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           rustup target add x86_64-apple-darwin
-          # Set LLVM environment variables for Rust build
-          export LLVM_CONFIG="${LLVM_PATH}/bin/llvm-config"
-          export CC="${LLVM_PATH}/bin/clang"
-          export CXX="${LLVM_PATH}/bin/clang++"
+          # Environment variables are already set in the LLVM installation step
+          # Use RUST_FLAGS to ensure the right toolchain is used
+          RUSTFLAGS="-C linker=${LLVM_PATH}/bin/clang" \
           cargo build -p partner-chains-node --locked --release --target x86_64-apple-darwin
           cp target/x86_64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
           rustup target add aarch64-apple-darwin
-          # Set LLVM environment variables for Rust build
-          export LLVM_CONFIG="${LLVM_PATH}/bin/llvm-config"
-          export CC="${LLVM_PATH}/bin/clang"
-          export CXX="${LLVM_PATH}/bin/clang++"
+          # Environment variables are already set in the LLVM installation step
+          # Use RUST_FLAGS to ensure the right toolchain is used
+          RUSTFLAGS="-C linker=${LLVM_PATH}/bin/clang" \
           cargo build -p partner-chains-node --locked --release --target aarch64-apple-darwin
           cp target/aarch64-apple-darwin/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         fi
-
     - name: Upload partner-chains-node artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -8,7 +8,7 @@ inputs:
     description: "Commit SHA to checkout"
     required: true
   os:
-    description: "Operating system for the build (linux, macos-x86_64, macos-arm64)"
+    description: "Operating system for the build (linux-x86_64, linux-arm64, macos-x86_64, macos-arm64)"
     required: true
 
 runs:
@@ -21,8 +21,10 @@ runs:
     - name: Set filename variables
       shell: bash
       run: |
-        if [[ "${{ inputs.os }}" == "linux" ]]; then
+        if [[ "${{ inputs.os }}" == "linux-x86_64" ]]; then
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-x86_64-linux" >> $GITHUB_ENV
+        elif [[ "${{ inputs.os }}" == "linux-arm64" ]]; then
+          echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-aarch64-linux" >> $GITHUB_ENV
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           echo "PARTNER_CHAINS_NODE=partner-chains-node-${{ inputs.tag }}-x86_64-apple-darwin" >> $GITHUB_ENV
         elif [[ "${{ inputs.os }}" == "macos-arm64" ]]; then
@@ -33,7 +35,7 @@ runs:
       shell: bash
       run: |
         cd $GITHUB_WORKSPACE
-        if [[ "${{ inputs.os }}" == "linux" ]]; then
+        if [[ "${{ inputs.os }}" == "linux-x86_64" || "${{ inputs.os }}" == "linux-arm64" ]]; then
           sudo apt-get install -y protobuf-compiler
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v21.3/protoc-21.3-osx-x86_64.zip
@@ -49,10 +51,15 @@ runs:
       shell: bash
       run: |
         cd $GITHUB_WORKSPACE
-        if [[ "${{ inputs.os }}" == "linux" ]]; then
+        if [[ "${{ inputs.os }}" == "linux-x86_64" ]]; then
           rustup target add x86_64-unknown-linux-gnu
           cargo build -p partner-chains-node --locked --release --target x86_64-unknown-linux-gnu
           cp target/x86_64-unknown-linux-gnu/release/partner-chains-node $PARTNER_CHAINS_NODE
+          chmod +x $PARTNER_CHAINS_NODE
+        elif [[ "${{ inputs.os }}" == "linux-arm64" ]]; then
+          rustup target add aarch64-unknown-linux-gnu
+          cargo build -p partner-chains-node --locked --release --target aarch64-unknown-linux-gnu
+          cp target/aarch64-unknown-linux-gnu/release/partner-chains-node $PARTNER_CHAINS_NODE
           chmod +x $PARTNER_CHAINS_NODE
         elif [[ "${{ inputs.os }}" == "macos-x86_64" ]]; then
           rustup target add x86_64-apple-darwin

--- a/.github/actions/artifacts/build-pc-artifacts/action.yml
+++ b/.github/actions/artifacts/build-pc-artifacts/action.yml
@@ -45,7 +45,7 @@ runs:
           sudo mv $HOME/protoc/bin/protoc /usr/local/bin/protoc
         fi
     - name: Install cross-compilation dependencies for Linux ARM64
-      if: inputs.os == 'linux-arm64'
+      if: ${{ inputs.os == 'linux-arm64' }}
       shell: bash
       run: |
         sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: macos-latest
+    runs-on: ubuntu-latest-arm64
     steps:
       - name: Checkout master
         uses: actions/checkout@v4
@@ -625,7 +625,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: macos-latest
+    runs-on: ubuntu-latest-arm64
     steps:
       - name: Checkout specific SHA
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,21 +629,18 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout master
+      - name: Checkout specific SHA
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: master
-      - name: Get current commit SHA
-        id: get_sha
-        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          ref: ${{ github.sha }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Build and Upload for linux arm64
         uses: ./.github/actions/artifacts/build-pc-artifacts
         with:
-          sha: ${{ steps.get_sha.outputs.sha }}
-          tag: ${{ steps.get_sha.outputs.sha }}
+          sha: ${{ inputs.sha }}
+          tag: ${{ inputs.sha }}
           os: linux-arm64
 
   build-macos-x86_64-workflow-dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -623,7 +623,7 @@ jobs:
             ./to-build/staging_preprod_chain_spec.json
 
   build-linux-arm64-workflow-dispatch:
-    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    if: github.event_name == 'workflow_dispatch'
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
 ### Pre merge workflow ###############################################################################################################
 
-  build-linux-pre-merge:
+  build-linux-x86_64-pre-merge:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
     outputs:
@@ -87,7 +87,7 @@ jobs:
 
   local-environment-tests:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
-    needs: build-linux-pre-merge
+    needs: build-linux-x86_64-pre-merge
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -99,8 +99,8 @@ jobs:
         uses: ./.github/actions/tests/local-environment-tests
         with:
           tag: CI
-          image: ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-pre-merge.outputs.sha }}
-          sha: ${{ needs.build-linux-pre-merge.outputs.sha }}
+          image: ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-x86_64-pre-merge.outputs.sha }}
+          sha: ${{ needs.build-linux-x86_64-pre-merge.outputs.sha }}
           tests: premerge
         env:
           SUBSTRATE_REPO_SSH_KEY: ${{ secrets.SUBSTRATE_REPO_SSH_KEY }}
@@ -143,7 +143,7 @@ jobs:
         shell: bash
 
   devshell-tests:
-    needs: build-linux-pre-merge
+    needs: build-linux-x86_64-pre-merge
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
     strategy:
       matrix:
@@ -176,7 +176,7 @@ jobs:
 
   upload-chain-specs-pre-merge:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == false
-    needs: build-linux-pre-merge
+    needs: build-linux-x86_64-pre-merge
     runs-on: eks
     steps:
       - name: Checkout
@@ -187,7 +187,7 @@ jobs:
       - name: Upload chain spec artifacts to Kubernetes
         uses: ./.github/actions/deploy/upload-chain-specs
         with:
-          sha: ${{ needs.build-linux-pre-merge.outputs.sha }}
+          sha: ${{ needs.build-linux-x86_64-pre-merge.outputs.sha }}
         env:
           kubeconfig_base64: ${{ secrets.kubeconfig_base64 }}
           K8S_SERVER: ${{ secrets.K8S_SERVER }}
@@ -195,12 +195,12 @@ jobs:
 
   pre-merge-checks-complete:
     if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.merged == false }}
-    needs: [build-linux-pre-merge, local-environment-tests, devshell-tests, upload-chain-specs-pre-merge]
+    needs: [build-linux-x86_64-pre-merge, local-environment-tests, devshell-tests, upload-chain-specs-pre-merge]
     runs-on: ubuntu-latest
     steps:
       - name: Check if any needed job failed
         run: |
-          if [[ "${{ needs.build-linux-pre-merge.result }}" != "success" ||
+          if [[ "${{ needs.build-linux-x86_64-pre-merge.result }}" != "success" ||
                 "${{ needs.local-environment-tests.result }}" != "success" ||
                 "${{ needs.devshell-tests.result }}" != "success" ||
                 "${{ needs.upload-chain-specs-pre-merge.result }}" != "success" ]]; then
@@ -212,7 +212,7 @@ jobs:
 
 ### Post merge workflow ###############################################################################################################
 
-  build-linux-post-merge:
+  build-linux-x86_64-post-merge:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     outputs:
@@ -289,6 +289,28 @@ jobs:
             ./to-build/staging_preview_chain_spec.json
             ./to-build/staging_preprod_chain_spec.json
 
+  build-linux-arm64:
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: macos-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: master
+      - name: Get current commit SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Build and Upload for linux arm64
+        uses: ./.github/actions/artifacts/build-pc-artifacts
+        with:
+          sha: ${{ steps.get_sha.outputs.sha }}
+          tag: ${{ steps.get_sha.outputs.sha }}
+          os: linux-arm64
+
   build-macos-x86_64:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     permissions:
@@ -336,7 +358,8 @@ jobs:
   upload-to-s3:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     needs:
-      - build-linux-post-merge
+      - build-linux-x86_64-post-merge
+      - build-linux-arm64
       - build-macos-x86_64
       - build-macos-arm64
     runs-on: ubuntu-latest
@@ -363,7 +386,7 @@ jobs:
 
   upload-chain-specs:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    needs: build-linux-post-merge
+    needs: build-linux-x86_64-post-merge
     runs-on: eks
     steps:
       - name: Checkout
@@ -374,7 +397,7 @@ jobs:
       - name: Upload chain spec artifacts to Kubernetes
         uses: ./.github/actions/deploy/upload-chain-specs
         with:
-          sha: ${{ needs.build-linux-post-merge.outputs.sha }}
+          sha: ${{ needs.build-linux-x86_64-post-merge.outputs.sha }}
         env:
           kubeconfig_base64: ${{ secrets.kubeconfig_base64 }}
           K8S_SERVER: ${{ secrets.K8S_SERVER }}
@@ -382,7 +405,7 @@ jobs:
 
   deploy-rustdoc:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    needs: build-linux-post-merge
+    needs: build-linux-x86_64-post-merge
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -400,7 +423,7 @@ jobs:
 
   local-environment-tests-post-merge:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
-    needs: build-linux-post-merge
+    needs: build-linux-x86_64-post-merge
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -412,8 +435,8 @@ jobs:
         uses: ./.github/actions/tests/local-environment-tests
         with:
           tag: CI
-          image: ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-post-merge.outputs.sha }}
-          sha: ${{ needs.build-linux-post-merge.outputs.sha }}
+          image: ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-x86_64-post-merge.outputs.sha }}
+          sha: ${{ needs.build-linux-x86_64-post-merge.outputs.sha }}
           tests: postmerge
         env:
           SUBSTRATE_REPO_SSH_KEY: ${{ secrets.SUBSTRATE_REPO_SSH_KEY }}
@@ -457,7 +480,7 @@ jobs:
 
   deploy-ci-preview:
     needs:
-      - build-linux-post-merge
+      - build-linux-x86_64-post-merge
       - local-environment-tests-post-merge-alert
     permissions:
       id-token: write
@@ -471,8 +494,8 @@ jobs:
       - name: Deploy ci-preview
         uses: ./.github/actions/deploy/deploy-ci-preview
         with:
-          image:  ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-post-merge.outputs.sha }}
-          sha: ${{ needs.build-linux-post-merge.outputs.sha }}
+          image:  ${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node:${{ needs.build-linux-x86_64-post-merge.outputs.sha }}
+          sha: ${{ needs.build-linux-x86_64-post-merge.outputs.sha }}
           no-wipe: true
         env:
           AWS_REGION: "eu-central-1"
@@ -512,22 +535,24 @@ jobs:
     if: ${{ always() && (github.event_name == 'pull_request' && github.event.pull_request.merged == true) }}
     needs:
       [
-        build-linux-post-merge,
+        build-linux-x86_64-post-merge,
         deploy-rustdoc,
         upload-chain-specs,
         local-environment-tests-post-merge,
         ci-preview-tests-post-merge,
         deploy-ci-preview,
+        upload-to-s3,
       ]
     runs-on: ubuntu-latest
     steps:
       - name: Check if any needed job failed
         run: |
           if [[ "${{ needs.deploy-rustdoc.result }}" != "success" ||
-                "${{ needs.build-linux-post-merge.result }}" != "success" ||
+                "${{ needs.build-linux-x86_64-post-merge.result }}" != "success" ||
                 "${{ needs.upload-chain-specs.result }}" != "success" ||
                 "${{ needs.local-environment-tests-post-merge.result }}" != "success" ]]
-                "${{ needs.deploy-ci-preview.result }}" != "success" ]]; then
+                "${{ needs.deploy-ci-preview.result }}" != "success" ]]
+                "${{ needs.upload-to-s3.result }}" != "success" ]]; then
             echo "One or more needed jobs failed."
             exit 1
           else
@@ -536,7 +561,7 @@ jobs:
 
 ### Workflow dispatch flow ###############################################################################################################
 
-  build-linux-workflow-dispatch:
+  build-linux-x86_64-workflow-dispatch:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     steps:
@@ -595,6 +620,25 @@ jobs:
             ./to-build/staging_preview_chain_spec.json
             ./to-build/staging_preprod_chain_spec.json
 
+  build-linux-arm64-workflow-dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      id-token: write
+      contents: write
+    runs-on: macos-latest
+    steps:
+      - name: Checkout specific SHA
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.sha }}
+      - name: Build and Upload for linux arm64
+        uses: ./.github/actions/artifacts/build-pc-artifacts
+        with:
+          sha: ${{ inputs.sha }}
+          tag: ${{ inputs.sha }}
+          os: linux-arm64
+
   build-macos-x86_64-workflow-dispatch:
     if: github.event_name == 'workflow_dispatch'
     permissions:
@@ -636,7 +680,8 @@ jobs:
   upload-to-s3-workflow-dispatch:
     if: github.event_name == 'workflow_dispatch'
     needs:
-      - build-linux-workflow-dispatch
+      - build-linux-x86_64-workflow-dispatch
+      - build-linux-arm64-workflow-dispatch
       - build-macos-x86_64-workflow-dispatch
       - build-macos-arm64-workflow-dispatch
     runs-on: ubuntu-latest
@@ -660,7 +705,7 @@ jobs:
 
   upload-chain-specs-workflow-dispatch:
     if: github.event_name == 'workflow_dispatch'
-    needs: build-linux-workflow-dispatch
+    needs: build-linux-x86_64-workflow-dispatch
     runs-on: eks
     steps:
       - name: Checkout specific SHA
@@ -679,12 +724,13 @@ jobs:
 
   workflow-dispatch-flow-complete:
     if: ${{ always() && github.event_name == 'workflow_dispatch' }}
-    needs: [build-linux-workflow-dispatch, build-macos-x86_64-workflow-dispatch, build-macos-arm64-workflow-dispatch, upload-to-s3-workflow-dispatch, upload-chain-specs-workflow-dispatch]
+    needs: [build-linux-x86_64-workflow-dispatch, build-linux-arm64-workflow-dispatch, build-macos-x86_64-workflow-dispatch, build-macos-arm64-workflow-dispatch, upload-to-s3-workflow-dispatch, upload-chain-specs-workflow-dispatch]
     runs-on: ubuntu-latest
     steps:
       - name: Check if any needed job failed
         run: |
-          if [[ "${{ needs.build-linux-workflow-dispatch.result }}" != "success" ||
+          if [[ "${{ needs.build-linux-x86_64-workflow-dispatch.result }}" != "success" ||
+                "${{ needs.build-linux-arm64-workflow-dispatch.result }}" != "success" ||
                 "${{ needs.build-macos-x86_64-workflow-dispatch.result }}" != "success" ||
                 "${{ needs.build-macos-arm64-workflow-dispatch.result }}" != "success" ||
                 "${{ needs.upload-to-s3-workflow-dispatch.result }}" != "success" ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,7 +294,7 @@ jobs:
     permissions:
       id-token: write
       contents: write
-    runs-on: ubuntu-latest-arm64
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout master
         uses: actions/checkout@v4
@@ -304,6 +304,8 @@ jobs:
       - name: Get current commit SHA
         id: get_sha
         run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build and Upload for linux arm64
         uses: ./.github/actions/artifacts/build-pc-artifacts
         with:
@@ -621,22 +623,27 @@ jobs:
             ./to-build/staging_preprod_chain_spec.json
 
   build-linux-arm64-workflow-dispatch:
-    if: github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     permissions:
       id-token: write
       contents: write
-    runs-on: ubuntu-latest-arm64
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout specific SHA
+      - name: Checkout master
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.sha }}
+          ref: master
+      - name: Get current commit SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
       - name: Build and Upload for linux arm64
         uses: ./.github/actions/artifacts/build-pc-artifacts
         with:
-          sha: ${{ inputs.sha }}
-          tag: ${{ inputs.sha }}
+          sha: ${{ steps.get_sha.outputs.sha }}
+          tag: ${{ steps.get_sha.outputs.sha }}
           os: linux-arm64
 
   build-macos-x86_64-workflow-dispatch:


### PR DESCRIPTION
Successful run with LLVM fixed to v19:
https://github.com/input-output-hk/partner-chains/actions/runs/14168655598

Successful run defaulting to latest LLVM:
https://github.com/input-output-hk/partner-chains/actions/runs/14168613179

