### PR TITLE
feat: CI post-merge pushes to new partner-chains-node-unstable GHCR repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,7 @@ jobs:
         run: |
           # earthly -P +ci-pre-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }}"
           earthly -P +ci-pre-merge \
-          --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" \
-          --image="ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
+          --images="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
           --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Upload partner-chains-node artifact
         uses: actions/upload-artifact@v4
@@ -348,8 +347,7 @@ jobs:
           EARTHLY_PUSH: true
         run: |
           earthly -P +ci-post-merge \
-          --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" \
-          --image="ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
+          --images="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
           --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Rename artifact
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,12 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ECR_REGISTRY_SECRET }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - name: Copy Earthfile to build directory
         run: |
           cp Earthfile ./to-build/
@@ -129,7 +135,11 @@ jobs:
           EARTHLY_OUTPUT: true
           EARTHLY_PUSH: true
         run: |
-          earthly -P +ci-pre-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }}"
+          # earthly -P +ci-pre-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }}"
+          earthly -P +ci-pre-merge \
+          --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node \
+          --image=ghcr.io/${{ github.repository }}/partner-chains-node-unstable \
+          --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Upload partner-chains-node artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
 permissions:
   id-token: write
   contents: write
+  packages: write
 
 jobs:
 
@@ -320,6 +321,12 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ECR_REGISTRY_SECRET }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
       - name: Copy Earthfile to build directory
         run: |
           cp Earthfile ./to-build/
@@ -330,7 +337,10 @@ jobs:
           EARTHLY_OUTPUT: true
           EARTHLY_PUSH: true
         run: |
-          earthly -P +ci-post-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }} latest"
+          earthly -P +ci-post-merge \
+          --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node \
+          --image=ghcr.io/${{ github.repository }}/partner-chains-node-unstable \
+          --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Rename artifact
         run: |
           cp ./to-build/partner-chains-node ./to-build/partner-chains-node-${{ steps.get_sha.outputs.sha }}-x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy Earthfile to build directory
         run: |
           cp Earthfile ./to-build/
@@ -336,7 +336,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
-          password: ${{ github.token }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy Earthfile to build directory
         run: |
           cp Earthfile ./to-build/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,8 @@ jobs:
         run: |
           # earthly -P +ci-pre-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }}"
           earthly -P +ci-pre-merge \
-          --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node \
-          --image=ghcr.io/${{ github.repository }}/partner-chains-node-unstable \
+          --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" \
+          --image="ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
           --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Upload partner-chains-node artifact
         uses: actions/upload-artifact@v4
@@ -348,8 +348,8 @@ jobs:
           EARTHLY_PUSH: true
         run: |
           earthly -P +ci-post-merge \
-          --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node \
-          --image=ghcr.io/${{ github.repository }}/partner-chains-node-unstable \
+          --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" \
+          --image="ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
           --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Rename artifact
         run: |
@@ -723,7 +723,7 @@ jobs:
           EARTHLY_OUTPUT: true
           EARTHLY_PUSH: true
         run: |
-          earthly -P +ci-workflow-dispatch --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ inputs.sha }}"
+          earthly -P +ci-workflow-dispatch --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" --tags="${{ inputs.sha }}"
       - name: Rename artifact
         run: |
           cp ./to-build/partner-chains-node ./to-build/partner-chains-node-${{ inputs.sha }}-x86_64-linux

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,12 +119,6 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ secrets.ECR_REGISTRY_SECRET }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Copy Earthfile to build directory
         run: |
           cp Earthfile ./to-build/
@@ -135,9 +129,8 @@ jobs:
           EARTHLY_OUTPUT: true
           EARTHLY_PUSH: true
         run: |
-          # earthly -P +ci-pre-merge --image=${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node --tags="${{ steps.get_sha.outputs.sha }}"
           earthly -P +ci-pre-merge \
-          --images="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node ghcr.io/${{ github.repository }}/partner-chains-node-unstable" \
+          --images="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" \
           --tags="${{ steps.get_sha.outputs.sha }} latest"
       - name: Upload partner-chains-node artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,7 +714,7 @@ jobs:
           EARTHLY_OUTPUT: true
           EARTHLY_PUSH: true
         run: |
-          earthly -P +ci-workflow-dispatch --image="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" --tags="${{ inputs.sha }}"
+          earthly -P +ci-workflow-dispatch --images="${{ secrets.ECR_REGISTRY_SECRET }}/partner-chains-node" --tags="${{ inputs.sha }}"
       - name: Rename artifact
         run: |
           cp ./to-build/partner-chains-node ./to-build/partner-chains-node-${{ inputs.sha }}-x86_64-linux

--- a/Earthfile
+++ b/Earthfile
@@ -10,12 +10,14 @@ ci-pre-merge:
   BUILD +clippy
   BUILD +chainspecs
   ARG tags
+  ARG --push images
   BUILD +docker --image=$images --tags=$tags
 
 ci-post-merge:
   BUILD +build
   BUILD +chainspecs
   ARG tags
+  ARG --push images
   BUILD +docker --image=$images --tags=$tags
 
 ci-workflow-dispatch:
@@ -25,6 +27,7 @@ ci-workflow-dispatch:
   BUILD +fmt
   BUILD +chainspecs
   ARG tags
+  ARG --push images
   BUILD +docker --image=$images --tags=$tags
 
 setup:
@@ -116,7 +119,7 @@ clippy:
 docker:
     FROM ubuntu:24.04
     ARG tags
-    ARG images
+    ARG --push images
 
     RUN apt-get update && apt-get install -y \
         ca-certificates \

--- a/Earthfile
+++ b/Earthfile
@@ -10,13 +10,13 @@ ci-pre-merge:
   BUILD +clippy
   BUILD +chainspecs
   ARG tags
-  BUILD +docker --image=$image --tags=$tags
+  BUILD +docker --image=$images --tags=$tags
 
 ci-post-merge:
   BUILD +build
   BUILD +chainspecs
   ARG tags
-  BUILD +docker --image=$image --tags=$tags
+  BUILD +docker --image=$images --tags=$tags
 
 ci-workflow-dispatch:
   BUILD +build
@@ -25,7 +25,7 @@ ci-workflow-dispatch:
   BUILD +fmt
   BUILD +chainspecs
   ARG tags
-  BUILD +docker --image=$image --tags=$tags
+  BUILD +docker --image=$images --tags=$tags
 
 setup:
   FROM ubuntu:24.04
@@ -116,7 +116,7 @@ clippy:
 docker:
     FROM ubuntu:24.04
     ARG tags
-    ARG image
+    ARG images
 
     RUN apt-get update && apt-get install -y \
         ca-certificates \
@@ -155,7 +155,7 @@ docker:
     ENTRYPOINT ["/usr/local/bin/partner-chains-node"]
 
     FOR tag IN $tags
-      FOR image IN $image
+      FOR image IN $images
         SAVE IMAGE --push $image:$tag
       END
     END

--- a/Earthfile
+++ b/Earthfile
@@ -9,14 +9,12 @@ ci-pre-merge:
   BUILD +fmt
   BUILD +clippy
   BUILD +chainspecs
-  ARG image=partner-chains-node
   ARG tags
   BUILD +docker --image=$image --tags=$tags
 
 ci-post-merge:
   BUILD +build
   BUILD +chainspecs
-  ARG image=partner-chains-node
   ARG tags
   BUILD +docker --image=$image --tags=$tags
 
@@ -26,7 +24,6 @@ ci-workflow-dispatch:
   BUILD +licenses
   BUILD +fmt
   BUILD +chainspecs
-  ARG image=partner-chains-node
   ARG tags
   BUILD +docker --image=$image --tags=$tags
 
@@ -118,8 +115,8 @@ clippy:
 
 docker:
     FROM ubuntu:24.04
-    ARG image=partner-chains-node
     ARG tags
+    ARG image
 
     RUN apt-get update && apt-get install -y \
         ca-certificates \
@@ -157,9 +154,11 @@ docker:
 
     ENTRYPOINT ["/usr/local/bin/partner-chains-node"]
 
-		FOR tag IN $tags
-		    SAVE IMAGE --push $image:$tag
-		END
+    FOR tag IN $tags
+      FOR image IN $image
+        SAVE IMAGE --push $image:$tag
+      END
+    END
 
 INSTALL:
   FUNCTION

--- a/Earthfile
+++ b/Earthfile
@@ -10,14 +10,14 @@ ci-pre-merge:
   BUILD +clippy
   BUILD +chainspecs
   ARG tags
-  ARG --push images
+  ARG images
   BUILD +docker --image=$images --tags=$tags
 
 ci-post-merge:
   BUILD +build
   BUILD +chainspecs
   ARG tags
-  ARG --push images
+  ARG images
   BUILD +docker --image=$images --tags=$tags
 
 ci-workflow-dispatch:
@@ -27,7 +27,7 @@ ci-workflow-dispatch:
   BUILD +fmt
   BUILD +chainspecs
   ARG tags
-  ARG --push images
+  ARG images
   BUILD +docker --image=$images --tags=$tags
 
 setup:
@@ -119,7 +119,7 @@ clippy:
 docker:
     FROM ubuntu:24.04
     ARG tags
-    ARG --push images
+    ARG images
 
     RUN apt-get update && apt-get install -y \
         ca-certificates \

--- a/dev/local-environment/setup.sh
+++ b/dev/local-environment/setup.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PARTNER_CHAINS_NODE_IMAGE="ghcr.io/input-output-hk/partner-chains/partner-chains-node:v1.5.0"
+PARTNER_CHAINS_NODE_IMAGE="ghcr.io/input-output-hk/partner-chains/partner-chains-node-unstable:latest"
 CARDANO_IMAGE="ghcr.io/intersectmbo/cardano-node:10.1.4"
 DBSYNC_IMAGE="ghcr.io/intersectmbo/cardano-db-sync:13.6.0.4"
 OGMIOS_IMAGE="cardanosolutions/ogmios:v6.11.0"


### PR DESCRIPTION
Successful pre-merge CI run test:
https://github.com/input-output-hk/partner-chains/actions/runs/14308332981

Package repository created:
https://github.com/input-output-hk/partner-chains/pkgs/container/partner-chains%2Fpartner-chains-node-unstable
