### PR TITLE
add: ETCM-9698 Governed Map get command

### DIFF
--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -1,6 +1,6 @@
 use crate::PaymentFilePath;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
-use partner_chains_cardano_offchain::governed_map::{run_insert, run_list, run_remove};
+use partner_chains_cardano_offchain::governed_map::{run_get, run_insert, run_list, run_remove};
 use serde_json::json;
 use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::UtxoId;
@@ -17,6 +17,8 @@ pub enum GovernedMapCmd {
 	List(ListCmd),
 	/// Removes a key-value pair from the Governed Map
 	Remove(RemoveCmd),
+	/// Retrieves the value stored in the Governed Map for the given key
+	Get(GetCmd),
 }
 
 impl GovernedMapCmd {
@@ -25,6 +27,7 @@ impl GovernedMapCmd {
 			Self::Insert(cmd) => cmd.execute().await,
 			Self::List(cmd) => cmd.execute().await,
 			Self::Remove(cmd) => cmd.execute().await,
+			Self::Get(cmd) => cmd.execute().await,
 		}
 	}
 }
@@ -113,21 +116,22 @@ impl RemoveCmd {
 }
 
 #[derive(Clone, Debug, clap::Parser)]
-pub struct ListCmd {
+pub struct GetCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+	#[arg(long)]
+	key: String,
 	#[arg(long, short('g'))]
 	genesis_utxo: UtxoId,
 }
 
-impl ListCmd {
+impl GetCmd {
 	pub async fn execute(self) -> crate::SubCmdResult {
 		let client = self.common_arguments.get_ogmios_client().await?;
-		let kv_pairs: Vec<_> = run_list(self.genesis_utxo, &client)
-			.await?
-			.map(|datum| json!({"key": datum.key, "value": datum.value.to_hex_string()}))
-			.collect();
+		let Some(value) = run_get(self.genesis_utxo, self.key.clone(), &client).await? else {
+			return Ok(json!({}).into());
+		};
 
-		Ok(json!(kv_pairs))
+		Ok(json!(value.to_hex_string()).into())
 	}
 }

--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -93,6 +93,7 @@ impl ListCmd {
 		Ok(json!(kv_pairs))
 	}
 }
+
 impl RemoveCmd {
 	pub async fn execute(self) -> crate::SubCmdResult {
 		let payment_key = self.payment_key_file.read_key()?;
@@ -108,5 +109,25 @@ impl RemoveCmd {
 		)
 		.await?;
 		Ok(serde_json::json!(result))
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+pub struct ListCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long, short('g'))]
+	genesis_utxo: UtxoId,
+}
+
+impl ListCmd {
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let client = self.common_arguments.get_ogmios_client().await?;
+		let kv_pairs: Vec<_> = run_list(self.genesis_utxo, &client)
+			.await?
+			.map(|datum| json!({"key": datum.key, "value": datum.value.to_hex_string()}))
+			.collect();
+
+		Ok(json!(kv_pairs))
 	}
 }

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -20,7 +20,7 @@ use partner_chains_cardano_offchain::{
 	cardano_keys::CardanoPaymentSigningKey,
 	d_param,
 	governance::MultiSigParameters,
-	governed_map::{run_insert, run_insert_with_force, run_list, run_remove},
+	governed_map::{run_get, run_insert, run_insert_with_force, run_list, run_remove},
 	init_governance,
 	multisig::{MultiSigSmartContractResult, MultiSigTransactionData},
 	permissioned_candidates,
@@ -340,7 +340,7 @@ async fn governed_map_operations() {
 
 	assert_eq!(
 		listed_values,
-		vec![(key1, value1), (key4.clone(), value4.clone()),],
+		vec![(key1.clone(), value1.clone()), (key4.clone(), value4.clone()),],
 		"All inserted and not changed or deleted keys should be listed"
 	);
 	// Now test the remove functionality
@@ -376,6 +376,12 @@ async fn governed_map_operations() {
 		remove_result3.is_ok_and(|x| x.is_none()),
 		"Removing a non-existent key should be a no-op"
 	);
+
+	let get_key1_result = run_get(genesis_utxo, key1, &client).await.unwrap();
+	assert_eq!(get_key1_result, Some(value1), "Existing key value should be returned by get");
+
+	let get_removed_key_result = run_get(genesis_utxo, key4, &client).await.unwrap();
+	assert_eq!(get_removed_key_result, None, "Get for non-existent key should return None");
 }
 
 async fn initialize<'a>(container: &Container<'a, GenericImage>) -> OgmiosClients {


### PR DESCRIPTION
# Description

Adds `smart-contracts governed-map get` command that retrieves value for given key in the Governed Map.
Output when there's data:
```json
"0xaabbcc"
```
Output when the key is unset:
```json
{}
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
