### PR TITLE
fix(devshell): disable compiler check on cc-rs

### DIFF
--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -30,6 +30,10 @@
           OPENSSL_DIR = "${pkgs.openssl.dev}";
           OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
           OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+
+          # Force skip support check of c++17 in CC crate
+          CRATE_CC_NO_DEFAULTS = "1";
+
           packages = with pkgs;
             [
               bashInteractive


### PR DESCRIPTION
On macOS, the error "failed to run custom build command for `wasm-opt-sys v0.116.0`" exists because of the way cc-rs detects whether a compiler supports std=c++17, it doesn't detect it available and compilation fails. This commit disables the check.

# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
