### PR TITLE
ETCM-6659 allow unset permissioned candidates if P=0

### DIFF
--- a/toolkit/data-sources/db-sync/src/candidates/mod.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/mod.rs
@@ -74,19 +74,28 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 			.map(|d| d.0)
 			.ok_or(ExpectedDataNotFound("DParameter Datum".to_string()))?;
 
-		let d_parameter = DParamDatum::try_from(d_datum)?.into();
+		let d_parameter: DParameter = DParamDatum::try_from(d_datum)?.into();
 
-		let candidates_output = candidates_output_opt
-			.ok_or(ExpectedDataNotFound("Permissioned Candidates List".to_string()))?;
+		let no_permissioned_candidates_expected =
+			d_parameter.num_permissioned_candidates == 0;
 
-		let candidates_datum = candidates_output
-			.datum
-			.map(|d| d.0)
-			.ok_or(ExpectedDataNotFound("Permissioned Candidates List Datum".to_string()))?;
+		let permissioned_candidates = if no_permissioned_candidates_expected
+			&& candidates_output_opt.is_none()
+		{
+			Vec::new()
+		} else {
+			let candidates_output = candidates_output_opt
+				.ok_or(ExpectedDataNotFound("Permissioned Candidates List".to_string()))?;
 
-		let permissioned_candidates = raw_permissioned_candidate_data_vec_from(
-			PermissionedCandidateDatums::try_from(candidates_datum)?
-		);
+			let candidates_datum = candidates_output
+				.datum
+				.map(|d| d.0)
+				.ok_or(ExpectedDataNotFound("Permissioned Candidates List Datum".to_string()))?;
+
+			raw_permissioned_candidate_data_vec_from(PermissionedCandidateDatums::try_from(
+				candidates_datum,
+			)?)
+		};
 
 		Ok(AriadneParameters { d_parameter, permissioned_candidates })
 	}


### PR DESCRIPTION
# Description

When getting Ariadne parameters, if `num_permissioned_candidates` in d_params is 0, having not inserted a permissioned candidates list is not an error. If a chain does not wish to have any permissioned candidates, this way they won't need to spend ADA submitting an empty list of them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
