### PR TITLE
add: ETCM-9697 Governed Map list command

### DIFF
--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -55,14 +55,8 @@ impl InsertCmd {
 			&FixedDelayRetries::five_minutes(),
 		)
 		.await?;
-		Ok(serde_json::json!(result).into())
+		Ok(serde_json::json!(result))
 	}
-}
-
-#[derive(Clone, Debug, clap::ValueEnum)]
-pub enum OutputFormat {
-	Json,
-	Table,
 }
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -71,8 +65,6 @@ pub struct ListCmd {
 	common_arguments: crate::CommonArguments,
 	#[arg(long, short('g'))]
 	genesis_utxo: UtxoId,
-	#[arg(long, value_enum, default_value_t=OutputFormat::Json)]
-	output_format: OutputFormat,
 }
 
 impl ListCmd {

--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -1,6 +1,7 @@
 use crate::PaymentFilePath;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
-use partner_chains_cardano_offchain::governed_map::run_insert;
+use partner_chains_cardano_offchain::governed_map::{run_insert, run_list};
+use serde_json::json;
 use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::UtxoId;
 
@@ -12,12 +13,15 @@ pub enum GovernedMapCmd {
 	/// NOTE: In rare cases, race conditions may occur, and two inserts with the same key will both succeed.
 	/// In that case the second one in terms of block and transaction number is considered valid.
 	Insert(InsertCmd),
+	/// Lists all key-value pairs currently stored in the Governed Map
+	List(ListCmd),
 }
 
 impl GovernedMapCmd {
 	pub async fn execute(self) -> crate::SubCmdResult {
 		match self {
 			Self::Insert(cmd) => cmd.execute().await,
+			Self::List(cmd) => cmd.execute().await,
 		}
 	}
 }
@@ -51,6 +55,34 @@ impl InsertCmd {
 			&FixedDelayRetries::five_minutes(),
 		)
 		.await?;
-		Ok(serde_json::json!(result))
+		Ok(serde_json::json!(result).into())
+	}
+}
+
+#[derive(Clone, Debug, clap::ValueEnum)]
+pub enum OutputFormat {
+	Json,
+	Table,
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct ListCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long, short('g'))]
+	genesis_utxo: UtxoId,
+	#[arg(long, value_enum, default_value_t=OutputFormat::Json)]
+	output_format: OutputFormat,
+}
+
+impl ListCmd {
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let client = self.common_arguments.get_ogmios_client().await?;
+		let kv_pairs: Vec<_> = run_list(self.genesis_utxo, &client)
+			.await?
+			.map(|datum| json!({"key": datum.key, "value": datum.value.to_hex_string()}))
+			.collect();
+
+		Ok(json!(kv_pairs))
 	}
 }


### PR DESCRIPTION
# Description

Adds the `smart-contracts governed-map list` command and wires it into the demo node.

Output:
```json
[{"key":"key1","value":"0xaaaabbbb0000"},{"key":"key2","value":"0x01"}]
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
