### PR TITLE
change: ETCM-9783 Rework the Governed Map IDP and data source API to operate on change lists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6933,6 +6933,7 @@ dependencies = [
  "num-bigint",
  "pallet-sidechain-rpc",
  "partner-chains-plutus-data",
+ "pretty_assertions",
  "serde",
  "serde_json",
  "sidechain-domain",

--- a/demo/node/src/data_sources.rs
+++ b/demo/node/src/data_sources.rs
@@ -96,8 +96,9 @@ pub async fn create_cached_db_sync_data_sources(
 			metrics_opt,
 			STAKE_CACHE_SIZE,
 		)),
-		governed_map: Arc::new(GovernedMapDataSourceMock::new(
-			[("key1".into(), vec![1, 2, 3].into())].into(),
-		)),
+		governed_map: Arc::new(GovernedMapDataSourceMock::new(vec![(
+			"key1".into(),
+			Some(vec![1, 2, 3].into()),
+		)])),
 	})
 }

--- a/demo/node/src/inherent_data.rs
+++ b/demo/node/src/inherent_data.rs
@@ -141,6 +141,7 @@ where
 			client.as_ref(),
 			parent_hash,
 			mc_hash.mc_hash(),
+			mc_hash.previous_mc_hash(),
 			governed_map_data_source.as_ref(),
 		)
 		.await?;
@@ -265,6 +266,7 @@ where
 			client.as_ref(),
 			parent_hash,
 			mc_hash,
+			mc_state_reference.previous_mc_hash(),
 			governed_map_data_source.as_ref(),
 		)
 		.await?;

--- a/demo/node/src/tests/runtime_api_mock.rs
+++ b/demo/node/src/tests/runtime_api_mock.rs
@@ -4,7 +4,6 @@ use authority_selection_inherents::CommitteeMember;
 use hex_literal::hex;
 use partner_chains_demo_runtime::opaque::SessionKeys;
 use partner_chains_demo_runtime::{BlockAuthor, CrossChainPublic};
-use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::*;
 use sidechain_mc_hash::McHashInherentDigest;
 use sidechain_slots::Slot;
@@ -140,9 +139,6 @@ sp_api::mock_impl_runtime_apis! {
 	}
 
 	impl sp_governed_map::GovernedMapIDPApi<Block> for TestApi {
-		fn get_stored_mappings() -> BTreeMap<String, ByteString> {
-			Default::default()
-		}
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
 			Default::default()
 		}

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -8,7 +8,6 @@ extern crate frame_benchmarking;
 
 extern crate alloc;
 
-use alloc::collections::BTreeMap;
 use alloc::string::String;
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
 use authority_selection_inherents::filter_invalid_candidates::{
@@ -34,7 +33,6 @@ use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier
 use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::byte_string::{BoundedString, SizedByteString};
 use sidechain_domain::{
 	CrossChainPublicKey, DelegatorKey, MainchainKeyHash, PermissionedCandidateData,
@@ -1043,10 +1041,6 @@ impl_runtime_apis! {
 	}
 
 	impl sp_governed_map::GovernedMapIDPApi<Block> for Runtime {
-		fn get_stored_mappings() -> BTreeMap<String, ByteString> {
-			GovernedMap::get_all_key_value_pairs_unbounded()
-				.collect()
-		}
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
 			GovernedMap::get_main_chain_scripts()
 		}

--- a/toolkit/data-sources/db-sync/Cargo.toml
+++ b/toolkit/data-sources/db-sync/Cargo.toml
@@ -55,6 +55,7 @@ sp-block-participation = { workspace = true, features = [
 tokio-test = "0.4.3"
 ctor = "0.4.1"
 testcontainers-modules = { version = "0.1.3", features = ["postgres"] }
+pretty_assertions = { workspace = true }
 
 [features]
 default = []

--- a/toolkit/data-sources/db-sync/src/governed_map/mod.rs
+++ b/toolkit/data-sources/db-sync/src/governed_map/mod.rs
@@ -1,7 +1,6 @@
-use crate::metrics::McFollowerMetrics;
-use crate::observed_async_trait;
 use crate::DataSourceError::ExpectedDataNotFound;
 use crate::Result;
+use crate::{metrics::McFollowerMetrics, observed_async_trait};
 use derive_new::new;
 use log::warn;
 use partner_chains_plutus_data::governed_map::GovernedMapDatum;
@@ -9,6 +8,7 @@ use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::*;
 use sp_governed_map::{GovernedMapDataSource, MainChainScriptsV1};
 use sqlx::PgPool;
+use std::collections::HashMap;
 
 #[cfg(test)]
 pub mod tests;
@@ -21,23 +21,37 @@ pub struct GovernedMapDataSourceImpl {
 
 observed_async_trait!(
 impl GovernedMapDataSource for GovernedMapDataSourceImpl {
-	async fn get_current_mappings(
+	async fn get_mapping_changes(
 		&self,
-		mc_block: McBlockHash,
+		since_mc_block: Option<McBlockHash>,
+		up_to_mc_block: McBlockHash,
 		scripts: MainChainScriptsV1,
-	) -> std::result::Result<BTreeMap<String, ByteString>, Box<dyn std::error::Error + Send + Sync>>
-	{
-		let mut governed_map = BTreeMap::new();
-		let entries = self.get_current_mapping_entries(mc_block, scripts).await?;
-		for entry in entries {
-			match GovernedMapDatum::try_from(entry.datum.0) {
-				Ok(GovernedMapDatum{key, value}) => {
-					governed_map.insert(key, value);
-				},
-				Err(err) => warn!("Failed decoding map entry: {err}"),
+	) -> std::result::Result<
+		Vec<(String, Option<ByteString>)>,
+		Box<dyn std::error::Error + Send + Sync>,
+	> {
+		let current_mappings =
+			self.get_current_mapping_entries(up_to_mc_block, scripts.clone()).await?;
+		let Some(since_mc_block) = since_mc_block else {
+			let changes =
+				current_mappings.into_iter().map(|(key, value)| (key, Some(value))).collect();
+			return Ok(changes);
+		};
+		let previous_mappings =
+			self.get_current_mapping_entries(since_mc_block, scripts.clone()).await?;
+		let mut changes = vec![];
+		for (key, value) in current_mappings.iter() {
+			if previous_mappings.get(key) != Some(value) {
+				changes.push((key.clone(), Some(value.clone())));
 			}
 		}
-		Ok(governed_map)
+		for key in previous_mappings.keys() {
+			if !current_mappings.contains_key(key) {
+				changes.push((key.clone(), None));
+			}
+		}
+
+		Ok(changes)
 	}
 }
 );
@@ -47,17 +61,29 @@ impl GovernedMapDataSourceImpl {
 		&self,
 		hash: McBlockHash,
 		scripts: MainChainScriptsV1,
-	) -> Result<Vec<crate::db_model::DatumOutput>> {
+	) -> Result<HashMap<String, ByteString>> {
 		let Some(block) = crate::db_model::get_block_by_hash(&self.pool, hash.clone()).await?
 		else {
 			return Err(ExpectedDataNotFound(format!("Block hash: {hash}")));
 		};
-		Ok(crate::db_model::get_datums_at_address_with_token(
+		let entries = crate::db_model::get_datums_at_address_with_token(
 			&self.pool,
 			&scripts.validator_address.into(),
 			block.block_no,
 			scripts.asset.into(),
 		)
-		.await?)
+		.await?;
+
+		let mut mappings = HashMap::new();
+		for entry in entries {
+			match GovernedMapDatum::try_from(entry.datum.0) {
+				Ok(GovernedMapDatum { key, value }) => {
+					mappings.insert(key, value);
+				},
+				Err(err) => warn!("Failed decoding map entry: {err}"),
+			}
+		}
+
+		Ok(mappings)
 	}
 }

--- a/toolkit/data-sources/db-sync/src/governed_map/tests.rs
+++ b/toolkit/data-sources/db-sync/src/governed_map/tests.rs
@@ -1,6 +1,7 @@
 use super::GovernedMapDataSourceImpl;
 use crate::metrics::mock::test_metrics;
 use hex_literal::hex;
+use pretty_assertions::assert_eq;
 use sidechain_domain::byte_string::ByteString;
 use sidechain_domain::*;
 use sp_governed_map::{GovernedMapDataSource, MainChainScriptsV1};
@@ -8,71 +9,71 @@ use sqlx::PgPool;
 use std::str::FromStr;
 use tokio_test::assert_err;
 
+// tx1: inserts key2
+// tx2: inserts key1, an invalid datum, and duplicate key2
+const BLOCK_1: McBlockHash =
+	McBlockHash(hex!("b702000000000000000000000000000000000000000000000000000000000002"));
+// tx3: deletes key1
+const BLOCK_4: McBlockHash =
+	McBlockHash(hex!("b702000000000000000000000000000000000000000000000000000000000005"));
+// tx4: inserts key3
+const BLOCK_6: McBlockHash =
+	McBlockHash(hex!("b702000000000000000000000000000000000000000000000000000000000007"));
+// tx5: updates key3
+const BLOCK_7: McBlockHash =
+	McBlockHash(hex!("b702000000000000000000000000000000000000000000000000000000000008"));
+
 #[sqlx::test(migrations = "./testdata/governed-map/migrations")]
 async fn test_governed_map_fails_on_wrong_block_hash(pool: PgPool) {
 	let source = make_source(pool);
 	let mc_block =
 		McBlockHash(hex!("FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"));
-	let result = source.get_current_mappings(mc_block, scripts()).await;
+	let result = source.get_mapping_changes(None, mc_block, scripts()).await;
 	assert_err!(result);
 }
 
 #[sqlx::test(migrations = "./testdata/governed-map/migrations")]
 async fn test_governed_map_insert(pool: PgPool) {
 	let source = make_source(pool);
-	let mc_block =
-		McBlockHash(hex!("B702000000000000000000000000000000000000000000000000000000000002"));
-	let result = source.get_current_mappings(mc_block, scripts()).await;
-	let mut expected: BTreeMap<String, ByteString> = BTreeMap::new();
-	expected.insert(
-		"key1".to_owned(),
-		ByteString::from(hex!("11111111111111111111111111111111").to_vec()),
-	);
-	expected.insert(
-		"key2".to_owned(),
-		ByteString::from(hex!("22222222222222222222222222222222").to_vec()),
-	);
-	assert_eq!(result.unwrap(), expected);
+	let mut result = source.get_mapping_changes(None, BLOCK_1, scripts()).await.unwrap();
+	result.sort();
+	let expected = vec![
+		(
+			"key1".to_owned(),
+			Some(ByteString::from(hex!("11111111111111111111111111111111").to_vec())),
+		),
+		(
+			"key2".to_owned(),
+			Some(ByteString::from(hex!("22222222222222222222222222222222").to_vec())),
+		),
+	];
+	assert_eq!(result, expected);
 }
 
 #[sqlx::test(migrations = "./testdata/governed-map/migrations")]
 async fn test_governed_map_delete(pool: PgPool) {
 	let source = make_source(pool);
-	let mc_block =
-		McBlockHash(hex!("B702000000000000000000000000000000000000000000000000000000000005"));
-	let result = source.get_current_mappings(mc_block, scripts()).await;
-	let mut expected: BTreeMap<String, ByteString> = BTreeMap::new();
-	expected.insert(
-		"key2".to_owned(),
-		ByteString::from(hex!("22222222222222222222222222222222").to_vec()),
-	);
+	let result = source.get_mapping_changes(Some(BLOCK_1), BLOCK_4, scripts()).await;
+	let expected = vec![("key1".to_owned(), None)];
 	assert_eq!(result.unwrap(), expected);
 }
 
 #[sqlx::test(migrations = "./testdata/governed-map/migrations")]
 async fn test_governed_map_upsert(pool: PgPool) {
 	let source = make_source(pool);
-	let mc_block =
-		McBlockHash(hex!("B702000000000000000000000000000000000000000000000000000000000008"));
-	let result = source.get_current_mappings(mc_block, scripts()).await;
-	let mut expected: BTreeMap<String, ByteString> = BTreeMap::new();
-	expected.insert(
-		"key2".to_owned(),
-		ByteString::from(hex!("22222222222222222222222222222222").to_vec()),
-	);
-	expected.insert(
+	let mut result = source.get_mapping_changes(Some(BLOCK_6), BLOCK_7, scripts()).await.unwrap();
+	result.sort();
+	let expected = vec![(
 		"key3".to_owned(),
-		ByteString::from(hex!("44444444444444444444444444444444").to_vec()),
-	);
-	assert_eq!(result.unwrap(), expected);
+		Some(ByteString::from(hex!("44444444444444444444444444444444").to_vec())),
+	)];
+	assert_eq!(result, expected);
 }
 
 fn scripts() -> MainChainScriptsV1 {
 	MainChainScriptsV1 {
 		asset: AssetId {
-			policy_id: PolicyId::from_hex_unsafe(
-				"500000000000000000000000000000000000434845434b504f494e69",
-			),
+			policy_id: PolicyId(hex!("500000000000000000000000000000000000434845434b504f494e69")),
 			asset_name: AssetName::empty(),
 		},
 		validator_address: MainchainAddress::from_str("governed_map_test_address").unwrap(),

--- a/toolkit/data-sources/db-sync/testdata/governed-map/migrations/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/governed-map/migrations/1_create_schema.sql
@@ -159,7 +159,8 @@ CREATE TABLE tx_out (
     payment_cred hash28type,
     stake_address_id bigint,
     value lovelace NOT NULL,
-    data_hash hash32type
+    data_hash hash32type,
+    comment varchar
 );
 
 CREATE TABLE redeemer (

--- a/toolkit/data-sources/db-sync/testdata/governed-map/migrations/2_data.sql
+++ b/toolkit/data-sources/db-sync/testdata/governed-map/migrations/2_data.sql
@@ -92,17 +92,17 @@ INSERT INTO tx ( id         , hash   , block_id, block_index, out_sum, fee, depo
               ,( ups_tx_id  , thash_6, 7       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
 ;
 
-INSERT INTO tx_out ( id   , tx_id      , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash )
-            VALUES ( 0    , cons_tx_id , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 1    , cons_tx_id , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 2    , cons_tx_id , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 3    , ins_tx_ida , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_1   ) -- add key2a
-                  ,( 4    , ins_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_2   ) -- add key1
-                  ,( 5    , ins_tx_id  , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_3   ) -- add invalid
-                  ,( 7    , ins_tx_id  , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_4   ) -- add key2 simulating 2 utxos with the same key
-                  ,( 8    , del_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      ) -- delete key1
-                  ,( 9    , ins_tx_id2 , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_5   ) -- add key3
-                  ,( 10   , ups_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_6   ) -- upsert key3
+INSERT INTO tx_out ( id   , tx_id      , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash, comment          )
+            VALUES ( 0    , cons_tx_id , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
+                  ,( 1    , cons_tx_id , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
+                  ,( 2    , cons_tx_id , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
+                  ,( 3    , ins_tx_ida , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_1  , 'add key2'       )
+                  ,( 4    , ins_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_2  , 'add key1'       )
+                  ,( 5    , ins_tx_id  , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_3  , 'add invalid'    )
+                  ,( 7    , ins_tx_id  , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_4  , 'duplicate key2' )
+                  ,( 8    , del_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , 'delete key1'    )
+                  ,( 9    , ins_tx_id2 , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_5  , 'add key3'       )
+                  ,( 10   , ups_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_6  , 'upsert key3'    )
 ;
 
 INSERT INTO ma_tx_out ( id   , quantity , tx_out_id , ident)

--- a/toolkit/data-sources/mock/src/governed_map.rs
+++ b/toolkit/data-sources/mock/src/governed_map.rs
@@ -6,22 +6,23 @@ use sp_governed_map::{GovernedMapDataSource, MainChainScriptsV1};
 
 #[derive(Debug, Default)]
 pub struct GovernedMapDataSourceMock {
-	mappings: BTreeMap<String, ByteString>,
+	changes: Vec<(String, Option<ByteString>)>,
 }
 
 impl GovernedMapDataSourceMock {
-	pub fn new(mappings: BTreeMap<String, ByteString>) -> Self {
-		Self { mappings }
+	pub fn new(changes: Vec<(String, Option<ByteString>)>) -> Self {
+		Self { changes }
 	}
 }
 
 #[async_trait]
 impl GovernedMapDataSource for GovernedMapDataSourceMock {
-	async fn get_current_mappings(
+	async fn get_mapping_changes(
 		&self,
-		_mc_block: McBlockHash,
+		_since_mc_block: Option<McBlockHash>,
+		_up_to_mc_block: McBlockHash,
 		_scripts: MainChainScriptsV1,
-	) -> Result<BTreeMap<String, ByteString>> {
-		Ok(self.mappings.clone())
+	) -> Result<Vec<(String, Option<ByteString>)>> {
+		Ok(self.changes.clone())
 	}
 }

--- a/toolkit/governed-map/primitives/src/lib.rs
+++ b/toolkit/governed-map/primitives/src/lib.rs
@@ -236,7 +236,7 @@ impl_tuple_on_governed_mapping_change!(A, B, C, D, E);
 
 type ChangesV1 = Vec<GovernedMapChangeV1>;
 
-/// Inherent data provider providing the list of Governed Map changes that occured since previous observation.
+/// Inherent data provider providing the list of Governed Map changes that occurred since previous observation.
 #[cfg(feature = "std")]
 #[derive(Debug, PartialEq)]
 pub enum GovernedMapInherentDataProvider {
@@ -283,7 +283,7 @@ impl sp_inherents::InherentDataProvider for GovernedMapInherentDataProvider {
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
 pub trait GovernedMapDataSource {
-	/// Queries all changes that occured in the mappings of the Governed Map on Cardano in the given range of blocks.
+	/// Queries all changes that occurred in the mappings of the Governed Map on Cardano in the given range of blocks.
 	///
 	/// # Arguments:
 	/// - `since_mc_block`: lower bound (exclusive). If [None], the data source should return all changes since the genesis block.

--- a/toolkit/governed-map/primitives/src/lib.rs
+++ b/toolkit/governed-map/primitives/src/lib.rs
@@ -45,6 +45,7 @@
 //!     client: &T,
 //!     governed_map_data_source: &(impl GovernedMapDataSource + Send + Sync),
 //!     parent_hash: Block::Hash,
+//! #   // Arguments below should be provided by the MC Hash IDP from `sidechain_mc_hash` crate
 //! #   mc_hash: McBlockHash,
 //! #   previous_mc_hash: Option<McBlockHash>,
 //! ) -> Result<InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>

--- a/toolkit/governed-map/primitives/src/lib.rs
+++ b/toolkit/governed-map/primitives/src/lib.rs
@@ -1,4 +1,90 @@
+//! # Governed Map primitives
+//!
+//! This crate provides shared types and logic of the Governed Map feature, together with its inherent
+//! data provider logic.
+//!
+//! ## Usage
+//!
+//!    This crate supports operation of `pallet_governed_map`. Consult the pallet's documentation on how to
+//!    include it in the runtime
+//!
+//! ### Adding to the node
+//!
+//! #### Implementing the runtime API
+//!
+//! [GovernedMapInherentDataProvider] requires access to the pallet's configuration via a runtime API.
+//! Assuming the pallet has been added to the runtime and is named `GovernedMap`, the API should be
+//! implemented like this:
+//!
+//! ```rust,ignore
+//! impl sp_governed_map::GovernedMapIDPApi<Block> for Runtime {
+//!     fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
+//!         GovernedMap::get_main_chain_scripts()
+//!     }
+//!     fn get_pallet_version() -> u32 {
+//!         GovernedMap::get_version()
+//!     }
+//! }
+//! ```
+//!
+//! #### Adding the data source
+//!
+//! [GovernedMapInherentDataProvider] needs a data source implementing the [GovernedMapDataSource] trait.
+//! For nodes using Db-Sync, one is provided by the `partner_chains_db_sync_data_sources` crate. Consult
+//! its documentation for more information.
+//!
+//! #### Adding the inherent data provider
+//!
+//! The [GovernedMapInherentDataProvider] should be added to your IDP stack using [GovernedMapInherentDataProvider::new]
+//! for both block proposal and validation, like so:
+//! ```rust
+//! # use sp_governed_map::*;
+//! # use sidechain_domain::*;
+//! type InherentDataProviders = (/* other IDPs */ GovernedMapInherentDataProvider);
+//! async fn create_idps<T, Block>(
+//!     client: &T,
+//!     governed_map_data_source: &(impl GovernedMapDataSource + Send + Sync),
+//!     parent_hash: Block::Hash,
+//! #   mc_hash: McBlockHash,
+//! #   previous_mc_hash: Option<McBlockHash>,
+//! ) -> Result<InherentDataProviders, Box<dyn std::error::Error + Send + Sync>>
+//! where
+//!     Block: sp_runtime::traits::Block,
+//!     T: sp_api::ProvideRuntimeApi<Block> + Send + Sync,
+//!     T::Api: GovernedMapIDPApi<Block> + Send + Sync
+//! {
+//!     /*
+//!      Create other IDPs
+//!      */
+//!     let governed_map = GovernedMapInherentDataProvider::new(
+//!         client,
+//!         parent_hash,
+//!         mc_hash,
+//!         previous_mc_hash,
+//!         governed_map_data_source
+//!     )
+//!     .await?;
+//!     Ok((/* other IDPs */ governed_map))
+//! # }
+//! ```
+//!
+//! Note that it requires access to the current and previous referenced Cardano block hash (`mc_hash` and `previous_mc_hash`).
+//! These are provided by the Partner Chains Toolkit's MC Hash inherent data provider from the `sidechain_mc_hash` crate.
+//!
+//! ## Adding to a running chain
+//!
+//! As with any other feature, if the Governed Map feature is to be added to an already running chain, a strict order
+//! of operations is required:
+//! 1. The node should be updated according to the steps described above, so that the inherent data provider is present
+//!    in the nodes IDP stack for both proposal and verfication.
+//! 2. The updated node binary should be distributed to the block producers who should update their nodes.
+//! 3. A new runtime version should be released with the pallet added according to its documentation and the runtime
+//!    API implemented as described above.
+//! 4. The Governed Map main chain scripts should be set through the `set_main_chain_scripts` extrinsic in the pallet.
+//!
+//! [GovernedMapInherentDataProvider] is version-aware and will stay inactive until the pallet is added and fully configured.
 #![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
 
 extern crate alloc;
 
@@ -7,17 +93,18 @@ use alloc::string::String;
 use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use sidechain_domain::{byte_string::*, *};
+#[cfg(feature = "std")]
+use sp_api::*;
 use sp_inherents::*;
 use sp_runtime::traits::Get;
 use sp_runtime::BoundedVec;
-#[cfg(feature = "std")]
-use {sp_api::*, std::collections::BTreeMap};
 
 #[cfg(any(test, feature = "mock"))]
 mod mock;
 #[cfg(test)]
 mod tests;
 
+/// Inherent identifier used by the Governed Map pallet
 pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"govrnmap";
 
 /// Cardano identifiers necessary for observation of the Governed Map
@@ -35,43 +122,54 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"govrnmap";
 )]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct MainChainScriptsV1 {
+	/// Cardano address of the Governed Map validator, at which UTXOs containig key-value pairs are located
 	pub validator_address: MainchainAddress,
+	/// Asset used to mark the UTXOs containing the Governed Map's key-value pairs
 	pub asset: AssetId,
 }
 
 /// Type describing a change made to a single key-value pair in the Governed Map.
 #[derive(Decode, Encode, TypeInfo, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct GovernedMapChangeV1 {
+	/// Key of the entry being modified
 	pub key: String,
+	/// New value under `key`
+	/// * [None] value indicates deletion
+	/// * [Some] value indicates insertion or update
 	pub new_value: Option<ByteString>,
-}
-
-impl GovernedMapChangeV1 {
-	pub fn upsert(key: &str, new_value: &[u8]) -> Self {
-		Self { key: key.into(), new_value: Some(new_value.into()) }
-	}
-	pub fn delete(key: &str) -> Self {
-		Self { key: key.into(), new_value: None }
-	}
 }
 
 /// Error type returned when creating or validating the Governed Map inherent
 #[derive(Decode, Encode, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
 pub enum InherentError {
+	/// Signals that the inherent was expected but not produced
 	#[cfg_attr(feature = "std", error("Inherent missing for Governed Map pallet"))]
 	InherentMissing,
+	/// Signals that the inherent was produced when not expected
 	#[cfg_attr(feature = "std", error("Unexpected inherent for Governed Map pallet"))]
 	InherentNotExpected,
 	#[cfg_attr(
 		feature = "std",
 		error("Data in Governed Map pallet inherent differs from inherent data")
 	)]
+	/// Signals that the inherent produced contains incorrect data
 	IncorrectInherent,
 	#[cfg_attr(feature = "std", error("Governed Map key {0} exceeds size bounds"))]
+	/// Signals that a key in the mapping change list is longer than the configured bound
 	KeyExceedsBounds(String),
 	#[cfg_attr(feature = "std", error("Governed Map value {1:?} for key {0} exceeds size bounds"))]
+	/// Signals that a value in the mapping change list is longer than the configured bound
 	ValueExceedsBounds(String, ByteString),
+	/// Signals that the number of unregistered changes to the mapping exceeds the configured upper limit
+	///
+	/// This should not normally occur if the pallet is configured to accept at least as many changes
+	/// as the planned number of keys in use, or if the number of keys exceeds this limit but the number
+	/// of changes is low enough not to overwhelm a non-stalled chain.
+	///
+	/// As this error prevents the production of a block, if this error occurs on a live chain, then the
+	/// only way of fixing it is to change the mappings on Cardano close enough to the last state
+	/// registered in the pallet to bring the change count below the limit.
 	#[cfg_attr(feature = "std", error("Number of changes to the Governed Map exceeds the limit"))]
 	TooManyChanges,
 }
@@ -145,7 +243,10 @@ pub enum GovernedMapInherentDataProvider {
 	/// Inactive variant that will not provide any data and will not raise any errors.
 	Inert,
 	/// Active variant that will provide data.
-	ActiveV1 { changes: ChangesV1 },
+	ActiveV1 {
+		/// List of changes to the Governed Map that occurred since previous observation
+		changes: ChangesV1,
+	},
 }
 
 #[cfg(feature = "std")]
@@ -182,22 +283,35 @@ impl sp_inherents::InherentDataProvider for GovernedMapInherentDataProvider {
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
 pub trait GovernedMapDataSource {
-	/// Returns all key-value mappings stored in the Governed Map on Cardano after execution of `mc_block`.
-	async fn get_current_mappings(
+	/// Queries all changes that occured in the mappings of the Governed Map on Cardano in the given range of blocks.
+	///
+	/// # Arguments:
+	/// - `since_mc_block`: lower bound (exclusive). If [None], the data source should return all changes since the genesis block.
+	/// - `up_to_block`: upper bound (inclusive).
+	///
+	/// # Return value:
+	/// Items in the returned vector should be key-value pairs representing changes to the Governed Map. Inserts and updates should
+	/// be represented as a [Some] containing the new value, while deletions should be indicated by a [None]. The vector should be
+	/// ordered from the oldest change to the newest.
+	async fn get_mapping_changes(
 		&self,
-		mc_block: McBlockHash,
+		since_mc_block: Option<McBlockHash>,
+		up_to_mc_block: McBlockHash,
 		main_chain_scripts: MainChainScriptsV1,
-	) -> Result<BTreeMap<String, ByteString>, Box<dyn std::error::Error + Send + Sync>>;
+	) -> Result<Vec<(String, Option<ByteString>)>, Box<dyn std::error::Error + Send + Sync>>;
 }
 
 /// Error type returned when creation of [GovernedMapInherentDataProvider] fails.
 #[cfg(feature = "std")]
 #[derive(Debug, thiserror::Error)]
 pub enum InherentProviderCreationError {
+	/// Signals that a runtime API call failed
 	#[error("Runtime API call failed: {0}")]
 	ApiError(#[from] sp_api::ApiError),
+	/// Signals that the data source returned an error
 	#[error("Data source call failed: {0}")]
 	DataSourceError(Box<dyn std::error::Error + Send + Sync>),
+	/// Signals that the current pallet version on the chain is higher than supported by the node's IDP
 	#[error("Unsupported pallet version {0} (highest supported version: {1})")]
 	UnsupportedPalletVersion(u32, u32),
 }
@@ -220,6 +334,7 @@ impl GovernedMapInherentDataProvider {
 		client: &T,
 		parent_hash: Block::Hash,
 		mc_hash: McBlockHash,
+		parent_mc_hash: Option<McBlockHash>,
 		data_source: &(dyn GovernedMapDataSource + Send + Sync),
 	) -> Result<Self, InherentProviderCreationError>
 	where
@@ -234,7 +349,7 @@ impl GovernedMapInherentDataProvider {
 		}
 
 		match api.get_pallet_version(parent_hash)? {
-			1 => Self::new_v1(client, parent_hash, mc_hash, data_source).await,
+			1 => Self::new_v1(client, parent_hash, mc_hash, parent_mc_hash, data_source).await,
 			unsupported_version => {
 				Err(InherentProviderCreationError::UnsupportedPalletVersion(unsupported_version, 1))
 			},
@@ -245,6 +360,7 @@ impl GovernedMapInherentDataProvider {
 		client: &T,
 		parent_hash: Block::Hash,
 		mc_hash: McBlockHash,
+		parent_mc_hash: Option<McBlockHash>,
 		data_source: &(dyn GovernedMapDataSource + Send + Sync),
 	) -> Result<Self, InherentProviderCreationError>
 	where
@@ -259,24 +375,20 @@ impl GovernedMapInherentDataProvider {
 			return Ok(Self::Inert);
 		};
 
-		let entries_in_storage = api.get_stored_mappings(parent_hash)?;
 		let current_entries = data_source
-			.get_current_mappings(mc_hash, main_chain_script)
+			.get_mapping_changes(parent_mc_hash, mc_hash, main_chain_script)
 			.await
 			.map_err(InherentProviderCreationError::DataSourceError)?;
 
 		let mut changes: ChangesV1 = ChangesV1::new();
 
-		for (key, value) in current_entries.iter() {
-			if entries_in_storage.get(key) != Some(value) {
-				changes.push(GovernedMapChangeV1::upsert(&key, &value));
-			}
-		}
-
-		for key in entries_in_storage.keys() {
-			if !current_entries.contains_key(key) {
-				changes.push(GovernedMapChangeV1::delete(&key));
-			}
+		for (key, value) in current_entries.into_iter() {
+			let key = key.into();
+			let change = match value {
+				None => GovernedMapChangeV1 { key, new_value: None },
+				Some(value) => GovernedMapChangeV1 { key, new_value: Some(value.into()) },
+			};
+			changes.push(change);
 		}
 
 		changes.sort();
@@ -290,8 +402,6 @@ sp_api::decl_runtime_apis! {
 	#[api_version(1)]
 	pub trait GovernedMapIDPApi
 	{
-		/// Returns all key-value mappings currently stored in the pallet
-		fn get_stored_mappings() -> BTreeMap<String, ByteString>;
 		/// Returns the main chain scripts currently set in the pallet or [None] otherwise
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1>;
 		/// Returns the current version of the pallet, 1-based.

--- a/toolkit/governed-map/primitives/src/mock.rs
+++ b/toolkit/governed-map/primitives/src/mock.rs
@@ -1,22 +1,22 @@
 use crate::*;
 use sidechain_domain::byte_string::ByteString;
 use sp_api::ProvideRuntimeApi;
-use std::collections::BTreeMap;
 
 #[cfg(feature = "std")]
 pub struct MockGovernedMapDataSource {
-	pub current_mappings: Result<BTreeMap<String, ByteString>, String>,
+	pub changes: Vec<(String, Option<ByteString>)>,
 }
 
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
 impl GovernedMapDataSource for MockGovernedMapDataSource {
-	async fn get_current_mappings(
+	async fn get_mapping_changes(
 		&self,
-		_mc_block: McBlockHash,
+		_since_mc_block: Option<McBlockHash>,
+		_up_to_mc_block: McBlockHash,
 		_main_chain_scripts: MainChainScriptsV1,
-	) -> Result<BTreeMap<String, ByteString>, Box<dyn std::error::Error + Send + Sync>> {
-		Ok(self.current_mappings.clone()?)
+	) -> Result<Vec<(String, Option<ByteString>)>, Box<dyn std::error::Error + Send + Sync>> {
+		Ok(self.changes.clone())
 	}
 }
 
@@ -27,9 +27,7 @@ pub(crate) type Block = sp_runtime::generic::Block<
 >;
 
 #[derive(Clone, Default)]
-pub(crate) struct TestApiV1 {
-	pub stored_mappings: BTreeMap<String, ByteString>,
-}
+pub(crate) struct TestApiV1;
 
 impl ProvideRuntimeApi<Block> for TestApiV1 {
 	type Api = Self;
@@ -41,9 +39,6 @@ impl ProvideRuntimeApi<Block> for TestApiV1 {
 
 sp_api::mock_impl_runtime_apis! {
 	impl GovernedMapIDPApi<Block> for TestApiV1 {
-		fn get_stored_mappings() -> BTreeMap<String, ByteString> {
-			self.stored_mappings.clone()
-		}
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
 			Some(Default::default())
 		}

--- a/toolkit/governed-map/primitives/src/tests.rs
+++ b/toolkit/governed-map/primitives/src/tests.rs
@@ -1,3 +1,14 @@
+#![allow(missing_docs)]
+
+impl crate::GovernedMapChangeV1 {
+	pub fn upsert(key: &str, new_value: &[u8]) -> Self {
+		Self { key: key.into(), new_value: Some(new_value.into()) }
+	}
+	pub fn delete(key: &str) -> Self {
+		Self { key: key.into(), new_value: None }
+	}
+}
+
 mod idp_v1 {
 	use crate::{mock::*, GovernedMapInherentDataProvider, *};
 	use sidechain_domain::McBlockHash;
@@ -6,25 +17,21 @@ mod idp_v1 {
 
 	#[tokio::test]
 	async fn calculates_changes_and_returns_active_if_non_empty() {
-		let api = TestApiV1 {
-			stored_mappings: [
-				("deleted_key".into(), vec![1].into()),
-				("updated_key".into(), vec![1, 2].into()),
+		let api = TestApiV1;
+		let data_source = MockGovernedMapDataSource {
+			changes: vec![
+				("updated_key".into(), Some(vec![63].into())),
+				("inserted_key".into(), Some(vec![1, 2, 3].into())),
+				("deleted_key".into(), None),
 			]
 			.into(),
-		};
-		let data_source = MockGovernedMapDataSource {
-			current_mappings: Ok([
-				("updated_key".into(), vec![63].into()),
-				("inserted_key".into(), vec![1, 2, 3].into()),
-			]
-			.into()),
 		};
 
 		let idp = GovernedMapInherentDataProvider::new(
 			&api,
 			<Block as BlockT>::Hash::default(),
 			McBlockHash::default(),
+			Some(McBlockHash::default()),
 			&data_source,
 		)
 		.await
@@ -45,20 +52,14 @@ mod idp_v1 {
 
 	#[tokio::test]
 	async fn is_empty_when_there_are_no_changes() {
-		let api = TestApiV1 {
-			stored_mappings: [
-				("deleted_key".into(), vec![1].into()),
-				("updated_key".into(), vec![1, 2].into()),
-			]
-			.into(),
-		};
-		let data_source =
-			MockGovernedMapDataSource { current_mappings: Ok(api.stored_mappings.clone()) };
+		let api = TestApiV1;
+		let data_source = MockGovernedMapDataSource { changes: vec![] };
 
 		let idp = GovernedMapInherentDataProvider::new(
 			&api,
 			<Block as BlockT>::Hash::default(),
 			McBlockHash::default(),
+			Some(McBlockHash::default()),
 			&data_source,
 		)
 		.await


### PR DESCRIPTION
# Description

* Redefines the `GovernedMapDataSource` to provide the list of mapping changes in a given block range instead of full state at block and rewrites the implementations to conform to it
* Rewrites the `GovernedMapInherentDataProvider` to operate on changes too

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
