### PR TITLE
fix: Release block participation based on block not slot number

### DIFF
--- a/node/runtime/src/test_helper_pallet.rs
+++ b/node/runtime/src/test_helper_pallet.rs
@@ -6,6 +6,7 @@ pub use pallet::*;
 pub mod pallet {
 	use crate::AccountId;
 	use crate::BlockAuthor;
+	use crate::System;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::OriginFor;
 	use frame_system::{ensure_none, ensure_root};
@@ -53,7 +54,7 @@ pub mod pallet {
 		pub fn should_release_participation_data(
 			slot: sidechain_slots::Slot,
 		) -> Option<sidechain_slots::Slot> {
-			if *slot % ParticipationDataReleasePeriod::<T>::get() == 0 {
+			if u64::from(System::block_number()) % ParticipationDataReleasePeriod::<T>::get() == 0 {
 				Some(slot)
 			} else {
 				None


### PR DESCRIPTION
# Description

This should make it much easier to test the feature. Now the block participation inherent should always release data for 30 (defaul) blocks at a time.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
