### PR TITLE
test(fix): query delegators with non-zero stake

### DIFF
--- a/e2e-tests/src/partner_chains_node/node.py
+++ b/e2e-tests/src/partner_chains_node/node.py
@@ -36,7 +36,7 @@ class PartnerChainsNode:
             return AddressAssociationSignature(
                 partner_chain_address=response["partnerchain_address"],
                 signature=response["signature"],
-                stake_public_key=response["stake_public_key"]
+                stake_public_key=response["stake_public_key"],
             )
         except Exception as e:
             logging.error(f"Could not parse response of sign-address-association cmd: {result}")
@@ -44,7 +44,7 @@ class PartnerChainsNode:
 
     def sign_block_producer_metadata(self, metadata, cross_chain_signing_key):
         cross_chain_signing_key = cross_chain_signing_key.to_string().hex()
-        metadata_str = str(metadata).replace("'",'\\"')
+        metadata_str = json.dumps(metadata)
         metadata_file_name = f"/tmp/metadata_{uuid.uuid4().hex}.json"
         save_file_cmd = f"echo '{metadata_str}' > {metadata_file_name}"
         self.run_command.run(save_file_cmd)
@@ -65,7 +65,7 @@ class PartnerChainsNode:
                 cross_chain_pub_key_hash=response["cross_chain_pub_key_hash"],
                 encoded_message=response["encoded_message"],
                 encoded_metadata=response["encoded_metadata"],
-                signature=response["signature"]
+                signature=response["signature"],
             )
         except Exception as e:
             logging.error(f"Could not parse response of sign-block-producer-metadata cmd: {result}")

--- a/e2e-tests/src/run_command.py
+++ b/e2e-tests/src/run_command.py
@@ -74,7 +74,8 @@ class LocalRunner(Runner):
         executable = self.shell
         if self.shell and self.shell.split(" "):
             executable = None
-            command = "{shell} \"{command}\"".format(shell=self.shell, command=command)
+            escaped_command = command.replace('"', '\\"')
+            command = "{shell} \"{command}\"".format(shell=self.shell, command=escaped_command)
 
         try:
             completed_process = subprocess.run(

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -7,7 +7,7 @@ COMMITTEE_REPETITIONS_IN_PC_EPOCH = 2
 
 
 @mark.xdist_group("faucet_tx")
-def test_block_producer_can_update_their_metadata(api: BlockchainApi, new_wallet: Wallet, get_wallet: Wallet):
+def test_block_producer_can_update_their_metadata(api: BlockchainApi, get_wallet: Wallet):
     logger.info("Signing block producer metadata...")
     skey, vkey_hex, vkey_hash = api.cardano_cli.generate_cross_chain_keys()
 

--- a/e2e-tests/tests/delegator_rewards/test_spo_journey.py
+++ b/e2e-tests/tests/delegator_rewards/test_spo_journey.py
@@ -177,7 +177,8 @@ def test_spo_participation(
                 "FROM epoch_stake es "
                 "JOIN stake_address sa ON es.addr_id = sa.id "
                 f"WHERE es.pool_id = (SELECT id FROM pool_hash WHERE view = '{stake_pool_id}') "
-                f"AND es.epoch_no = {mc_epoch_for_stake};"
+                f"AND es.epoch_no = {mc_epoch_for_stake} "
+                "AND es.amount > 0;"
             )
             spdd = db_sync.execute(query)
             expected_spo["delegators"] = []


### PR DESCRIPTION
fixes:
- delegator rewards tests may fail if delegators had 0 stake
- `test_block_producer_can_update_their_metadata` was failing on non local-env due to incorrect escaping