### PR TITLE
feat: add block producer fees pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6376,6 +6376,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-block-producer-fees"
+version = "1.6.0"
+dependencies = [
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-consensus-slots",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-block-producer-metadata"
 version = "1.6.0"
 dependencies = [
@@ -7049,6 +7064,7 @@ dependencies = [
  "pallet-aura",
  "pallet-balances",
  "pallet-block-participation",
+ "pallet-block-producer-fees",
  "pallet-block-producer-metadata",
  "pallet-block-production-log",
  "pallet-governed-map",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ members = [
 	"toolkit/address-associations/pallet",
 	"toolkit/block-participation/pallet",
 	"toolkit/block-participation/primitives",
+	"toolkit/block-producer-fees/pallet",
 	"toolkit/block-producer-metadata/pallet",
 	"toolkit/block-producer-metadata/primitives",
 	"toolkit/block-producer-metadata/rpc",
@@ -219,6 +220,7 @@ sc-transaction-pool = { default-features = false, git = "https://github.com/pari
 sc-transaction-pool-api = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
 sc-offchain = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
 sp-api = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
+sp-arithmetic = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
 sp-application-crypto = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
 sp-block-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
 sp-blockchain = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2503" }
@@ -304,6 +306,9 @@ pallet-block-production-log = { path = "toolkit/block-production-log/pallet", de
 sp-block-production-log = { path = "toolkit/block-production-log/primitives", default-features = false }
 pallet-block-participation = { path = "toolkit/block-participation/pallet", default-features = false }
 sp-block-participation = { path = "toolkit/block-participation/primitives", default-features = false }
+
+# block producer fees
+pallet-block-producer-fees = { path = "toolkit/block-producer-fees/pallet", default-features = false }
 
 # block producer metadata
 pallet-block-producer-metadata = { path = "toolkit/block-producer-metadata/pallet", default-features = false }

--- a/changelog.md
+++ b/changelog.md
@@ -44,6 +44,7 @@ the feature `pallet-session-compat`.
 * `governance init` when genesis utxo had a script attached, then transaction fee was sometimes calculated incorrectly
 
 ## Added
+* `pallet-block-producer-fees` - with settings for the rewards payout logic
 * `governed-map remove` command, that removes a key-value pair from the governed map
 * `governed-map insert` command, that inserts a key-value pair into the governed map
 * `ariadne_v2` selection algorithm that selects committee respecting D-parameter and candidates

--- a/demo/runtime/Cargo.toml
+++ b/demo/runtime/Cargo.toml
@@ -87,6 +87,7 @@ pallet-block-participation = { workspace = true }
 sp-block-participation = { workspace = true }
 pallet-governed-map = { workspace = true }
 sp-governed-map = { workspace = true }
+pallet-block-producer-fees = { workspace = true }
 
 [dev-dependencies]
 sp-io = { workspace = true }

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -21,7 +21,7 @@ use frame_support::inherent::ProvideInherent;
 use frame_support::weights::constants::RocksDbWeight as RuntimeDbWeight;
 use frame_support::{
 	BoundedVec, construct_runtime, parameter_types,
-	traits::{ConstBool, ConstU8, ConstU32, ConstU64, ConstU128},
+	traits::{ConstBool, ConstU8, ConstU16, ConstU32, ConstU64, ConstU128},
 	weights::{IdentityFee, constants::WEIGHT_REF_TIME_PER_SECOND},
 };
 use opaque::SessionKeys;
@@ -553,6 +553,17 @@ impl pallet_address_associations::Config for Runtime {
 	type OnNewAssociation = TestHelperPallet;
 }
 
+impl pallet_block_producer_fees::Config for Runtime {
+	type WeightInfo = ();
+
+	type HistoricalChangesPerProducer = ConstU16<5>;
+
+	fn current_slot() -> sp_consensus_slots::Slot {
+		let slot: u64 = pallet_aura::CurrentSlot::<Runtime>::get().into();
+		sp_consensus_slots::Slot::from(slot)
+	}
+}
+
 impl pallet_block_producer_metadata::Config for Runtime {
 	type WeightInfo = pallet_block_producer_metadata::weights::SubstrateWeight<Runtime>;
 
@@ -621,6 +632,7 @@ construct_runtime!(
 		Sidechain: pallet_sidechain,
 		SessionCommitteeManagement: pallet_session_validator_management,
 		AddressAssociations: pallet_address_associations,
+		BlockProducerFees: pallet_block_producer_fees,
 		BlockProducerMetadata: pallet_block_producer_metadata,
 		BlockProductionLog: pallet_block_production_log,
 		BlockParticipation: pallet_block_participation,

--- a/toolkit/block-participation/pallet/src/mock.rs
+++ b/toolkit/block-participation/pallet/src/mock.rs
@@ -25,9 +25,6 @@ pub mod mock_pallet {
 	pub trait Config: frame_system::Config {}
 
 	#[pallet::storage]
-	pub type CurrentSlot<T: Config> = StorageValue<_, Slot, ValueQuery>;
-
-	#[pallet::storage]
 	pub type SlotToPay<T: Config> = StorageMap<_, Twox64Concat, Slot, Slot, OptionQuery>;
 
 	#[pallet::storage]

--- a/toolkit/block-producer-fees/pallet/Cargo.toml
+++ b/toolkit/block-producer-fees/pallet/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "pallet-block-producer-fees"
+version.workspace = true
+license = "Apache-2.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+frame-support = { workspace = true }
+frame-system = { workspace = true }
+parity-scale-codec = { workspace = true }
+scale-info = { workspace = true }
+sp-consensus-slots = { workspace = true }
+sp-std = { workspace = true }
+
+[dev-dependencies]
+sp-core = { workspace = true }
+sp-io = { workspace = true }
+sp-runtime = { workspace = true }
+
+[features]
+default = ["std"]
+std = [
+	"frame-support/std",
+	"frame-system/std",
+	"parity-scale-codec/std",
+	"scale-info/std",
+	"sp-std/std",
+]

--- a/toolkit/block-producer-fees/pallet/src/lib.rs
+++ b/toolkit/block-producer-fees/pallet/src/lib.rs
@@ -1,4 +1,4 @@
-//! Pallet to store Block Producer Fees settings that are important in context of rewards payments.
+//! Pallet to store Block Producer Fees settings that are relevant to rewards payments.
 //!
 //! Margin fee is percent of block rewards that will be paid to the block producer before
 //! distributing the rest of rewards to his stakers. Precision of the margin fee setting is bounded
@@ -79,7 +79,6 @@ pub mod pallet {
 					let _ = fees_log.pop_back();
 				}
 				fees_log.push_front((T::current_slot(), fee_numerator));
-				fees_log.clone()
 			});
 			Ok(())
 		}

--- a/toolkit/block-producer-fees/pallet/src/lib.rs
+++ b/toolkit/block-producer-fees/pallet/src/lib.rs
@@ -1,0 +1,116 @@
+//! Pallet to store Block Producer Fees settings that are important in context of rewards payments.
+//!
+//! Margin fee is percent of block rewards that will be paid to the block producer before
+//! distributing the rest of rewards to his stakers. Precision of the margin fee setting is bounded
+//! to 1/100 of a percent.
+//!
+//! The margin fees are stored together with the slot at which change occurred, so this data can be
+//! exposed to rewards calculation.
+//!
+//! Log of changes per account is bounded. The oldest entries are dropped when new ones are added.
+//! Intention is to discourage users from too frequent changes and there is an assumption
+//! that rewards calculation algorithm will account for it.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+
+#[cfg(test)]
+mod mock;
+#[cfg(test)]
+mod tests;
+pub mod weights;
+
+pub use pallet::*;
+pub use weights::WeightInfo;
+
+#[frame_support::pallet]
+pub mod pallet {
+	use super::*;
+	use frame_support::pallet_prelude::*;
+	use frame_system::pallet_prelude::*;
+	use sp_consensus_slots::Slot;
+	use sp_std::collections::vec_deque::VecDeque;
+
+	/// Current version of the pallet
+	pub const PALLET_VERSION: u32 = 1;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {
+		/// Maximum number of past changes per one block producer kept in the storage.
+		type HistoricalChangesPerProducer: Get<u16>;
+
+		/// Weight information on extrinsic in the pallet. For convenience weights in [weights] module can be used.
+		type WeightInfo: WeightInfo;
+
+		/// The slot number of the current block.
+		fn current_slot() -> Slot;
+	}
+
+	// Margin Fee precision is 0.01 of a percent, so use 1/10000 as unit.
+	type PerTenThousands = u16;
+
+	type FeeChange = (Slot, PerTenThousands);
+
+	/// Stores bounded amount of fee changes per
+	#[pallet::storage]
+	#[pallet::unbounded]
+	pub type FeesChanges<T: Config> = StorageMap<
+		Hasher = Twox64Concat,
+		Key = T::AccountId,
+		Value = VecDeque<FeeChange>,
+		QueryKind = ValueQuery,
+	>;
+
+	#[pallet::call]
+	impl<T: Config> Pallet<T> {
+		/// Sets the margin fee of a caller. Margin fee is (fee numerator / 10000).
+		#[pallet::call_index(0)]
+		#[pallet::weight((T::WeightInfo::set_fee(), DispatchClass::Normal))]
+		pub fn set_fee(origin: OriginFor<T>, fee_numerator: PerTenThousands) -> DispatchResult {
+			let account_id = ensure_signed(origin)?;
+			if fee_numerator > 10000 {
+				return Err(DispatchError::Other("fee numerator must be in range from 0 to 10000"));
+			}
+			FeesChanges::<T>::mutate(account_id, |fees_log| {
+				if fees_log.len() > T::HistoricalChangesPerProducer::get().into() {
+					let _ = fees_log.pop_back();
+				}
+				fees_log.push_front((T::current_slot(), fee_numerator));
+				fees_log.clone()
+			});
+			Ok(())
+		}
+	}
+
+	impl<T: Config> Pallet<T> {
+		/// Returns the current pallet version.
+		pub fn get_version() -> u32 {
+			PALLET_VERSION
+		}
+
+		/// Retrieves all stored block producer fees settings.
+		pub fn get_all() -> impl Iterator<Item = (T::AccountId, VecDeque<FeeChange>)> {
+			FeesChanges::<T>::iter()
+		}
+
+		/// Retrieves the latest fee settings for all accounts.
+		pub fn get_all_latest() -> impl Iterator<Item = (T::AccountId, FeeChange)> {
+			Self::get_all().map(|(account_id, changes)| {
+				(account_id, *changes.front().expect("There are no empty collections in storage"))
+			})
+		}
+
+		/// Retrieves block producers fees settings.
+		pub fn get(id: T::AccountId) -> VecDeque<FeeChange> {
+			FeesChanges::<T>::get(id)
+		}
+
+		/// Gets the latest fee setting for the given account.
+		pub fn get_latest(id: T::AccountId) -> Option<FeeChange> {
+			FeesChanges::<T>::get(id).front().cloned()
+		}
+	}
+}

--- a/toolkit/block-producer-fees/pallet/src/mock.rs
+++ b/toolkit/block-producer-fees/pallet/src/mock.rs
@@ -1,0 +1,84 @@
+use frame_support::{
+	construct_runtime,
+	pallet_prelude::*,
+	traits::{ConstU16, ConstU32, ConstU64, Everything},
+};
+use frame_system::mocking::MockBlock;
+use sp_consensus_slots::Slot;
+use sp_io::TestExternalities;
+use sp_runtime::{
+	traits::{BlakeTwo256, IdentityLookup},
+	AccountId32, BuildStorage,
+};
+
+#[frame_support::pallet]
+pub mod mock_pallet {
+	use super::*;
+
+	#[pallet::pallet]
+	pub struct Pallet<T>(_);
+
+	#[pallet::config]
+	pub trait Config: frame_system::Config {}
+
+	#[pallet::storage]
+	pub type CurrentSlot<T: Config> = StorageValue<_, Slot, ValueQuery>;
+}
+
+construct_runtime! {
+	pub enum Test {
+		System: frame_system,
+		BlockProducerFees: crate::pallet,
+		Mock: crate::mock::mock_pallet
+	}
+}
+
+impl mock_pallet::Config for Test {}
+
+impl frame_system::Config for Test {
+	type BaseCallFilter = Everything;
+	type BlockWeights = ();
+	type BlockLength = ();
+	type DbWeight = ();
+	type RuntimeOrigin = RuntimeOrigin;
+	type RuntimeCall = RuntimeCall;
+	type Hash = sp_core::H256;
+	type Hashing = BlakeTwo256;
+	type AccountId = AccountId32;
+	type Lookup = IdentityLookup<Self::AccountId>;
+	type RuntimeEvent = RuntimeEvent;
+	type BlockHashCount = ConstU64<250>;
+	type Version = ();
+	type PalletInfo = PalletInfo;
+	type AccountData = ();
+	type OnNewAccount = ();
+	type OnKilledAccount = ();
+	type SystemWeightInfo = ();
+	type ExtensionsWeightInfo = ();
+	type SS58Prefix = ConstU16<42>;
+	type OnSetCode = ();
+	type MaxConsumers = ConstU32<16>;
+	type Block = MockBlock<Test>;
+	type Nonce = u64;
+	type RuntimeTask = RuntimeTask;
+	type SingleBlockMigrations = ();
+	type MultiBlockMigrator = ();
+	type PreInherents = ();
+	type PostInherents = ();
+	type PostTransactions = ();
+}
+
+impl crate::pallet::Config for Test {
+	type WeightInfo = ();
+
+	// Stores the current and one historical, so up to two values
+	type HistoricalChangesPerProducer = ConstU16<1>;
+
+	fn current_slot() -> Slot {
+		mock_pallet::CurrentSlot::<Test>::get()
+	}
+}
+
+pub fn new_test_ext() -> TestExternalities {
+	frame_system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
+}

--- a/toolkit/block-producer-fees/pallet/src/mock.rs
+++ b/toolkit/block-producer-fees/pallet/src/mock.rs
@@ -7,8 +7,8 @@ use frame_system::mocking::MockBlock;
 use sp_consensus_slots::Slot;
 use sp_io::TestExternalities;
 use sp_runtime::{
-	traits::{BlakeTwo256, IdentityLookup},
 	AccountId32, BuildStorage,
+	traits::{BlakeTwo256, IdentityLookup},
 };
 
 #[frame_support::pallet]
@@ -71,7 +71,7 @@ impl frame_system::Config for Test {
 impl crate::pallet::Config for Test {
 	type WeightInfo = ();
 
-	// Stores the current and one historical, so up to two values
+	// Stores the current and one historical value, two in total
 	type HistoricalChangesPerProducer = ConstU16<1>;
 
 	fn current_slot() -> Slot {

--- a/toolkit/block-producer-fees/pallet/src/tests.rs
+++ b/toolkit/block-producer-fees/pallet/src/tests.rs
@@ -1,0 +1,76 @@
+use super::*;
+use frame_support::{assert_err, assert_ok};
+use frame_system::pallet_prelude::OriginFor;
+use mock::*;
+use sp_consensus_slots::Slot;
+use sp_runtime::{AccountId32, DispatchError};
+use sp_std::collections::vec_deque::VecDeque;
+
+#[test]
+fn stores_the_configured_number_of_fee_changes() {
+	new_test_ext().execute_with(|| {
+		let alice = AccountId32::new([1u8; 32]);
+		let bob = AccountId32::new([2u8; 32]);
+		let charlie = AccountId32::new([3u8; 32]);
+
+		mock_pallet::CurrentSlot::<Test>::set(Slot::from(1));
+		assert_ok!(Pallet::<Test>::set_fee(OriginFor::<Test>::signed(alice.clone()), 101));
+		assert_ok!(Pallet::<Test>::set_fee(OriginFor::<Test>::signed(bob.clone()), 201));
+
+		mock_pallet::CurrentSlot::<Test>::set(Slot::from(2));
+		assert_ok!(Pallet::<Test>::set_fee(OriginFor::<Test>::signed(alice.clone()), 102));
+
+		mock_pallet::CurrentSlot::<Test>::set(Slot::from(3));
+		// Setting third fee causes drop of the first one
+		assert_ok!(Pallet::<Test>::set_fee(OriginFor::<Test>::signed(alice.clone()), 103));
+
+		let alice_entry_2 = (Slot::from(2), 102);
+		let alice_entry_3 = (Slot::from(3), 103);
+		let alice_entries = VecDeque::from(vec![alice_entry_3, alice_entry_2]);
+		let bob_entry_1 = (Slot::from(1), 201);
+		let bob_entries = VecDeque::from(vec![bob_entry_1]);
+
+		assert_eq!(Pallet::<Test>::get(alice.clone()), alice_entries);
+		assert_eq!(Pallet::<Test>::get_latest(alice.clone()), Some(alice_entry_3));
+
+		assert_eq!(Pallet::<Test>::get(bob.clone()), bob_entries);
+		assert_eq!(Pallet::<Test>::get_latest(bob.clone()), Some(bob_entry_1));
+
+		assert_eq!(Pallet::<Test>::get(charlie.clone()), VecDeque::new());
+		assert_eq!(Pallet::<Test>::get_latest(charlie.clone()), None);
+
+		assert_eq!(
+			Pallet::<Test>::get_all().collect::<Vec<_>>(),
+			vec![(alice.clone(), alice_entries), (bob.clone(), bob_entries)]
+		);
+
+		assert_eq!(
+			Pallet::<Test>::get_all_latest().collect::<Vec<_>>(),
+			vec![(alice.clone(), alice_entry_3), (bob.clone(), bob_entry_1)]
+		);
+	})
+}
+
+#[test]
+fn accepts_only_signed_origin() {
+	new_test_ext().execute_with(|| {
+		assert_err!(
+			Pallet::<Test>::set_fee(OriginFor::<Test>::none(), 1),
+			DispatchError::BadOrigin
+		);
+		assert_err!(
+			Pallet::<Test>::set_fee(OriginFor::<Test>::root(), 1),
+			DispatchError::BadOrigin
+		);
+	})
+}
+
+#[test]
+fn rejects_fee_over_10000() {
+	new_test_ext().execute_with(|| {
+		assert_err!(
+			Pallet::<Test>::set_fee(OriginFor::<Test>::signed(AccountId32::new([0u8; 32])), 10001),
+			DispatchError::Other("fee numerator must be in range from 0 to 10000")
+		);
+	})
+}

--- a/toolkit/block-producer-fees/pallet/src/weights.rs
+++ b/toolkit/block-producer-fees/pallet/src/weights.rs
@@ -3,7 +3,7 @@ use frame_support::weights::Weight;
 
 /// Weight functions needed for the pallet.
 pub trait WeightInfo {
-	/// Yes
+	/// Weight of set_fee
 	fn set_fee() -> Weight;
 }
 

--- a/toolkit/block-producer-fees/pallet/src/weights.rs
+++ b/toolkit/block-producer-fees/pallet/src/weights.rs
@@ -1,0 +1,14 @@
+//! Weights for runtime calls, output of benchmarking
+use frame_support::weights::Weight;
+
+/// Weight functions needed for the pallet.
+pub trait WeightInfo {
+	/// Yes
+	fn set_fee() -> Weight;
+}
+
+impl WeightInfo for () {
+	fn set_fee() -> Weight {
+		Weight::zero()
+	}
+}

--- a/toolkit/block-producer-fees/readme.md
+++ b/toolkit/block-producer-fees/readme.md
@@ -1,0 +1,3 @@
+# Block Producer Fees pallet
+
+Stores limited number of fee changes per block producer.


### PR DESCRIPTION
# Description

Adds `block-producer-fees` pallet.

Requirements were trimmed down to one setting for margin fee, that should be in range between 0% and 100%, with precision of 1/100th of a percent.

The configurable number of historical items and storing the slot of a change is added to satisfy requirements:
* "Changes to the fee in epoch n MUST take effect in epoch n+1" - rewards will be able to use value that is not the latest
* "There must be a mechanism that allows for delegators to be notified of a change in margin fee"

RPC and benchmarking will be done separately.

Ticket with requirements: https://input-output.atlassian.net/browse/ETCM-9326

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
