### PR TITLE
fix: Ignore decoding errors when filtering governed map utxos

### DIFF
--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -67,7 +67,6 @@ pub async fn run_insert<
 	Ok(tx_hash_opt)
 }
 
-
 fn ogmios_utxos_to_governed_map_utxos(
 	utxos: impl Iterator<Item = OgmiosUtxo>,
 	token: PolicyId,
@@ -86,12 +85,9 @@ fn get_current_value(
 	key: String,
 	token: PolicyId,
 ) -> Option<ByteString> {
-	for datum_key in ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), token) {
-		if datum_key.key == key {
-			return Some(datum_key.value);
-		}
-	}
-	None
+	ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), token)
+		.find(|datum| datum.key == key)
+		.map(|datum| datum.value)
 }
 
 async fn insert<C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId>(

--- a/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
@@ -151,7 +151,7 @@ mod get_current_value_tests {
 	#[test]
 	fn returns_none_when_no_utxos() {
 		let utxos = vec![];
-		let result = get_current_value(utxos, test_key(), test_policy().policy_id()).unwrap();
+		let result = get_current_value(utxos, test_key(), test_policy().policy_id());
 		assert_eq!(result, None);
 	}
 
@@ -171,7 +171,7 @@ mod get_current_value_tests {
 			}),
 			..Default::default()
 		};
-		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result, None);
 	}
 
@@ -199,7 +199,7 @@ mod get_current_value_tests {
 			}),
 			..Default::default()
 		};
-		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result, None);
 	}
 
@@ -227,7 +227,7 @@ mod get_current_value_tests {
 			}),
 			..Default::default()
 		};
-		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result, Some(test_value()));
 	}
 }


### PR DESCRIPTION
# Description

This causes the offchain to not fail if some utxos contain datums that do not conform to the expected schema and instead to ignore those datums completely.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
