### PR TITLE
fix: use 'c' as short for 'genesis-utxo' parameter

### DIFF
--- a/toolkit/smart-contracts/commands/src/d_parameter.rs
+++ b/toolkit/smart-contracts/commands/src/d_parameter.rs
@@ -1,7 +1,7 @@
-use crate::{option_to_json, PaymentFilePath};
+use crate::{option_to_json, GenesisUtxo, PaymentFilePath};
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::d_param::upsert_d_param;
-use sidechain_domain::{DParameter, UtxoId};
+use sidechain_domain::DParameter;
 
 #[derive(Clone, Debug, clap::Parser)]
 pub struct UpsertDParameterCmd {
@@ -13,8 +13,8 @@ pub struct UpsertDParameterCmd {
 	registered_candidates_count: u16,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	#[arg(long, short('c'))]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 }
 
 impl UpsertDParameterCmd {
@@ -27,7 +27,7 @@ impl UpsertDParameterCmd {
 		let client = self.common_arguments.get_ogmios_client().await?;
 
 		let result = upsert_d_param(
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&d_param,
 			&payment_key,
 			&client,

--- a/toolkit/smart-contracts/commands/src/get_scripts.rs
+++ b/toolkit/smart-contracts/commands/src/get_scripts.rs
@@ -1,19 +1,18 @@
+use crate::GenesisUtxo;
 use partner_chains_cardano_offchain::scripts_data::get_scripts_data_with_ogmios;
-use sidechain_domain::UtxoId;
 
 #[derive(Clone, Debug, clap::Parser)]
 pub struct GetScripts {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	/// Genesis UTXO that identifies the partner chain.
-	#[arg(long, short = 'c')]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 }
 
 impl GetScripts {
 	pub async fn execute(self) -> crate::SubCmdResult {
 		let client = self.common_arguments.get_ogmios_client().await?;
-		let scripts_data = get_scripts_data_with_ogmios(self.genesis_utxo, &client).await?;
+		let scripts_data = get_scripts_data_with_ogmios(self.genesis_utxo.into(), &client).await?;
 		Ok(serde_json::json!(scripts_data))
 	}
 }

--- a/toolkit/smart-contracts/commands/src/governance.rs
+++ b/toolkit/smart-contracts/commands/src/governance.rs
@@ -1,4 +1,4 @@
-use crate::{option_to_json, PaymentFilePath};
+use crate::{option_to_json, GenesisUtxo, PaymentFilePath};
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
 	governance::{get_governance_policy_summary, MultiSigParameters},
@@ -77,9 +77,8 @@ pub struct UpdateGovernanceCmd {
 	threshold: u8,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	/// Genesis UTXO of the chain
-	#[arg(long, short = 'c')]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 }
 
 impl UpdateGovernanceCmd {
@@ -93,7 +92,7 @@ impl UpdateGovernanceCmd {
 		let result = run_update_governance(
 			&multisig_parameters,
 			&payment_key,
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&client,
 			FixedDelayRetries::five_minutes(),
 		)

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -112,6 +112,19 @@ impl PaymentFilePath {
 	}
 }
 
+#[derive(Clone, Debug, clap::Parser)]
+pub(crate) struct GenesisUtxo {
+	/// Genesis UTXO that identifies the partner chain.
+	#[arg(long, short = 'c')]
+	genesis_utxo: UtxoId,
+}
+
+impl From<GenesisUtxo> for UtxoId {
+	fn from(value: GenesisUtxo) -> Self {
+		value.genesis_utxo
+	}
+}
+
 // Parses public keys in formatted as SIDECHAIN_KEY:AURA_KEY:GRANDPA_KEY
 pub(crate) fn parse_partnerchain_public_keys(
 	partner_chain_public_keys: &str,

--- a/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
@@ -1,9 +1,6 @@
-use crate::option_to_json;
-use crate::parse_partnerchain_public_keys;
-use crate::PaymentFilePath;
+use crate::{option_to_json, parse_partnerchain_public_keys, GenesisUtxo, PaymentFilePath};
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
 use partner_chains_cardano_offchain::permissioned_candidates::upsert_permissioned_candidates;
-use sidechain_domain::UtxoId;
 use std::fs::read_to_string;
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -16,8 +13,8 @@ pub struct UpsertPermissionedCandidatesCmd {
 	permissioned_candidates_file: String,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	#[arg(long, short('c'))]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 }
 
 impl UpsertPermissionedCandidatesCmd {
@@ -45,7 +42,7 @@ impl UpsertPermissionedCandidatesCmd {
 		let client = self.common_arguments.get_ogmios_client().await?;
 
 		let result = upsert_permissioned_candidates(
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&permissioned_candidates,
 			&payment_key,
 			&client,

--- a/toolkit/smart-contracts/commands/src/register.rs
+++ b/toolkit/smart-contracts/commands/src/register.rs
@@ -1,5 +1,6 @@
 use crate::{
-	option_to_json, parse_partnerchain_public_keys, transaction_submitted_json, PaymentFilePath,
+	option_to_json, parse_partnerchain_public_keys, transaction_submitted_json, GenesisUtxo,
+	PaymentFilePath,
 };
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
@@ -14,9 +15,8 @@ use sidechain_domain::{
 pub struct RegisterCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	/// Genesis UTXO of the partner-chain
-	#[arg(long)]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 	/// UTXO that will be spend when executing registration transaction, part of the registration message
 	#[arg(long)]
 	registration_utxo: UtxoId,
@@ -59,7 +59,7 @@ impl RegisterCmd {
 		};
 
 		let result = run_register(
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&candidate_registration,
 			&payment_key,
 			&client,
@@ -74,9 +74,8 @@ impl RegisterCmd {
 pub struct DeregisterCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	/// Genesis UTXO of the partner-chain
-	#[arg(long)]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
 	/// Hex string representing bytes of the Stake Pool Verification Key
@@ -90,7 +89,7 @@ impl DeregisterCmd {
 		let client = self.common_arguments.get_ogmios_client().await?;
 
 		let result = run_deregister(
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&payment_signing_key,
 			self.spo_public_key,
 			&client,

--- a/toolkit/smart-contracts/commands/src/reserve.rs
+++ b/toolkit/smart-contracts/commands/src/reserve.rs
@@ -1,4 +1,4 @@
-use crate::{option_to_json, transaction_submitted_json, PaymentFilePath};
+use crate::{option_to_json, transaction_submitted_json, GenesisUtxo, PaymentFilePath};
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,
 	reserve::{
@@ -49,9 +49,8 @@ pub struct InitReserveCmd {
 	common_arguments: crate::CommonArguments,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	/// Genesis UTXO of the partner-chain.
-	#[arg(long, short('c'))]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 }
 
 impl InitReserveCmd {
@@ -59,7 +58,7 @@ impl InitReserveCmd {
 		let payment_key = self.payment_key_file.read_key()?;
 		let client = self.common_arguments.get_ogmios_client().await?;
 		let result = init_reserve_management(
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
 			&FixedDelayRetries::five_minutes(),
@@ -75,9 +74,8 @@ pub struct CreateReserveCmd {
 	common_arguments: crate::CommonArguments,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	/// Genesis UTXO of the partner-chain.
-	#[arg(long, short('c'))]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 	/// Script hash of the 'total accrued function', also called V-function, that computes how many tokens could be released from the reserve at given moment.
 	#[arg(long)]
 	total_accrued_function_script_hash: ScriptHash,
@@ -99,7 +97,7 @@ impl CreateReserveCmd {
 				token: self.token,
 				initial_deposit: self.initial_deposit_amount,
 			},
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
 			&FixedDelayRetries::five_minutes(),
@@ -115,9 +113,8 @@ pub struct DepositReserveCmd {
 	common_arguments: crate::CommonArguments,
 	#[clap(flatten)]
 	payment_key_file: PaymentFilePath,
-	/// Genesis UTXO of the partner-chain, identifies the partner chain and its reserve.
-	#[arg(long, short('c'))]
-	genesis_utxo: UtxoId,
+	#[clap(flatten)]
+	genesis_utxo: GenesisUtxo,
 	/// Amount of tokens to deposit. They must be present in the payment wallet.
 	#[arg(long)]
 	amount: u64,
@@ -129,7 +126,7 @@ impl DepositReserveCmd {
 		let client = self.common_arguments.get_ogmios_client().await?;
 		let result = deposit_to_reserve(
 			self.amount,
-			self.genesis_utxo,
+			self.genesis_utxo.into(),
 			&payment_key,
 			&client,
 			&FixedDelayRetries::five_minutes(),


### PR DESCRIPTION
# Description

'g' was used for governed map. I propose to use a type for genesis-utxo parameter.
It is intentional to not use it in `governance init`, because it I think it should have a different help message in that context.
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
