### PR TITLE
fix: make prepare-configuration update genesis_utxo in pc-chain-config.json

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ the feature `pallet-session-compat`.
 
 ## Fixed
 
+* `prepare-configuration` wizard now updates existing `chain_parameters.genesis_utxo` field in `pc-chain-config.json`
 * MC Hash inherent data provider will not propose older MC state than one already present in the ledger
 * `governance init` when genesis utxo had a script attached, then transaction fee was sometimes calculated incorrectly
 


### PR DESCRIPTION
# Description

When running `prepare-configuration` with config file already containing `chain_parameters.genesis_utxo`, the value of the field was not updated with the new UTXO

REF: ETCM-9786

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [x] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
