### PR TITLE
change: use single uplc, minicbor and pallas versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,7 +575,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "log",
- "minicbor 0.20.0",
+ "minicbor",
  "num-bigint",
  "num-traits",
  "parity-scale-codec",
@@ -3208,12 +3208,6 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
-
-[[package]]
-name = "half"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
@@ -3221,6 +3215,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hamming"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65043da274378d68241eb9a8f8f8aa54e349136f7b8e12f63e3ef44043cc30e1"
 
 [[package]]
 name = "hash-db"
@@ -5286,33 +5286,12 @@ dependencies = [
 
 [[package]]
 name = "minicbor"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d15f4203d71fdf90903c2696e55426ac97a363c67b218488a73b534ce7aca10"
-dependencies = [
- "half 1.8.3",
- "minicbor-derive 0.13.0",
-]
-
-[[package]]
-name = "minicbor"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0452a60c1863c1f50b5f77cd295e8d2786849f35883f0b9e18e7e6e1b5691b0"
 dependencies = [
- "half 2.4.1",
- "minicbor-derive 0.15.3",
-]
-
-[[package]]
-name = "minicbor-derive"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1154809406efdb7982841adb6311b3d095b46f78342dd646736122fe6b19e267"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "half",
+ "minicbor-derive",
 ]
 
 [[package]]
@@ -6003,81 +5982,42 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "pallas-addresses"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84460293bb3323066e9ce608702750c14f02bc36d41c469e44b3eef5ec0fdbf6"
+checksum = "d7bd039d7f1618d12ff348dd03eebe38c5d2a010325750e5341526c419b0f8e0"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "crc",
  "cryptoxide",
  "hex",
- "pallas-codec 0.30.2",
- "pallas-crypto 0.30.2",
- "thiserror",
-]
-
-[[package]]
-name = "pallas-addresses"
-version = "0.31.0"
-source = "git+https://github.com/txpipe/pallas.git?tag=v0.31.0#3ba8dac19c06d6023a947877ca205dad62409a9a"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "crc",
- "cryptoxide",
- "hex",
- "pallas-codec 0.31.0",
- "pallas-crypto 0.31.0",
+ "pallas-codec",
+ "pallas-crypto",
  "thiserror",
 ]
 
 [[package]]
 name = "pallas-codec"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "747279d1bc612986035619a3eaded8f9f4ceae29668aa7a5feae83681a0e93f4"
+checksum = "1584d615857c0a44058fb612e892e9e0cc47b56c3c82cdf7347b5c1d1193598c"
 dependencies = [
  "hex",
- "minicbor 0.20.0",
+ "minicbor",
  "num-bigint",
  "serde",
  "thiserror",
 ]
 
 [[package]]
-name = "pallas-codec"
-version = "0.31.0"
-source = "git+https://github.com/txpipe/pallas.git?tag=v0.31.0#3ba8dac19c06d6023a947877ca205dad62409a9a"
-dependencies = [
- "hex",
- "minicbor 0.25.1",
- "serde",
- "thiserror",
-]
-
-[[package]]
 name = "pallas-crypto"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6f8b08e32c7dbb50302222701ae15ef9ac1a7cc39225ce29c253f6ddab2aa7"
+checksum = "37c1d642326ce402eb9191aeacc3dd0bf2b499848e97a56396c978a6eb9dd31a"
 dependencies = [
  "cryptoxide",
  "hex",
- "pallas-codec 0.30.2",
- "rand_core 0.6.4",
- "serde",
- "thiserror",
-]
-
-[[package]]
-name = "pallas-crypto"
-version = "0.31.0"
-source = "git+https://github.com/txpipe/pallas.git?tag=v0.31.0#3ba8dac19c06d6023a947877ca205dad62409a9a"
-dependencies = [
- "cryptoxide",
- "hex",
- "pallas-codec 0.31.0",
+ "pallas-codec",
  "rand_core 0.6.4",
  "serde",
  "thiserror",
@@ -6086,47 +6026,32 @@ dependencies = [
 
 [[package]]
 name = "pallas-primitives"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24929d461308626183d5bf15290e6315f4cc67fa38a1a66469425919683cceb2"
+checksum = "6d30f5053073554d016a9f009c077f9a84275951a611cce54230de6c54d34d9b"
 dependencies = [
  "base58",
  "bech32 0.9.1",
  "hex",
  "log",
- "pallas-codec 0.30.2",
- "pallas-crypto 0.30.2",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "pallas-primitives"
-version = "0.31.0"
-source = "git+https://github.com/txpipe/pallas.git?tag=v0.31.0#3ba8dac19c06d6023a947877ca205dad62409a9a"
-dependencies = [
- "base58",
- "bech32 0.9.1",
- "hex",
- "log",
- "pallas-codec 0.31.0",
- "pallas-crypto 0.31.0",
+ "pallas-codec",
+ "pallas-crypto",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "pallas-traverse"
-version = "0.30.2"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ca94c2278a160c226d6f5bb1756ea5f355421158aaa697445f59f09477a6a4"
+checksum = "02d2572d316883fe866ae648bc3c5357e70cbbe8de5d78b1246f6109520fa52f"
 dependencies = [
  "hex",
  "itertools 0.13.0",
- "pallas-addresses 0.30.2",
- "pallas-codec 0.30.2",
- "pallas-crypto 0.30.2",
- "pallas-primitives 0.30.2",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
  "paste",
  "serde",
  "thiserror",
@@ -6701,10 +6626,10 @@ dependencies = [
  "hex-literal",
  "itertools 0.13.0",
  "log",
- "minicbor 0.20.0",
+ "minicbor",
  "ogmios-client",
- "pallas-addresses 0.31.0",
- "pallas-primitives 0.31.0",
+ "pallas-addresses",
+ "pallas-primitives",
  "partner-chains-plutus-data",
  "plutus",
  "pretty_assertions",
@@ -6904,7 +6829,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "log",
- "minicbor 0.20.0",
+ "minicbor",
  "pallet-address-associations",
  "pallet-aura",
  "pallet-balances",
@@ -7218,7 +7143,7 @@ name = "plutus"
 version = "1.6.0"
 dependencies = [
  "hex",
- "minicbor 0.20.0",
+ "minicbor",
  "num-bigint",
  "num-traits",
  "serde",
@@ -10861,7 +10786,7 @@ dependencies = [
  "authority-selection-inherents",
  "derive-new",
  "hex-literal",
- "minicbor 0.20.0",
+ "minicbor",
  "parity-scale-codec",
  "plutus",
  "plutus-datum-derive",
@@ -12515,12 +12440,14 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "uplc"
-version = "1.1.6"
+version = "1.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21877260ad4000bac13566f9c3a95a406044ec9dcad532d248896e6f98b0a8a7"
+checksum = "2551f87e839964c3e9a41e46edced6237eb603a65130bbbb214da4c9ebdad910"
 dependencies = [
+ "bitvec",
  "blst",
  "cryptoxide",
+ "hamming",
  "hex",
  "indexmap 1.9.3",
  "itertools 0.10.5",
@@ -12530,18 +12457,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "once_cell",
- "pallas-addresses 0.30.2",
- "pallas-codec 0.30.2",
- "pallas-crypto 0.30.2",
- "pallas-primitives 0.30.2",
+ "pallas-addresses",
+ "pallas-codec",
+ "pallas-crypto",
+ "pallas-primitives",
  "pallas-traverse",
  "peg",
  "pretty",
  "secp256k1 0.26.0",
  "serde",
  "serde_json",
- "strum 0.24.1",
- "strum_macros 0.24.3",
+ "strum 0.26.3",
  "thiserror",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ itertools = "0.13.0"
 jsonrpsee = { version = "0.24", features = ["client-core", "server", "macros"] }
 libp2p-identity = "0.2"
 log = { version = "0.4", default-features = false }
-minicbor = { version = "0.20", features = ["alloc"] }
+minicbor = { version = "0.25.1", features = ["alloc"] }
 num-bigint = { version = "0.4.3", default-features = false }
 num-traits = { version = "0.2.17", default-features = false }
 parity-scale-codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = [
@@ -130,8 +130,8 @@ parity-scale-codec = { package = "parity-scale-codec", version = "3.6.12", defau
 	"max-encoded-len",
 ] }
 quickcheck = { version = "1.0.3" }
-pallas-addresses = { git = "https://github.com/txpipe/pallas.git", tag = "v0.31.0" }
-pallas-primitives = { git = "https://github.com/txpipe/pallas.git", tag = "v0.31.0" }
+pallas-addresses = { version = "0.32.0" }
+pallas-primitives = { version = "0.32.0" }
 proptest = { version = "1.5.0" }
 scale-info = { version = "2.11.1", default-features = false, features = [
 	"derive",
@@ -156,7 +156,7 @@ tempfile = "3.10.1"
 thiserror = { version = "1.0.48" }
 time = { version = "0.3.36", default-features = false }
 tokio = { version = "1.0", features = ["rt-multi-thread", "macros"] }
-uplc = { version = "1.1.6" }
+uplc = { version = "1.1.16" }
 lazy_static = "1.4.0"
 lru = { version = "0.12.4" }
 pretty_assertions = { version = "1.4.1" }

--- a/toolkit/smart-contracts/offchain/tests/legacy_governance_tx.rs
+++ b/toolkit/smart-contracts/offchain/tests/legacy_governance_tx.rs
@@ -1,5 +1,6 @@
 use cardano_serialization_lib::*;
 use hex_literal::hex;
+use pallas_primitives::MaybeIndefArray;
 use partner_chains_cardano_offchain::plutus_script::PlutusScript as PCPlutusScript;
 use partner_chains_cardano_offchain::scripts_data::version_oracle;
 use sidechain_domain::UtxoId;
@@ -20,12 +21,12 @@ pub fn legacy_governance_init_transaction(
 				.to_bytes();
 		PCPlutusScript::from_wrapped_cbor(raw_scripts::MULTI_SIG_POLICY, Language::new_plutus_v2())
 			.unwrap()
-			.apply_uplc_data(uplc::PlutusData::Array(vec![
-				uplc::PlutusData::Array(vec![uplc::PlutusData::BoundedBytes(
-					governance_authorithy_key_hash.into(),
-				)]),
+			.apply_uplc_data(uplc::PlutusData::Array(MaybeIndefArray::Def(vec![
+				uplc::PlutusData::Array(MaybeIndefArray::Def(vec![
+					uplc::PlutusData::BoundedBytes(governance_authorithy_key_hash.into()),
+				])),
 				uplc::PlutusData::BigInt(uplc::BigInt::Int(1.into())),
-			]))
+			])))
 			.unwrap()
 			.to_csl()
 	};

--- a/toolkit/utils/plutus/src/cbor.rs
+++ b/toolkit/utils/plutus/src/cbor.rs
@@ -5,9 +5,8 @@ extern crate alloc;
 use crate::{Datum, Datum::*, MapDatumEntry};
 
 use minicbor::{
-	data::Tag,
-	encode,
-	encode::{Encoder, Write},
+	data::{IanaTag, Tag},
+	encode::{self, Encoder, Write},
 };
 
 impl<C> encode::Encode<C> for Datum {
@@ -49,8 +48,8 @@ fn encode_integer<W: Write, C>(
 		_ => {
 			let (sign, bytes) = i.to_bytes_be();
 			match sign {
-				Sign::Plus => e.tag(Tag::PosBignum)?,
-				Sign::Minus => e.tag(Tag::NegBignum)?,
+				Sign::Plus => e.tag(IanaTag::PosBignum)?,
+				Sign::Minus => e.tag(IanaTag::NegBignum)?,
 				Sign::NoSign => unreachable!("NoSign is not possible here, since 0 is a valid i64"),
 			};
 			encode_bytestring(&bytes, e, ctx)
@@ -145,14 +144,14 @@ fn encode_entries<W: Write, C>(
 }
 
 fn constructor_small_tag(value: u64) -> Tag {
-	Tag::Unassigned(value + 121)
+	Tag::new(value + 121)
 }
 
 fn constructor_big_tag(value: u64) -> Tag {
-	Tag::Unassigned(1280 + value - 7)
+	Tag::new(1280 + value - 7)
 }
 
-const CONSTRUCTOR_OVER_LIMIT_TAG: Tag = Tag::Unassigned(102);
+const CONSTRUCTOR_OVER_LIMIT_TAG: Tag = Tag::new(102);
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
# Description

Addressing the issue https://github.com/input-output-hk/partner-chains/issues/554 this PR updates uplc, minicbor and pallas versions so both pallas libraries and minicbor are used in one version

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
