### PR TITLE
Add cmd line args for configuring retry params

### DIFF
--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -15,7 +15,10 @@ use anyhow::anyhow;
 use partner_chains_cardano_offchain::register::Deregister;
 
 #[derive(Clone, Debug, clap::Parser)]
-pub struct DeregisterCmd;
+pub struct DeregisterCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+}
 
 impl CmdRun for DeregisterCmd {
 	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
@@ -40,6 +43,7 @@ impl CmdRun for DeregisterCmd {
 		let runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
 		runtime
 			.block_on(offchain.deregister(
+				self.common_arguments.retries(),
 				chain_config.chain_parameters.genesis_utxo,
 				&payment_signing_key,
 				stake_ownership_pub_key,

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -23,7 +23,24 @@ mod tests;
 
 use clap::Parser;
 use io::*;
+use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 pub use runtime_bindings::{PartnerChainRuntime, PartnerChainRuntimeBindings, RuntimeTypeWrapper};
+use std::time::Duration;
+
+#[derive(Clone, Debug, clap::Parser)]
+#[command(author, version, about, long_about = None)]
+pub struct CommonArguments {
+	#[arg(default_value = "5", long)]
+	retry_delay_seconds: u64,
+	#[arg(default_value = "59", long)]
+	retry_count: usize,
+}
+
+impl CommonArguments {
+	pub fn retries(&self) -> FixedDelayRetries {
+		FixedDelayRetries::new(Duration::from_secs(self.retry_delay_seconds), self.retry_count)
+	}
+}
 
 #[derive(Clone, Debug, Parser)]
 #[command(

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -14,6 +14,8 @@ use sidechain_domain::*;
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Register3Cmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
 	#[arg(long)]
 	pub genesis_utxo: UtxoId,
 	#[arg(long)]
@@ -69,6 +71,7 @@ impl CmdRun for Register3Cmd {
 		let runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
 		runtime
 			.block_on(offchain.register(
+				self.common_arguments.retries(),
 				self.genesis_utxo,
 				&candidate_registration,
 				&payment_signing_key,
@@ -312,6 +315,7 @@ mod tests {
 
 	fn mock_register3_cmd() -> Register3Cmd {
 		Register3Cmd {
+			common_arguments: crate::CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
             genesis_utxo: genesis_utxo(),
             registration_utxo: "cdefe62b0a0016c2ccf8124d7dda71f6865283667850cc7b471f761d2bc1eb13#0".parse().unwrap(),
             partner_chain_pub_key: "020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1".parse().unwrap(),

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -7,7 +7,7 @@ use crate::ogmios::config::tests::{
 use crate::prepare_configuration::tests::{prompt, prompt_with_default};
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
 use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
-use crate::{verify_json, CmdRun};
+use crate::{verify_json, CmdRun, CommonArguments};
 use hex_literal::hex;
 use partner_chains_cardano_offchain::multisig::MultiSigSmartContractResult;
 use serde_json::json;
@@ -27,7 +27,7 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 			prompt_d_parameter_update_io(false),
 			print_post_update_info_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 
 	result.expect("should succeed");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
@@ -63,7 +63,7 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 			insert_d_parameter_io(),
 			print_post_update_info_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
@@ -82,7 +82,7 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 			prompt_d_parameter_update_io(false),
 			print_post_update_info_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
 }
@@ -118,7 +118,7 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 			update_d_parameter_io(),
 			print_post_update_info_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
@@ -142,7 +142,7 @@ fn fails_if_update_permissioned_candidates_fail() {
 			prompt_permissioned_candidates_update_io(true),
 			upsert_permissioned_candidates_failed_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect_err("should return error");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, post_updates_resources_json());
 }
@@ -160,9 +160,15 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 			prompt_d_parameter_update_io(false),
 			print_post_update_info_io(),
 		]);
-	let result = SetupMainChainStateCmd.run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, no_updates_resources_json());
+}
+
+fn setup_main_chain_state_cmd() -> SetupMainChainStateCmd {
+	SetupMainChainStateCmd {
+		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
+	}
 }
 
 fn print_info_io() -> MockIO {

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -1,6 +1,7 @@
 use crate::io::IOContext;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 use anyhow::anyhow;
+use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::d_param::UpsertDParam;
 use partner_chains_cardano_offchain::governance::MultiSigParameters;
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
@@ -347,6 +348,7 @@ impl GetScriptsData for OffchainMock {
 impl InitGovernance for OffchainMock {
 	async fn init_governance(
 		&self,
+		_retries: FixedDelayRetries,
 		governance_authority: &MultiSigParameters,
 		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
@@ -363,6 +365,7 @@ impl InitGovernance for OffchainMock {
 impl UpsertDParam for OffchainMock {
 	async fn upsert_d_param(
 		&self,
+		_retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		d_parameter: &DParameter,
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -383,6 +386,7 @@ impl UpsertDParam for OffchainMock {
 impl Register for OffchainMock {
 	async fn register(
 		&self,
+		_retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidate_registration: &CandidateRegistration,
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -402,6 +406,7 @@ impl Register for OffchainMock {
 impl Deregister for OffchainMock {
 	async fn deregister(
 		&self,
+		_retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
 		stake_ownership_pub_key: StakePoolPublicKey,
@@ -421,6 +426,7 @@ impl Deregister for OffchainMock {
 impl UpsertPermissionedCandidates for OffchainMock {
 	async fn upsert_permissioned_candidates(
 		&self,
+		_retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidates: &[sidechain_domain::PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,

--- a/toolkit/smart-contracts/commands/src/assemble_tx.rs
+++ b/toolkit/smart-contracts/commands/src/assemble_tx.rs
@@ -1,6 +1,5 @@
 use crate::transaction_submitted_json;
 use partner_chains_cardano_offchain::assemble_tx::assemble_tx;
-use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::csl::{transaction_from_bytes, vkey_witness_from_bytes};
 use sidechain_domain::{TransactionCbor, VKeyWitnessCbor};
 
@@ -29,8 +28,7 @@ impl AssembleAndSubmitCmd {
 			.collect::<Result<Vec<_>, _>>()?;
 
 		let tx_hash =
-			assemble_tx(transaction, witnesses, &client, &FixedDelayRetries::five_minutes())
-				.await?;
+			assemble_tx(transaction, witnesses, &client, &self.common_arguments.retries()).await?;
 		Ok(transaction_submitted_json(tx_hash))
 	}
 }

--- a/toolkit/smart-contracts/commands/src/d_parameter.rs
+++ b/toolkit/smart-contracts/commands/src/d_parameter.rs
@@ -1,5 +1,4 @@
 use crate::{option_to_json, GenesisUtxo, PaymentFilePath};
-use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::d_param::upsert_d_param;
 use sidechain_domain::DParameter;
 
@@ -31,7 +30,7 @@ impl UpsertDParameterCmd {
 			&d_param,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 

--- a/toolkit/smart-contracts/commands/src/governance.rs
+++ b/toolkit/smart-contracts/commands/src/governance.rs
@@ -1,6 +1,5 @@
 use crate::{option_to_json, GenesisUtxo, PaymentFilePath};
 use partner_chains_cardano_offchain::{
-	await_tx::FixedDelayRetries,
 	governance::{get_governance_policy_summary, MultiSigParameters},
 	init_governance::run_init_governance,
 	update_governance::run_update_governance,
@@ -58,7 +57,7 @@ impl InitGovernanceCmd {
 			&payment_key,
 			self.genesis_utxo,
 			&client,
-			FixedDelayRetries::five_minutes(),
+			self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -94,7 +93,7 @@ impl UpdateGovernanceCmd {
 			&payment_key,
 			self.genesis_utxo.into(),
 			&client,
-			FixedDelayRetries::five_minutes(),
+			self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))

--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -1,5 +1,4 @@
 use crate::{GenesisUtxo, PaymentFilePath};
-use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::governed_map::{
 	run_get, run_insert, run_list, run_remove, run_update,
 };
@@ -62,7 +61,7 @@ impl InsertCmd {
 			self.value,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -131,7 +130,7 @@ impl RemoveCmd {
 			self.key,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -172,7 +171,7 @@ impl UpdateCmd {
 			self.current_value,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -1,10 +1,12 @@
 use ogmios_client::jsonrpsee::{client_for_url, OgmiosClients};
 use partner_chains_cardano_offchain::{
+	await_tx::FixedDelayRetries,
 	cardano_keys::{CardanoKeyFileContent, CardanoPaymentSigningKey},
 	multisig::MultiSigSmartContractResult,
 };
 use serde::Serialize;
 use sidechain_domain::*;
+use std::time::Duration;
 
 pub mod assemble_tx;
 pub mod d_parameter;
@@ -49,6 +51,10 @@ pub enum SmartContractsCmd {
 pub struct CommonArguments {
 	#[arg(default_value = "ws://localhost:1337", long, short = 'O')]
 	ogmios_url: String,
+	#[arg(default_value = "5", long)]
+	retry_delay_seconds: u64,
+	#[arg(default_value = "59", long)]
+	retry_count: usize,
 }
 
 impl CommonArguments {
@@ -56,6 +62,10 @@ impl CommonArguments {
 		Ok(client_for_url(&self.ogmios_url).await.map_err(|e| {
 			format!("Failed to connect to Ogmios at {} with: {}", &self.ogmios_url, e)
 		})?)
+	}
+
+	pub fn retries(&self) -> FixedDelayRetries {
+		FixedDelayRetries::new(Duration::from_secs(self.retry_delay_seconds), self.retry_count)
 	}
 }
 

--- a/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
@@ -1,5 +1,4 @@
 use crate::{option_to_json, parse_partnerchain_public_keys, GenesisUtxo, PaymentFilePath};
-use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::permissioned_candidates::upsert_permissioned_candidates;
 use std::fs::read_to_string;
 
@@ -46,7 +45,7 @@ impl UpsertPermissionedCandidatesCmd {
 			&permissioned_candidates,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(option_to_json(result))

--- a/toolkit/smart-contracts/commands/src/register.rs
+++ b/toolkit/smart-contracts/commands/src/register.rs
@@ -2,10 +2,7 @@ use crate::{
 	option_to_json, parse_partnerchain_public_keys, transaction_submitted_json, GenesisUtxo,
 	PaymentFilePath,
 };
-use partner_chains_cardano_offchain::{
-	await_tx::FixedDelayRetries,
-	register::{run_deregister, run_register},
-};
+use partner_chains_cardano_offchain::register::{run_deregister, run_register};
 use sidechain_domain::{
 	AdaBasedStaking, CandidateRegistration, MainchainSignature, PermissionedCandidateData,
 	SidechainSignature, StakePoolPublicKey, UtxoId,
@@ -63,7 +60,7 @@ impl RegisterCmd {
 			&candidate_registration,
 			&payment_key,
 			&client,
-			FixedDelayRetries::five_minutes(),
+			self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(option_to_json(result.map(transaction_submitted_json)))
@@ -93,7 +90,7 @@ impl DeregisterCmd {
 			&payment_signing_key,
 			self.spo_public_key,
 			&client,
-			FixedDelayRetries::five_minutes(),
+			self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(option_to_json(result.map(transaction_submitted_json)))

--- a/toolkit/smart-contracts/commands/src/reserve.rs
+++ b/toolkit/smart-contracts/commands/src/reserve.rs
@@ -1,14 +1,11 @@
 use crate::{option_to_json, transaction_submitted_json, GenesisUtxo, PaymentFilePath};
-use partner_chains_cardano_offchain::{
-	await_tx::FixedDelayRetries,
-	reserve::{
-		create::{create_reserve_utxo, ReserveParameters},
-		deposit::deposit_to_reserve,
-		handover::handover_reserve,
-		init::init_reserve_management,
-		release::release_reserve_funds,
-		update_settings::update_reserve_settings,
-	},
+use partner_chains_cardano_offchain::reserve::{
+	create::{create_reserve_utxo, ReserveParameters},
+	deposit::deposit_to_reserve,
+	handover::handover_reserve,
+	init::init_reserve_management,
+	release::release_reserve_funds,
+	update_settings::update_reserve_settings,
 };
 use sidechain_domain::{AssetId, ScriptHash, UtxoId};
 use std::num::NonZero;
@@ -61,7 +58,7 @@ impl InitReserveCmd {
 			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -100,7 +97,7 @@ impl CreateReserveCmd {
 			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -129,7 +126,7 @@ impl DepositReserveCmd {
 			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -159,7 +156,7 @@ impl UpdateReserveSettingsCmd {
 			&payment_key,
 			self.total_accrued_function_script_hash,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(option_to_json(result))
@@ -185,7 +182,7 @@ impl HandoverReserveCmd {
 			self.genesis_utxo,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(serde_json::json!(result))
@@ -219,7 +216,7 @@ impl ReleaseReserveCmd {
 			self.reference_utxo,
 			&payment_key,
 			&client,
-			&FixedDelayRetries::five_minutes(),
+			&self.common_arguments.retries(),
 		)
 		.await?;
 		Ok(transaction_submitted_json(result))

--- a/toolkit/smart-contracts/offchain/src/assemble_tx.rs
+++ b/toolkit/smart-contracts/offchain/src/assemble_tx.rs
@@ -11,6 +11,7 @@ pub trait AssembleTx {
 	#[allow(async_fn_in_trait)]
 	async fn assemble_tx(
 		&self,
+		retries: &FixedDelayRetries,
 		transaction: Transaction,
 		witnesses: Vec<Vkeywitness>,
 	) -> anyhow::Result<McTxHash>;
@@ -19,10 +20,11 @@ pub trait AssembleTx {
 impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId> AssembleTx for C {
 	async fn assemble_tx(
 		&self,
+		retries: &FixedDelayRetries,
 		transaction: Transaction,
 		witnesses: Vec<Vkeywitness>,
 	) -> anyhow::Result<McTxHash> {
-		assemble_tx(transaction, witnesses, self, &FixedDelayRetries::five_minutes()).await
+		assemble_tx(transaction, witnesses, self, retries).await
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/src/d_param/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/d_param/mod.rs
@@ -33,6 +33,7 @@ pub trait UpsertDParam {
 	#[allow(async_fn_in_trait)]
 	async fn upsert_d_param(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		d_parameter: &DParameter,
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -42,18 +43,12 @@ pub trait UpsertDParam {
 impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId> UpsertDParam for C {
 	async fn upsert_d_param(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		d_parameter: &DParameter,
 		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
-		upsert_d_param(
-			genesis_utxo,
-			d_parameter,
-			payment_signing_key,
-			self,
-			&FixedDelayRetries::five_minutes(),
-		)
-		.await
+		upsert_d_param(genesis_utxo, d_parameter, payment_signing_key, self, &retries).await
 	}
 }
 
@@ -88,6 +83,7 @@ pub async fn upsert_d_param<
 					ctx,
 					genesis_utxo,
 					ogmios_client,
+					await_tx,
 				)
 				.await?,
 			)
@@ -95,8 +91,16 @@ pub async fn upsert_d_param<
 		None => {
 			log::info!("There is no D-parameter set. Inserting new one.");
 			Some(
-				insert_d_param(&validator, &policy, d_parameter, ctx, genesis_utxo, ogmios_client)
-					.await?,
+				insert_d_param(
+					&validator,
+					&policy,
+					d_parameter,
+					ctx,
+					genesis_utxo,
+					ogmios_client,
+					await_tx,
+				)
+				.await?,
 			)
 		},
 	};
@@ -128,13 +132,17 @@ fn get_current_d_parameter(
 	}
 }
 
-async fn insert_d_param<C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId>(
+async fn insert_d_param<
+	C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
 	validator: &PlutusScript,
 	policy: &PlutusScript,
 	d_parameter: &DParameter,
 	ctx: TransactionContext,
 	genesis_utxo: UtxoId,
 	client: &C,
+	await_tx: &A,
 ) -> anyhow::Result<MultiSigSmartContractResult> {
 	let gov_data = GovernanceData::get(genesis_utxo, client).await?;
 
@@ -144,12 +152,15 @@ async fn insert_d_param<C: QueryLedgerState + Transactions + QueryNetwork + Quer
 		|costs, ctx| mint_d_param_token_tx(validator, policy, d_parameter, &gov_data, costs, &ctx),
 		"Insert D-parameter",
 		client,
-		&FixedDelayRetries::five_minutes(),
+		await_tx,
 	)
 	.await
 }
 
-async fn update_d_param<C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId>(
+async fn update_d_param<
+	C: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
 	validator: &PlutusScript,
 	policy: &PlutusScript,
 	d_parameter: &DParameter,
@@ -157,6 +168,7 @@ async fn update_d_param<C: QueryLedgerState + Transactions + QueryNetwork + Quer
 	ctx: TransactionContext,
 	genesis_utxo: UtxoId,
 	client: &C,
+	await_tx: &A,
 ) -> anyhow::Result<MultiSigSmartContractResult> {
 	let governance_data = GovernanceData::get(genesis_utxo, client).await?;
 
@@ -176,7 +188,7 @@ async fn update_d_param<C: QueryLedgerState + Transactions + QueryNetwork + Quer
 		},
 		"Update D-parameter",
 		client,
-		&FixedDelayRetries::five_minutes(),
+		await_tx,
 	)
 	.await
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -25,6 +25,7 @@ pub trait InitGovernance {
 	#[allow(async_fn_in_trait)]
 	async fn init_governance(
 		&self,
+		retries: FixedDelayRetries,
 		governance_parameters: &MultiSigParameters,
 		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
@@ -37,6 +38,7 @@ where
 {
 	async fn init_governance(
 		&self,
+		retries: FixedDelayRetries,
 		governance_parameters: &MultiSigParameters,
 		payment_key: &CardanoPaymentSigningKey,
 		genesis_utxo_id: UtxoId,
@@ -46,7 +48,7 @@ where
 			payment_key,
 			Some(genesis_utxo_id),
 			self,
-			FixedDelayRetries::five_minutes(),
+			retries,
 		)
 		.await
 		.map(|result| result.tx_hash)

--- a/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/offchain/src/permissioned_candidates.rs
@@ -32,6 +32,7 @@ pub trait UpsertPermissionedCandidates {
 	#[allow(async_fn_in_trait)]
 	async fn upsert_permissioned_candidates(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -43,6 +44,7 @@ impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId>
 {
 	async fn upsert_permissioned_candidates(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidates: &[PermissionedCandidateData],
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -52,7 +54,7 @@ impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId>
 			candidates,
 			payment_signing_key,
 			self,
-			&FixedDelayRetries::five_minutes(),
+			&retries,
 		)
 		.await
 	}

--- a/toolkit/smart-contracts/offchain/src/register.rs
+++ b/toolkit/smart-contracts/offchain/src/register.rs
@@ -27,6 +27,7 @@ pub trait Register {
 	#[allow(async_fn_in_trait)]
 	async fn register(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidate_registration: &CandidateRegistration,
 		payment_signing_key: &CardanoPaymentSigningKey,
@@ -39,19 +40,14 @@ where
 {
 	async fn register(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		candidate_registration: &CandidateRegistration,
 		payment_signing_key: &CardanoPaymentSigningKey,
 	) -> Result<Option<McTxHash>, OffchainError> {
-		run_register(
-			genesis_utxo,
-			candidate_registration,
-			payment_signing_key,
-			self,
-			FixedDelayRetries::five_minutes(),
-		)
-		.await
-		.map_err(|e| OffchainError::InternalError(e.to_string()))
+		run_register(genesis_utxo, candidate_registration, payment_signing_key, self, retries)
+			.await
+			.map_err(|e| OffchainError::InternalError(e.to_string()))
 	}
 }
 
@@ -122,6 +118,7 @@ pub trait Deregister {
 	#[allow(async_fn_in_trait)]
 	async fn deregister(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
 		stake_ownership_pub_key: StakePoolPublicKey,
@@ -134,19 +131,14 @@ where
 {
 	async fn deregister(
 		&self,
+		retries: FixedDelayRetries,
 		genesis_utxo: UtxoId,
 		payment_signing_key: &CardanoPaymentSigningKey,
 		stake_ownership_pub_key: StakePoolPublicKey,
 	) -> Result<Option<McTxHash>, OffchainError> {
-		run_deregister(
-			genesis_utxo,
-			payment_signing_key,
-			stake_ownership_pub_key,
-			self,
-			FixedDelayRetries::five_minutes(),
-		)
-		.await
-		.map_err(|e| OffchainError::InternalError(e.to_string()))
+		run_deregister(genesis_utxo, payment_signing_key, stake_ownership_pub_key, self, retries)
+			.await
+			.map_err(|e| OffchainError::InternalError(e.to_string()))
 	}
 }
 

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -693,6 +693,7 @@ async fn run_register<T: QueryLedgerState + Transactions + QueryNetwork + QueryU
 	let registration_utxo = eve_utxos.first().unwrap().utxo_id();
 	client
 		.register(
+			FixedDelayRetries::five_minutes(),
 			genesis_utxo,
 			&CandidateRegistration {
 				stake_ownership: AdaBasedStaking {


### PR DESCRIPTION
# Description

Adds command line arguments to allow setting retry parameters, while preserving the currently set defaults.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
