### PR TITLE
ci: drop rust-cache from deploy-rustdoc action

### DIFF
--- a/.github/actions/deploy/deploy-rustdoc/action.yml
+++ b/.github/actions/deploy/deploy-rustdoc/action.yml
@@ -21,9 +21,6 @@ runs:
         ssh-add - <<< "${{ inputs.ssh_key }}"
       shell: bash
 
-    - name: Rust cache
-      uses: Swatinem/rust-cache@v2.6.2
-
     - name: Build rustdocs
       run: nix develop .#nightly -c gen-cargo-docs
       shell: bash


### PR DESCRIPTION
# Description

Drop the rust cache from the deploy-rustdoc action

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
