### PR TITLE
change: Remove asset name from governed map scripts

### DIFF
--- a/toolkit/data-sources/db-sync/src/governed_map/mod.rs
+++ b/toolkit/data-sources/db-sync/src/governed_map/mod.rs
@@ -1,6 +1,7 @@
 use crate::DataSourceError::ExpectedDataNotFound;
 use crate::Result;
 use crate::{metrics::McFollowerMetrics, observed_async_trait};
+use db_sync_sqlx::Asset;
 use derive_new::new;
 use log::warn;
 use partner_chains_plutus_data::governed_map::GovernedMapDatum;
@@ -70,7 +71,7 @@ impl GovernedMapDataSourceImpl {
 			&self.pool,
 			&scripts.validator_address.into(),
 			block.block_no,
-			scripts.asset.into(),
+			Asset::new(scripts.asset_policy_id),
 		)
 		.await?;
 

--- a/toolkit/data-sources/db-sync/src/governed_map/tests.rs
+++ b/toolkit/data-sources/db-sync/src/governed_map/tests.rs
@@ -72,10 +72,7 @@ async fn test_governed_map_upsert(pool: PgPool) {
 
 fn scripts() -> MainChainScriptsV1 {
 	MainChainScriptsV1 {
-		asset: AssetId {
-			policy_id: PolicyId(hex!("500000000000000000000000000000000000434845434b504f494e69")),
-			asset_name: AssetName::empty(),
-		},
+		asset_policy_id: PolicyId(hex!("500000000000000000000000000000000000434845434b504f494e69")),
 		validator_address: MainchainAddress::from_str("governed_map_test_address").unwrap(),
 	}
 }

--- a/toolkit/governed-map/primitives/src/lib.rs
+++ b/toolkit/governed-map/primitives/src/lib.rs
@@ -125,8 +125,8 @@ pub const INHERENT_IDENTIFIER: InherentIdentifier = *b"govrnmap";
 pub struct MainChainScriptsV1 {
 	/// Cardano address of the Governed Map validator, at which UTXOs containig key-value pairs are located
 	pub validator_address: MainchainAddress,
-	/// Asset used to mark the UTXOs containing the Governed Map's key-value pairs
-	pub asset: AssetId,
+	/// Policy of the asset used to mark the UTXOs containing the Governed Map's key-value pairs
+	pub asset_policy_id: PolicyId,
 }
 
 /// Type describing a change made to a single key-value pair in the Governed Map.


### PR DESCRIPTION
# Description

The asset name is currently hard-coded to be empty, so this PR removes it from the scripts configuration to avoid confusion.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
