### PR TITLE
change: remove default features from workspace crates (1.5.1)

### DIFF
--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -13,11 +13,11 @@ ed25519 = { workspace = true, features = ["alloc"]}
 ed25519-zebra  = { workspace = true}
 hex = { workspace = true }
 hex-literal = { workspace = true }
-plutus = { workspace = true, default-features = true }
-plutus-datum-derive = { workspace = true, default-features = true }
+plutus = { workspace = true }
+plutus-datum-derive = { workspace = true }
 secp256k1 = { workspace = true, features = ["std", "global-context"] }
-sidechain-domain = { workspace = true, default-features = true }
-sp-io = { workspace = true, default-features = true }
+sidechain-domain = { workspace = true, features = ["std"] }
+sp-io = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/toolkit/cli/node-commands/Cargo.toml
+++ b/toolkit/cli/node-commands/Cargo.toml
@@ -16,13 +16,13 @@ parity-scale-codec = { workspace = true }
 partner-chains-cli = { workspace = true }
 partner-chains-smart-contracts-commands = { workspace = true }
 plutus = { workspace = true }
-sidechain-domain = { workspace = true, default-features = true }
-sc-cli = { workspace = true, default-features = true }
-sc-service = { workspace = true, default-features = true }
-sp-api = { workspace = true, default-features = true }
-sp-blockchain = { workspace = true, default-features = true }
-sp-runtime = { workspace = true, default-features = true }
-sp-sidechain = { workspace = true, default-features = true }
+sidechain-domain = { workspace = true, features = ["std"] }
+sc-cli = { workspace = true }
+sc-service = { workspace = true }
+sp-api = { workspace = true, features = ["std"] }
+sp-blockchain = { workspace = true }
+sp-runtime = { workspace = true, features = ["std"] }
+sp-sidechain = { workspace = true, features = ["std"] }
 sp-session-validator-management = { workspace = true }
 sp-session-validator-management-query = { workspace = true }
 

--- a/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
+++ b/toolkit/mainchain-follower/db-sync-follower/Cargo.toml
@@ -13,7 +13,7 @@ chrono = "0.4.31"
 hex = { workspace = true }
 hex-literal = { workspace = true }
 itertools = { workspace = true }
-sidechain-domain = { workspace = true, default-features = true }
+sidechain-domain = { workspace = true, features = ["std", "serde"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 bigdecimal = { workspace = true }

--- a/toolkit/pallets/session-validator-management/rpc/Cargo.toml
+++ b/toolkit/pallets/session-validator-management/rpc/Cargo.toml
@@ -7,5 +7,5 @@ license = "Apache-2.0"
 [dependencies]
 derive-new = { workspace = true }
 jsonrpsee = { workspace = true }
-sidechain-domain = { workspace = true, default-features = true }
-sp-session-validator-management-query = { workspace = true, default-features = true }
+sidechain-domain = { workspace = true, features = ["std"] }
+sp-session-validator-management-query = { workspace = true }

--- a/toolkit/pallets/sidechain/rpc/Cargo.toml
+++ b/toolkit/pallets/sidechain/rpc/Cargo.toml
@@ -10,8 +10,7 @@ license = "Apache-2.0"
 parity-scale-codec = { workspace = true, features = ['std'] }
 scale-info = { workspace = true, features = ['std'] }
 jsonrpsee = { workspace = true }
-serde = { workspace = true, default-features = true }
-
+serde = { workspace = true }
 sp-core = { workspace = true, features = ['std'] }
 sp-runtime = { workspace = true, features = ['std'] }
 sp-api = { workspace = true, features = ['std'] }

--- a/toolkit/primitives/plutus-data/Cargo.toml
+++ b/toolkit/primitives/plutus-data/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 log = { workspace = true }
-sidechain-domain = { workspace = true, default-features = true }
+sidechain-domain = { workspace = true, features = ["std"] }
 
 cardano-serialization-lib = { workspace = true }
 thiserror = { workspace = true }

--- a/toolkit/primitives/session-validator-management/query/Cargo.toml
+++ b/toolkit/primitives/session-validator-management/query/Cargo.toml
@@ -15,11 +15,11 @@ sp-core = { workspace = true }
 sp-runtime = { workspace = true }
 sp-api = { workspace = true }
 sp-blockchain = { workspace = true }
-sp-session-validator-management = { workspace = true, default-features = true }
-sp-sidechain = { workspace = true, default-features = true }
-sidechain-domain = { workspace = true, default-features = true }
+sp-session-validator-management = { workspace = true, features = ["std"] }
+sp-sidechain = { workspace = true, features = ["std"] }
+sidechain-domain = { workspace = true, features = ["std"] }
 sidechain-block-search = { workspace = true }
-authority-selection-inherents = { workspace = true, default-features = true }
+authority-selection-inherents = { workspace = true, features = ["std"] }
 thiserror = { workspace = true }
 plutus = { workspace = true }
 

--- a/toolkit/primitives/sidechain-block-search/Cargo.toml
+++ b/toolkit/primitives/sidechain-block-search/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 parity-scale-codec = { workspace = true, features = ['std'] }
 scale-info = { workspace = true, features = ['std'] }
-serde = { workspace = true, default-features = true }
+serde = { workspace = true, features = ['std'] }
 
 sp-core = { workspace = true, features = ['std'] }
 sp-runtime = { workspace = true, features = ['std'] }


### PR DESCRIPTION
# Description

This ports https://github.com/input-output-hk/partner-chains/pull/660 to 1.5.1

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
