### PR TITLE
ci: run cargo doc on nixos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -507,7 +507,7 @@ jobs:
   deploy-rustdoc:
     if: github.event_name == 'pull_request' && github.event.pull_request.merged == true
     needs: build-linux-x86_64-post-merge
-    runs-on: ubuntu-latest
+    runs-on: nixos
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description

The rustdoc ci action uses nix and needs to be executed no nixos

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
