### PR TITLE
Governed map commands return {} instead of null

### DIFF
--- a/toolkit/smart-contracts/commands/src/governed_map.rs
+++ b/toolkit/smart-contracts/commands/src/governed_map.rs
@@ -64,8 +64,8 @@ impl InsertCmd {
 			&client,
 			&self.common_arguments.retries(),
 		)
-		.await?;
-		Ok(serde_json::json!(result))
+		.await;
+		print_result_json(result)
 	}
 }
 
@@ -103,8 +103,8 @@ impl UpdateCmd {
 			&client,
 			&self.common_arguments.retries(),
 		)
-		.await?;
-		Ok(serde_json::json!(result))
+		.await;
+		print_result_json(result)
 	}
 }
 
@@ -133,8 +133,8 @@ impl RemoveCmd {
 			&client,
 			&self.common_arguments.retries(),
 		)
-		.await?;
-		Ok(serde_json::json!(result))
+		.await;
+		print_result_json(result)
 	}
 }
 
@@ -177,5 +177,15 @@ impl GetCmd {
 		};
 
 		Ok(json!(value.to_hex_string()).into())
+	}
+}
+
+fn print_result_json(
+	result: anyhow::Result<Option<crate::MultiSigSmartContractResult>>,
+) -> crate::SubCmdResult {
+	match result {
+		Err(err) => Err(err)?,
+		Ok(Some(res)) => Ok(json!(res)),
+		Ok(None) => Ok(json!({})),
 	}
 }


### PR DESCRIPTION
# Description

This PR changes the output of governed map commands:
- When no TX is submitted we return `{}` instead of `null`

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
