### PR TITLE
Nightly cargo docs

### DIFF
--- a/.github/actions/deploy/deploy-rustdoc/action.yml
+++ b/.github/actions/deploy/deploy-rustdoc/action.yml
@@ -10,13 +10,6 @@ outputs: {}
 runs:
   using: "composite"
   steps:
-    - name: Install tooling
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
-        protoc --version
-      shell: bash
-
     - name: Checkout repository
       uses: actions/checkout@v4
 
@@ -28,19 +21,11 @@ runs:
         ssh-add - <<< "${{ inputs.ssh_key }}"
       shell: bash
 
-    - name: Rust versions
-      run: rustup show
-      shell: bash
-
     - name: Rust cache
       uses: Swatinem/rust-cache@v2.6.2
 
     - name: Build rustdocs
-      run: SKIP_WASM_BUILD=1 cargo doc --all --no-deps
-      shell: bash
-
-    - name: Make index.html
-      run: echo "<meta http-equiv=refresh content=0;url=partner_chains_demo_node/index.html>" > ./target/doc/index.html
+      run: nix develop .#nightly -c gen-cargo-docs
       shell: bash
 
     - name: Deploy documentation

--- a/dev/nix/shell.nix
+++ b/dev/nix/shell.nix
@@ -25,7 +25,7 @@
           }).cargo;
 
           gen-cargo-docs = pkgs.writeScriptBin "gen-cargo-docs" ''
-            RUSTDOCFLAGS="--enable-index-page -Zunstable-options" ${nightlyCargo}/bin/cargo doc --no-deps
+            RUSTDOCFLAGS="--enable-index-page -Zunstable-options" SKIP_WASM_BUILD=1 ${nightlyCargo}/bin/cargo doc --no-deps
           '';
 
           packages = with pkgs; [


### PR DESCRIPTION
# Description

This changes the rust-doc CI job to build docs using nightly cargo which supports `--enable-index` creating an index.html that links to all crates.

Cargo is provided via small addition in shell.nix providing nightly in a devShell of the same name.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
