### PR TITLE
change: make Partner Chain address used by node-commands generic

### DIFF
--- a/demo/node/src/cli.rs
+++ b/demo/node/src/cli.rs
@@ -4,6 +4,7 @@ use partner_chains_node_commands::{
 	PartnerChainRuntimeBindings, PartnerChainsSubcommand, RuntimeTypeWrapper,
 };
 use sc_cli::RunCmd;
+use sp_runtime::AccountId32;
 
 #[derive(Debug, clap::Parser)]
 pub struct Cli {
@@ -32,7 +33,7 @@ pub enum Subcommand {
 	Key(sc_cli::KeySubcommand),
 
 	#[clap(flatten)]
-	PartnerChains(PartnerChainsSubcommand<WizardBindings>),
+	PartnerChains(PartnerChainsSubcommand<WizardBindings, AccountId32>),
 
 	/// Build a chain specification.
 	BuildSpec(sc_cli::BuildSpecCmd),

--- a/demo/node/src/command/mod.rs
+++ b/demo/node/src/command/mod.rs
@@ -7,6 +7,7 @@ use crate::{
 use partner_chains_demo_runtime::{Block, BlockProducerMetadataType};
 use sc_cli::SubstrateCli;
 use sc_service::PartialComponents;
+use sp_runtime::AccountId32;
 
 impl SubstrateCli for Cli {
 	fn impl_name() -> String {
@@ -72,11 +73,15 @@ pub fn run() -> sc_cli::Result<()> {
 					components.other.3.authority_selection,
 				))
 			};
-			partner_chains_node_commands::run::<_, _, _, _, BlockProducerMetadataType, WizardBindings>(
-				&cli,
-				make_dependencies,
-				cmd.clone(),
-			)
+			partner_chains_node_commands::run::<
+				_,
+				_,
+				_,
+				_,
+				BlockProducerMetadataType,
+				WizardBindings,
+				AccountId32,
+			>(&cli, make_dependencies, cmd.clone())
 		},
 		Some(Subcommand::BuildSpec(cmd)) => {
 			let runner = cli.create_runner(cmd)?;


### PR DESCRIPTION
# Description

We unnecessarily hard-coded `AccountId32` for Address Associations in `partner-chains-node-commands`.
This PR replaces it with a generic type.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
