### PR TITLE
add governed-map remove command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -33,6 +33,7 @@ the feature `pallet-session-compat`.
 * `governance init` when genesis utxo had a script attached, then transaction fee was sometimes calculated incorrectly
 
 ## Added
+* `governed-map remove` command, that removes a key-value pair from the governed map
 * `governed-map insert` command, that inserts a key-value pair into the governed map
 * `ariadne_v2` selection algorithm that selects committee respecting D-parameter and candidates
 weights, but has much less variance, thanks to assigning guaranteed seats to candidates with

--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -70,6 +70,7 @@ pub struct ListCmd {
 	genesis_utxo: UtxoId,
 }
 
+#[derive(Clone, Debug, clap::Parser)]
 pub struct RemoveCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,

--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -1,6 +1,6 @@
 use crate::PaymentFilePath;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
-use partner_chains_cardano_offchain::governed_map::{run_insert, run_list};
+use partner_chains_cardano_offchain::governed_map::{run_insert, run_list, run_remove};
 use serde_json::json;
 use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::UtxoId;
@@ -15,6 +15,8 @@ pub enum GovernedMapCmd {
 	Insert(InsertCmd),
 	/// Lists all key-value pairs currently stored in the Governed Map
 	List(ListCmd),
+	/// Removes a key-value pair from the Governed Map
+	Remove(RemoveCmd),
 }
 
 impl GovernedMapCmd {
@@ -22,6 +24,7 @@ impl GovernedMapCmd {
 		match self {
 			Self::Insert(cmd) => cmd.execute().await,
 			Self::List(cmd) => cmd.execute().await,
+			Self::Remove(cmd) => cmd.execute().await,
 		}
 	}
 }
@@ -67,6 +70,17 @@ pub struct ListCmd {
 	genesis_utxo: UtxoId,
 }
 
+pub struct RemoveCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long)]
+	key: String,
+	#[clap(flatten)]
+	payment_key_file: PaymentFilePath,
+	#[arg(long, short('g'))]
+	genesis_utxo: UtxoId,
+}
+
 impl ListCmd {
 	pub async fn execute(self) -> crate::SubCmdResult {
 		let client = self.common_arguments.get_ogmios_client().await?;
@@ -76,5 +90,22 @@ impl ListCmd {
 			.collect();
 
 		Ok(json!(kv_pairs))
+	}
+}
+impl RemoveCmd {
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let payment_key = self.payment_key_file.read_key()?;
+
+		let client = self.common_arguments.get_ogmios_client().await?;
+
+		let result = run_remove(
+			self.genesis_utxo,
+			self.key,
+			&payment_key,
+			&client,
+			&FixedDelayRetries::five_minutes(),
+		)
+		.await?;
+		Ok(serde_json::json!(result))
 	}
 }

--- a/toolkit/smart-contracts/offchain/src/csl.rs
+++ b/toolkit/smart-contracts/offchain/src/csl.rs
@@ -199,7 +199,7 @@ pub trait CostStore {
 	fn get_mint(&self, script: &PlutusScript) -> ExUnits;
 	fn get_spend(&self, spend_ix: u32) -> ExUnits;
 	fn get_one_spend(&self) -> ExUnits;
-	fn get_spend_indicies(&self) -> Vec<u32>;
+	fn get_spend_indices(&self) -> Vec<u32>;
 }
 
 impl CostStore for Costs {
@@ -236,7 +236,7 @@ impl CostStore for Costs {
 			},
 		}
 	}
-	fn get_spend_indicies(&self) -> Vec<u32> {
+	fn get_spend_indices(&self) -> Vec<u32> {
 		match self {
 			Costs::ZeroCosts => vec![],
 			Costs::Costs(cost_lookup) => cost_lookup.spends.keys().cloned().collect(),

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -109,7 +109,7 @@ fn get_utxos_for_key(
 	token: PolicyId,
 ) -> Vec<OgmiosUtxo> {
 	ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), token.clone())
-		.filter(|(utxo, datum)| datum.key == key && utxo.value.native_tokens.contains_key(&token.0))
+		.filter(|(_, datum)| datum.key == key)
 		.map(|(utxo, _)| utxo)
 		.collect()
 }

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -77,7 +77,8 @@ pub async fn run_list<C: QueryLedgerState + QueryNetwork + Transactions + QueryU
 	let (validator, policy) = crate::scripts_data::governed_map_scripts(genesis_utxo, network)?;
 	let validator_address = validator.address_bech32(network)?;
 	let validator_utxos = ogmios_client.query_utxos(&[validator_address]).await?;
-	Ok(ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), policy.policy_id()))
+	Ok(ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), policy.policy_id())
+		.map(|(_, datum)| datum))
 }
 
 fn ogmios_utxos_to_governed_map_utxos(

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -1,6 +1,6 @@
 use crate::csl::{
-	empty_asset_name, get_builder_config, unit_plutus_data, CostStore, Costs, NetworkTypeExt,
-	TransactionBuilderExt, TransactionExt,
+	empty_asset_name, get_builder_config, unit_plutus_data, CostStore, Costs, InputsBuilderExt,
+	NetworkTypeExt, TransactionBuilderExt, TransactionExt,
 };
 use crate::governance::GovernanceData;
 use crate::multisig::submit_or_create_tx_to_sign;
@@ -13,7 +13,9 @@ use crate::{
 	multisig::MultiSigSmartContractResult,
 };
 use anyhow::anyhow;
-use cardano_serialization_lib::{PlutusData, Transaction, TransactionBuilder};
+use cardano_serialization_lib::{
+	Int, PlutusData, Transaction, TransactionBuilder, TxInputsBuilder,
+};
 use ogmios_client::{
 	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
 	query_network::QueryNetwork,
@@ -166,5 +168,151 @@ fn insert_key_value_tx(
 	Ok(tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses())
 }
 
+pub async fn run_remove<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	key: String,
+	payment_signing_key: &CardanoPaymentSigningKey,
+	ogmios_client: &C,
+	await_tx: &A,
+) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
+	let ctx = TransactionContext::for_payment_key(payment_signing_key, ogmios_client).await?;
+	let (validator, policy) = crate::scripts_data::governed_map_scripts(genesis_utxo, ctx.network)?;
+	let validator_address = validator.address_bech32(ctx.network)?;
+	let validator_utxos = ogmios_client.query_utxos(&[validator_address]).await?;
+
+	let utxos_for_key = get_utxos_for_key(validator_utxos, key.clone(), policy.policy_id())?;
+	let tx_hash_opt = match utxos_for_key.len() {
+		0 => {
+			log::info!("There is no value stored for key '{}'. Skipping remove.", key);
+			None
+		},
+		_ => Some(
+			remove(&validator, &policy, &utxos_for_key, ctx, genesis_utxo, ogmios_client).await?,
+		),
+	};
+	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
+		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+	}
+	Ok(tx_hash_opt)
+}
+
+fn get_utxos_for_key(
+	utxos: Vec<OgmiosUtxo>,
+	key: String,
+	token: PolicyId,
+) -> anyhow::Result<Vec<OgmiosUtxo>> {
+	let mut utxos_for_key = Vec::new();
+	for utxo in utxos {
+		if let Some(datum) = utxo.clone().datum {
+			let datum_plutus_data =
+				PlutusData::from_bytes(datum.bytes).map_err(|e| {
+					anyhow!("Internal error: could not decode datum of Governed Map validator script: {}", e)
+				})?;
+			let governed_map_datum =
+				GovernedMapDatum::try_from(datum_plutus_data).map_err(|e| {
+					anyhow!("Internal error: could not decode datum of Governed Map validator script: {}", e)
+				})?;
+			let contains_governed_map_token = utxo.value.native_tokens.contains_key(&token.0);
+			if governed_map_datum.key == key && contains_governed_map_token {
+				utxos_for_key.push(utxo);
+			}
+		}
+	}
+	Ok(utxos_for_key)
+}
+
+async fn remove<C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId>(
+	validator: &PlutusScript,
+	policy: &PlutusScript,
+	utxos_for_key: &Vec<OgmiosUtxo>,
+	ctx: TransactionContext,
+	genesis_utxo: UtxoId,
+	client: &C,
+) -> anyhow::Result<MultiSigSmartContractResult> {
+	let governance_data = GovernanceData::get(genesis_utxo, client).await?;
+
+	submit_or_create_tx_to_sign(
+		&governance_data,
+		ctx,
+		|costs, ctx| {
+			remove_key_value_tx(validator, policy, utxos_for_key, &governance_data, costs, &ctx)
+		},
+		"Remove Key-Value pair",
+		client,
+		&FixedDelayRetries::five_minutes(),
+	)
+	.await
+}
+
+fn remove_key_value_tx(
+	validator: &PlutusScript,
+	policy: &PlutusScript,
+	utxos_for_key: &Vec<OgmiosUtxo>,
+	governance_data: &GovernanceData,
+	costs: Costs,
+	ctx: &TransactionContext,
+) -> anyhow::Result<Transaction> {
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+
+	let gov_tx_input = governance_data.utxo_id_as_tx_input();
+	tx_builder.add_mint_one_script_token_using_reference_script(
+		&governance_data.policy.script(),
+		&gov_tx_input,
+		&costs,
+	)?;
+
+	let spend_indicies = costs.get_spend_indicies();
+
+	let mut inputs = TxInputsBuilder::new();
+	for (ix, utxo) in utxos_for_key.iter().enumerate() {
+		inputs.add_script_utxo_input(
+			utxo,
+			validator,
+			&PlutusData::new_bytes(vec![]),
+			&costs.get_spend(*spend_indicies.get(ix).unwrap_or(&0)),
+		)?;
+	}
+	tx_builder.set_inputs(&inputs);
+
+	let burn_amount = (-1 as i32) * (utxos_for_key.len() as i32);
+	tx_builder.add_mint_script_tokens(
+		policy,
+		&empty_asset_name(),
+		&unit_plutus_data(),
+		&costs.get_mint(&policy.clone()),
+		&Int::new_i32(burn_amount),
+	)?;
+
+	Ok(tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses())
+}
+
 #[cfg(test)]
 mod tests;
+
+/// Neccesary to test rare case, wher two inserts for the same key are executed
+#[allow(dead_code)]
+pub async fn run_insert_with_force<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	key: String,
+	value: ByteString,
+	payment_signing_key: &CardanoPaymentSigningKey,
+	ogmios_client: &C,
+	await_tx: &A,
+) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
+	let ctx = TransactionContext::for_payment_key(payment_signing_key, ogmios_client).await?;
+	let (validator, policy) = crate::scripts_data::governed_map_scripts(genesis_utxo, ctx.network)?;
+
+	let tx_hash_opt =
+		Some(insert(&validator, &policy, key, value, ctx, genesis_utxo, ogmios_client).await?);
+
+	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
+		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+	}
+	Ok(tx_hash_opt)
+}

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -251,7 +251,7 @@ fn remove_key_value_tx(
 		&costs,
 	)?;
 
-	let spend_indicies = costs.get_spend_indicies();
+	let spend_indicies = costs.get_spend_indices();
 
 	let mut inputs = TxInputsBuilder::new();
 	for (ix, utxo) in utxos_for_key.iter().enumerate() {
@@ -279,7 +279,7 @@ fn remove_key_value_tx(
 #[cfg(test)]
 mod tests;
 
-/// Neccesary to test rare case, wher two inserts for the same key are executed
+/// Necessary to test rare case, where two inserts for the same key are executed
 #[allow(dead_code)]
 pub async fn run_insert_with_force<
 	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -108,7 +108,7 @@ fn get_utxos_for_key(
 	key: String,
 	token: PolicyId,
 ) -> Vec<OgmiosUtxo> {
-	ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), token.clone())
+	ogmios_utxos_to_governed_map_utxos(validator_utxos.into_iter(), token)
 		.filter(|(_, datum)| datum.key == key)
 		.map(|(utxo, _)| utxo)
 		.collect()

--- a/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
@@ -1,4 +1,4 @@
-use super::{get_current_value, insert_key_value_tx};
+use super::{get_current_value, get_utxos_for_key, insert_key_value_tx, remove_key_value_tx};
 use crate::csl::{empty_asset_name, TransactionContext};
 use crate::governance::GovernanceData;
 use crate::test_values::*;
@@ -229,6 +229,359 @@ mod get_current_value_tests {
 		};
 		let result = get_current_value(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result, Some(test_value()));
+	}
+}
+
+mod get_utxos_for_key_tests {
+	use super::*;
+	use pretty_assertions::assert_eq;
+
+	#[test]
+	fn returns_empty_when_no_utxos() {
+		let utxos = vec![];
+		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id()).unwrap();
+		assert_eq!(result.len(), 0);
+	}
+
+	#[test]
+	fn returns_empty_when_utxo_without_token() {
+		let utxo = OgmiosUtxo {
+			transaction: OgmiosTx { id: [1; 32] },
+			index: 1,
+			value: OgmiosValue { lovelace: 1000000, native_tokens: vec![].into_iter().collect() },
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					test_key(),
+					test_value(),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		};
+		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		assert_eq!(result.len(), 0);
+	}
+
+	#[test]
+	fn returns_empty_when_utxo_with_token_but_different_key() {
+		let utxo = OgmiosUtxo {
+			transaction: OgmiosTx { id: [1; 32] },
+			index: 1,
+			value: OgmiosValue {
+				lovelace: 1000000,
+				native_tokens: vec![(
+					test_policy().policy_id().0,
+					vec![OgmiosAsset { name: vec![], amount: 1 }],
+				)]
+				.into_iter()
+				.collect(),
+			},
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					"different_key".to_string(),
+					test_value(),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		};
+		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		assert_eq!(result.len(), 0);
+	}
+
+	#[test]
+	fn returns_utxo_when_matches_key_and_has_token() {
+		let expected_utxo = OgmiosUtxo {
+			transaction: OgmiosTx { id: [1; 32] },
+			index: 1,
+			value: OgmiosValue {
+				lovelace: 1000000,
+				native_tokens: vec![(
+					test_policy().policy_id().0,
+					vec![OgmiosAsset { name: vec![], amount: 1 }],
+				)]
+				.into_iter()
+				.collect(),
+			},
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					test_key(),
+					test_value(),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		};
+		let result =
+			get_utxos_for_key(vec![expected_utxo.clone()], test_key(), test_policy().policy_id())
+				.unwrap();
+		assert_eq!(result.len(), 1);
+		assert_eq!(result[0].transaction.id, expected_utxo.transaction.id);
+		assert_eq!(result[0].index, expected_utxo.index);
+	}
+
+	#[test]
+	fn returns_multiple_matching_utxos() {
+		let utxo1 = OgmiosUtxo {
+			transaction: OgmiosTx { id: [1; 32] },
+			index: 1,
+			value: OgmiosValue {
+				lovelace: 1000000,
+				native_tokens: vec![(
+					test_policy().policy_id().0,
+					vec![OgmiosAsset { name: vec![], amount: 1 }],
+				)]
+				.into_iter()
+				.collect(),
+			},
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					test_key(),
+					test_value(),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		};
+
+		let utxo2 = OgmiosUtxo {
+			transaction: OgmiosTx { id: [2; 32] },
+			index: 0,
+			value: OgmiosValue {
+				lovelace: 2000000,
+				native_tokens: vec![(
+					test_policy().policy_id().0,
+					vec![OgmiosAsset { name: vec![], amount: 1 }],
+				)]
+				.into_iter()
+				.collect(),
+			},
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					test_key(),
+					ByteString::from(hex::decode("9988776655").unwrap()),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		};
+
+		let utxos = vec![utxo1, utxo2];
+		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id()).unwrap();
+		assert_eq!(result.len(), 2);
+	}
+}
+
+mod governed_map_remove_tx_tests {
+	use crate::csl::Costs;
+
+	use super::*;
+	use cardano_serialization_lib::Transaction;
+
+	fn policy_ex_units() -> ExUnits {
+		ExUnits::new(&10000u32.into(), &200u32.into())
+	}
+
+	fn governance_ex_units() -> ExUnits {
+		ExUnits::new(&20000u32.into(), &400u32.into())
+	}
+
+	fn spend_ex_units() -> ExUnits {
+		ExUnits::new(&30000u32.into(), &600u32.into())
+	}
+
+	fn test_costs() -> Costs {
+		// Create a map of spend indices
+		let mut spend_indices = std::collections::HashMap::new();
+		// Add indices 0-9 to support tests with multiple UTXOs
+		for i in 0..10 {
+			spend_indices.insert(i, spend_ex_units());
+		}
+
+		Costs::new(
+			vec![
+				(ScriptHash::from_bytes(token_policy_id().to_vec()).unwrap(), policy_ex_units()),
+				(governance_script_hash(), governance_ex_units()),
+			]
+			.into_iter()
+			.collect(),
+			spend_indices,
+		)
+	}
+
+	fn create_key_utxo(tx_id: [u8; 32], index: u16) -> OgmiosUtxo {
+		OgmiosUtxo {
+			transaction: OgmiosTx { id: tx_id },
+			index,
+			value: OgmiosValue {
+				lovelace: 1000000,
+				native_tokens: vec![(
+					test_policy().policy_id().0,
+					vec![OgmiosAsset { name: vec![], amount: 1 }],
+				)]
+				.into_iter()
+				.collect(),
+			},
+			address: validator_addr().to_bech32(None).unwrap(),
+			datum: Some(Datum {
+				bytes: PlutusData::from(governed_map_datum_to_plutus_data(&GovernedMapDatum::new(
+					test_key(),
+					test_value(),
+				)))
+				.to_bytes(),
+			}),
+			..Default::default()
+		}
+	}
+
+	fn governed_map_remove_tx_test(utxos_count: usize) -> Transaction {
+		let mut utxos_for_key = Vec::new();
+		for i in 0..utxos_count {
+			let mut tx_id = [0u8; 32];
+			tx_id[0] = i as u8;
+			utxos_for_key.push(create_key_utxo(tx_id, i as u16));
+		}
+
+		remove_key_value_tx(
+			&test_validator(),
+			&test_policy(),
+			&utxos_for_key,
+			&governance_data(),
+			test_costs(),
+			&test_tx_context(),
+		)
+		.expect("Test transaction should be constructed without error")
+	}
+
+	#[test]
+	fn redeemer_is_set_correctly() {
+		let tx = governed_map_remove_tx_test(1);
+
+		let redeemers = tx.witness_set().redeemers().unwrap();
+		assert_eq!(redeemers.len(), 3); // 1 spend + 2 mint
+
+		// Check that we have the correct set of redeemer tags
+		let mut mint_count = 0;
+		let mut spend_count = 0;
+
+		for i in 0..redeemers.len() {
+			let redeemer = redeemers.get(i);
+			if redeemer.tag() == RedeemerTag::new_mint() {
+				mint_count += 1;
+				assert_eq!(redeemer.data(), PlutusData::new_empty_constr_plutus_data(&0u64.into()));
+			} else if redeemer.tag() == RedeemerTag::new_spend() {
+				spend_count += 1;
+				assert_eq!(redeemer.data(), PlutusData::new_bytes(vec![]));
+				assert_eq!(redeemer.ex_units(), spend_ex_units());
+			}
+		}
+
+		// We should have 2 mint redeemers and 1 spend redeemer
+		assert_eq!(mint_count, 2, "Expected 2 mint redeemers");
+		assert_eq!(spend_count, 1, "Expected 1 spend redeemer");
+	}
+
+	#[test]
+	fn change_is_returned_correctly() {
+		let body = governed_map_remove_tx_test(1).body();
+		let outputs = body.outputs();
+
+		let change_output = outputs.into_iter().find(|o| o.address() == payment_addr()).unwrap();
+		let coins_sum = change_output.amount().coin().checked_add(&body.fee()).unwrap();
+
+		// We're just checking that the sum is reasonable, not the exact amount
+		let total_input = (greater_payment_utxo().value.lovelace
+			+ lesser_payment_utxo().value.lovelace
+			+ 1000000)
+			.into();
+		assert!(coins_sum <= total_input, "Sum of outputs plus fee should not exceed total input");
+	}
+
+	#[test]
+	fn burns_one_key_value_token() {
+		let body = &governed_map_remove_tx_test(1).body();
+
+		let key_value_token_mint_amount = body
+			.mint()
+			.expect("Should burn a token")
+			.get(&token_policy_id().into())
+			.and_then(|policy| policy.get(0))
+			.expect("The burned token should have the key value policy")
+			.get(&empty_asset_name())
+			.expect("The burned token should have an empty asset name");
+
+		assert_eq!(key_value_token_mint_amount, Int::new_i32(-1));
+	}
+
+	#[test]
+	fn burns_multiple_key_value_tokens() {
+		let body = &governed_map_remove_tx_test(3).body();
+
+		let key_value_token_mint_amount = body
+			.mint()
+			.expect("Should burn tokens")
+			.get(&token_policy_id().into())
+			.and_then(|policy| policy.get(0))
+			.expect("The burned token should have the key value policy")
+			.get(&empty_asset_name())
+			.expect("The burned token should have an empty asset name");
+
+		assert_eq!(key_value_token_mint_amount, Int::new_i32(-3));
+	}
+
+	#[test]
+	fn input_contains_key_value_tokens() {
+		let tx = governed_map_remove_tx_test(1);
+		let inputs = tx.body().inputs();
+
+		// We should have 2 inputs: the payment UTXO and the key-value UTXO
+		assert_eq!(inputs.len(), 2);
+
+		// The first input should be the payment UTXO
+		let payment_input = inputs.get(0);
+		assert_eq!(payment_input.index(), 0);
+
+		// Check that the second input is a key-value UTXO
+		let kv_input = inputs.get(1);
+		// The index should match what we set in create_key_utxo
+		assert_eq!(kv_input.index(), 0);
+	}
+
+	#[test]
+	fn multiple_inputs_are_consumed_when_removing_multiple_utxos() {
+		let tx = governed_map_remove_tx_test(3);
+		let inputs = tx.body().inputs();
+
+		// We should have at least 2 inputs - one payment UTXO and at least one key-value UTXO
+		assert!(inputs.len() >= 2, "Expected at least 2 inputs");
+
+		// The actual implementation combines multiple UTXOs, so we just verify
+		// that we have the inputs we need without checking exact count
+
+		// Verify the index of the first input (payment UTXO)
+		let payment_input = inputs.get(0);
+		assert_eq!(payment_input.index(), 0, "First input should be payment UTXO");
+	}
+
+	#[test]
+	fn transaction_has_no_output_to_validator_address() {
+		let tx = governed_map_remove_tx_test(1);
+		let body = tx.body();
+		let outputs = body.outputs();
+
+		// None of the outputs should go to the validator address
+		let validator_outputs =
+			outputs.into_iter().filter(|o| o.address() == validator_addr()).count();
+
+		assert_eq!(
+			validator_outputs, 0,
+			"Transaction should not have outputs to validator address"
+		);
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/tests.rs
@@ -239,7 +239,7 @@ mod get_utxos_for_key_tests {
 	#[test]
 	fn returns_empty_when_no_utxos() {
 		let utxos = vec![];
-		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id()).unwrap();
+		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id());
 		assert_eq!(result.len(), 0);
 	}
 
@@ -259,7 +259,7 @@ mod get_utxos_for_key_tests {
 			}),
 			..Default::default()
 		};
-		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result.len(), 0);
 	}
 
@@ -287,7 +287,7 @@ mod get_utxos_for_key_tests {
 			}),
 			..Default::default()
 		};
-		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id()).unwrap();
+		let result = get_utxos_for_key(vec![utxo], test_key(), test_policy().policy_id());
 		assert_eq!(result.len(), 0);
 	}
 
@@ -316,8 +316,7 @@ mod get_utxos_for_key_tests {
 			..Default::default()
 		};
 		let result =
-			get_utxos_for_key(vec![expected_utxo.clone()], test_key(), test_policy().policy_id())
-				.unwrap();
+			get_utxos_for_key(vec![expected_utxo.clone()], test_key(), test_policy().policy_id());
 		assert_eq!(result.len(), 1);
 		assert_eq!(result[0].transaction.id, expected_utxo.transaction.id);
 		assert_eq!(result[0].index, expected_utxo.index);
@@ -372,7 +371,7 @@ mod get_utxos_for_key_tests {
 		};
 
 		let utxos = vec![utxo1, utxo2];
-		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id()).unwrap();
+		let result = get_utxos_for_key(utxos, test_key(), test_policy().policy_id());
 		assert_eq!(result.len(), 2);
 	}
 }

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -340,7 +340,7 @@ async fn governed_map_operations() {
 
 	assert_eq!(
 		listed_values,
-		vec![(key1, value1), (key4, value4),],
+		vec![(key1, value1), (key4.clone(), value4.clone()),],
 		"All inserted and not changed or deleted keys should be listed"
 	);
 	// Now test the remove functionality

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -20,7 +20,7 @@ use partner_chains_cardano_offchain::{
 	cardano_keys::CardanoPaymentSigningKey,
 	d_param,
 	governance::MultiSigParameters,
-	governed_map::{run_insert, run_list},
+	governed_map::{run_insert, run_insert_with_force, run_list, run_remove},
 	init_governance,
 	multisig::{MultiSigSmartContractResult, MultiSigTransactionData},
 	permissioned_candidates,
@@ -342,6 +342,39 @@ async fn governed_map_operations() {
 		listed_values,
 		vec![(key1, value1), (key4, value4),],
 		"All inserted and not changed or deleted keys should be listed"
+	);
+	// Now test the remove functionality
+
+	let result_force = run_governance_map_insert_with_force(
+		genesis_utxo,
+		key4.clone(),
+		value4.clone(),
+		&skey,
+		&client,
+		&await_tx,
+	)
+	.await;
+	assert!(result_force.is_ok_and(|x| x.is_some()), "force insertion succeed");
+	// Remove a key that exists, should succeed
+	let remove_result1 =
+		run_governance_map_remove(genesis_utxo, key4.clone(), &skey, &client, &await_tx).await;
+	assert!(remove_result1.is_ok_and(|x| x.is_some()), "Removing an existing key should succeed");
+
+	// Try to remove the same key again, should be a no-op
+	let remove_result2 =
+		run_governance_map_remove(genesis_utxo, key4.clone(), &skey, &client, &await_tx).await;
+	assert!(
+		remove_result2.is_ok_and(|x| x.is_none()),
+		"Removing a non-existent key should be a no-op"
+	);
+
+	// Try to remove a key that never existed, should be a no-op
+	let never_existed_key = "key_never_existed".to_string();
+	let remove_result3 =
+		run_governance_map_remove(genesis_utxo, never_existed_key, &skey, &client, &await_tx).await;
+	assert!(
+		remove_result3.is_ok_and(|x| x.is_none()),
+		"Removing a non-existent key should be a no-op"
 	);
 }
 
@@ -808,6 +841,39 @@ async fn run_governance_map_insert<
 	await_tx: &A,
 ) -> Result<Option<MultiSigSmartContractResult>, anyhow::Error> {
 	let result = run_insert(genesis_utxo, key, value, payment_signing_key, client, await_tx).await;
+	result.iter().for_each(|x| x.iter().for_each(cleanup_temp_wallet_file));
+	result
+}
+
+async fn run_governance_map_insert_with_force<
+	T: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	key: String,
+	value: ByteString,
+	payment_signing_key: &CardanoPaymentSigningKey,
+	client: &T,
+	await_tx: &A,
+) -> Result<Option<MultiSigSmartContractResult>, anyhow::Error> {
+	let result =
+		run_insert_with_force(genesis_utxo, key, value, payment_signing_key, client, await_tx)
+			.await;
+	result.iter().for_each(|x| x.iter().for_each(cleanup_temp_wallet_file));
+	result
+}
+
+async fn run_governance_map_remove<
+	T: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	key: String,
+	payment_signing_key: &CardanoPaymentSigningKey,
+	client: &T,
+	await_tx: &A,
+) -> Result<Option<MultiSigSmartContractResult>, anyhow::Error> {
+	let result = run_remove(genesis_utxo, key, payment_signing_key, client, await_tx).await;
 	result.iter().for_each(|x| x.iter().for_each(cleanup_temp_wallet_file));
 	result
 }


### PR DESCRIPTION
# Description


[link](https://input-output.atlassian.net/browse/ETCM-9696)

The remove command should spend all utxos with the given key if multiple are found. I'm kind of worried about this, becasue  this is the first time we have transaction that spends more than one utxo from script address. If my assumption about how cost models will behave is correct, this PR should be ok, and we should not worry. I've added test that does remove when there are 2 utxos with the same key, but I'm still kind of worried, that it might break down in some real life scenario. 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
