### PR TITLE
add bashInteractive to dev shell

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -32,6 +32,8 @@
           OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
           packages = with pkgs;
             [
+              bashInteractive
+
               # core tooling to share across linux/macos
               coreutils
               pkg-config


### PR DESCRIPTION
# Description

Adds bashInteractive to nix shell. This fixes an issue with the embedded terminal of vscode.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
