### PR TITLE
change: ETCM-9800 track and handle initialization of the governed map pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10694,6 +10694,7 @@ dependencies = [
  "async-trait",
  "log",
  "parity-scale-codec",
+ "pretty_assertions",
  "scale-info",
  "serde",
  "sidechain-domain",

--- a/demo/node/src/data_sources.rs
+++ b/demo/node/src/data_sources.rs
@@ -63,7 +63,7 @@ pub fn create_mock_data_sources()
 		authority_selection: Arc::new(AuthoritySelectionDataSourceMock::new_from_env()?),
 		native_token: Arc::new(NativeTokenDataSourceMock::new()),
 		block_participation: Arc::new(StakeDistributionDataSourceMock::new()),
-		governed_map: Arc::new(GovernedMapDataSourceMock::new([].into())),
+		governed_map: Arc::new(GovernedMapDataSourceMock::default()),
 	})
 }
 

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -8,6 +8,7 @@ extern crate frame_benchmarking;
 
 extern crate alloc;
 
+use alloc::collections::BTreeMap;
 use alloc::string::String;
 use authority_selection_inherents::CommitteeMember;
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
@@ -33,7 +34,7 @@ use pallet_transaction_payment::{ConstFeeMultiplier, FungibleAdapter, Multiplier
 use parity_scale_codec::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use scale_info::TypeInfo;
 use serde::{Deserialize, Serialize};
-use sidechain_domain::byte_string::{BoundedString, SizedByteString};
+use sidechain_domain::byte_string::{BoundedString, ByteString, SizedByteString};
 use sidechain_domain::{
 	CrossChainPublicKey, DelegatorKey, MainchainKeyHash, PermissionedCandidateData,
 	RegistrationData, ScEpochNumber, ScSlotNumber, StakeDelegation, StakePoolPublicKey, UtxoId,
@@ -1071,6 +1072,12 @@ impl_runtime_apis! {
 	}
 
 	impl sp_governed_map::GovernedMapIDPApi<Block> for Runtime {
+		fn is_initialized() -> bool {
+			GovernedMap::is_initialized()
+		}
+		fn get_current_state() -> BTreeMap<String, ByteString> {
+			GovernedMap::get_all_key_value_pairs_unbounded().collect()
+		}
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
 			GovernedMap::get_main_chain_scripts()
 		}

--- a/toolkit/data-sources/mock/src/governed_map.rs
+++ b/toolkit/data-sources/mock/src/governed_map.rs
@@ -7,11 +7,15 @@ use sp_governed_map::{GovernedMapDataSource, MainChainScriptsV1};
 #[derive(Debug, Default)]
 pub struct GovernedMapDataSourceMock {
 	changes: Vec<(String, Option<ByteString>)>,
+	data: BTreeMap<String, ByteString>,
 }
 
 impl GovernedMapDataSourceMock {
-	pub fn new(changes: Vec<(String, Option<ByteString>)>) -> Self {
-		Self { changes }
+	pub fn new(
+		changes: Vec<(String, Option<ByteString>)>,
+		data: BTreeMap<String, ByteString>,
+	) -> Self {
+		Self { changes, data }
 	}
 }
 
@@ -24,5 +28,13 @@ impl GovernedMapDataSource for GovernedMapDataSourceMock {
 		_scripts: MainChainScriptsV1,
 	) -> Result<Vec<(String, Option<ByteString>)>> {
 		Ok(self.changes.clone())
+	}
+
+	async fn get_state_at_block(
+		&self,
+		_mc_block: McBlockHash,
+		_main_chain_scripts: MainChainScriptsV1,
+	) -> Result<BTreeMap<String, ByteString>> {
+		Ok(self.data.clone())
 	}
 }

--- a/toolkit/governed-map/pallet/src/benchmarking.rs
+++ b/toolkit/governed-map/pallet/src/benchmarking.rs
@@ -42,6 +42,7 @@
 //! from Polkadot SDK.
 
 use super::*;
+use alloc::collections::BTreeMap;
 use alloc::format;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;
@@ -51,7 +52,10 @@ use sidechain_domain::bounded_str;
 pub trait BenchmarkHelper<T: crate::Config> {
 	/// Returns a list of changes to the Governed Map parameters of length `length`.
 	fn changes(length: u32) -> crate::Changes<T> {
-		BoundedVec::truncate_from((0..length).map(|i| (Self::key(i), Self::value(i))).collect())
+		BoundedBTreeMap::try_from(
+			(0..length).map(|i| (Self::key(i), Self::value(i))).collect::<BTreeMap<_, _>>(),
+		)
+		.unwrap()
 	}
 
 	/// Returns `index`th mock Governance Map key

--- a/toolkit/governed-map/primitives/Cargo.toml
+++ b/toolkit/governed-map/primitives/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
+pretty_assertions = { workspace = true }
 
 [features]
 default = ["std"]

--- a/toolkit/governed-map/primitives/src/lib.rs
+++ b/toolkit/governed-map/primitives/src/lib.rs
@@ -129,17 +129,6 @@ pub struct MainChainScriptsV1 {
 	pub asset_policy_id: PolicyId,
 }
 
-/// Type describing a change made to a single key-value pair in the Governed Map.
-#[derive(Decode, Encode, TypeInfo, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
-pub struct GovernedMapChangeV1 {
-	/// Key of the entry being modified
-	pub key: String,
-	/// New value under `key`
-	/// * [None] value indicates deletion
-	/// * [Some] value indicates insertion or update
-	pub new_value: Option<ByteString>,
-}
-
 /// Error type returned when creating or validating the Governed Map inherent
 #[derive(Decode, Encode, Debug, PartialEq)]
 #[cfg_attr(feature = "std", derive(thiserror::Error))]
@@ -231,7 +220,13 @@ impl_tuple_on_governed_mapping_change!(A, B, C);
 impl_tuple_on_governed_mapping_change!(A, B, C, D);
 impl_tuple_on_governed_mapping_change!(A, B, C, D, E);
 
-type ChangesV1 = Vec<GovernedMapChangeV1>;
+/// Inherent data produced by the Governed Map observation
+///
+/// List of changes that occured since last observation
+/// Elements are key-value pairs where:
+/// - [None] value indicates deletion
+/// - [Some] value indicates insertion or update
+pub type GovernedMapInherentDataV1 = BTreeMap<String, Option<ByteString>>;
 
 /// Inherent data provider providing the list of Governed Map changes that occurred since previous observation.
 #[cfg(feature = "std")]
@@ -241,8 +236,8 @@ pub enum GovernedMapInherentDataProvider {
 	Inert,
 	/// Active variant that will provide data.
 	ActiveV1 {
-		/// List of changes to the Governed Map that occurred since previous observation
-		changes: ChangesV1,
+		/// Inherent data provided by this IDP
+		data: GovernedMapInherentDataV1,
 	},
 }
 
@@ -254,8 +249,8 @@ impl sp_inherents::InherentDataProvider for GovernedMapInherentDataProvider {
 		inherent_data: &mut sp_inherents::InherentData,
 	) -> Result<(), sp_inherents::Error> {
 		match self {
-			Self::ActiveV1 { changes } if !changes.is_empty() => {
-				inherent_data.put_data(INHERENT_IDENTIFIER, &changes)?;
+			Self::ActiveV1 { data } => {
+				inherent_data.put_data(INHERENT_IDENTIFIER, &data)?;
 			},
 			_ => {},
 		}
@@ -280,6 +275,13 @@ impl sp_inherents::InherentDataProvider for GovernedMapInherentDataProvider {
 #[cfg(feature = "std")]
 #[async_trait::async_trait]
 pub trait GovernedMapDataSource {
+	/// Returns all key-value mappings stored in the Governed Map on Cardano after execution of `mc_block`.
+	async fn get_state_at_block(
+		&self,
+		mc_block: McBlockHash,
+		main_chain_scripts: MainChainScriptsV1,
+	) -> Result<BTreeMap<String, ByteString>, Box<dyn std::error::Error + Send + Sync>>;
+
 	/// Queries all changes that occurred in the mappings of the Governed Map on Cardano in the given range of blocks.
 	///
 	/// # Arguments:
@@ -372,25 +374,43 @@ impl GovernedMapInherentDataProvider {
 			return Ok(Self::Inert);
 		};
 
-		let current_entries = data_source
-			.get_mapping_changes(parent_mc_hash, mc_hash, main_chain_script)
-			.await
-			.map_err(InherentProviderCreationError::DataSourceError)?;
+		if api.is_initialized(parent_hash)? {
+			let raw_changes = data_source
+				.get_mapping_changes(parent_mc_hash, mc_hash, main_chain_script)
+				.await
+				.map_err(InherentProviderCreationError::DataSourceError)?;
 
-		let mut changes: ChangesV1 = ChangesV1::new();
+			let mut changes = GovernedMapInherentDataV1::new();
 
-		for (key, value) in current_entries.into_iter() {
-			let key = key.into();
-			let change = match value {
-				None => GovernedMapChangeV1 { key, new_value: None },
-				Some(value) => GovernedMapChangeV1 { key, new_value: Some(value.into()) },
-			};
-			changes.push(change);
+			for (key, value) in raw_changes.into_iter() {
+				changes.insert(key, value);
+			}
+
+			Ok(Self::ActiveV1 { data: changes })
+		} else {
+			let new_state = data_source
+				.get_state_at_block(mc_hash, main_chain_script)
+				.await
+				.map_err(InherentProviderCreationError::DataSourceError)?;
+
+			let current_state = api.get_current_state(parent_hash)?;
+
+			let mut changes = GovernedMapInherentDataV1::new();
+
+			for key in current_state.keys() {
+				if !new_state.contains_key(key) {
+					changes.insert(key.clone(), None);
+				}
+			}
+
+			for (key, value) in new_state.into_iter() {
+				if current_state.get(&key) != Some(&value) {
+					changes.insert(key, Some(value));
+				}
+			}
+
+			Ok(Self::ActiveV1 { data: changes })
 		}
-
-		changes.sort();
-
-		Ok(Self::ActiveV1 { changes })
 	}
 }
 
@@ -399,6 +419,10 @@ sp_api::decl_runtime_apis! {
 	#[api_version(1)]
 	pub trait GovernedMapIDPApi
 	{
+		/// Returns initialization state of the pallet
+		fn is_initialized() -> bool;
+		/// Returns all mappings currently stored in the pallet
+		fn get_current_state() -> BTreeMap<String, ByteString>;
 		/// Returns the main chain scripts currently set in the pallet or [None] otherwise
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1>;
 		/// Returns the current version of the pallet, 1-based.

--- a/toolkit/governed-map/primitives/src/mock.rs
+++ b/toolkit/governed-map/primitives/src/mock.rs
@@ -3,8 +3,10 @@ use sidechain_domain::byte_string::ByteString;
 use sp_api::ProvideRuntimeApi;
 
 #[cfg(feature = "std")]
+#[derive(Debug, Default)]
 pub struct MockGovernedMapDataSource {
 	pub changes: Vec<(String, Option<ByteString>)>,
+	pub data: BTreeMap<String, ByteString>,
 }
 
 #[cfg(feature = "std")]
@@ -18,6 +20,14 @@ impl GovernedMapDataSource for MockGovernedMapDataSource {
 	) -> Result<Vec<(String, Option<ByteString>)>, Box<dyn std::error::Error + Send + Sync>> {
 		Ok(self.changes.clone())
 	}
+
+	async fn get_state_at_block(
+		&self,
+		_mc_block: McBlockHash,
+		_main_chain_scripts: MainChainScriptsV1,
+	) -> Result<BTreeMap<String, ByteString>, Box<dyn std::error::Error + Send + Sync>> {
+		Ok(self.data.clone())
+	}
 }
 
 pub(crate) type BlockHash = sp_runtime::traits::BlakeTwo256;
@@ -27,7 +37,23 @@ pub(crate) type Block = sp_runtime::generic::Block<
 >;
 
 #[derive(Clone, Default)]
-pub(crate) struct TestApiV1;
+pub(crate) struct TestApiV1 {
+	pub(crate) initialized: bool,
+	pub(crate) current_state: BTreeMap<String, ByteString>,
+}
+
+#[cfg(test)]
+impl TestApiV1 {
+	pub(crate) fn initialized() -> Self {
+		Self { initialized: true, ..Default::default() }
+	}
+	pub(crate) fn uninitialized() -> Self {
+		Self { initialized: false, ..Default::default() }
+	}
+	pub(crate) fn with_current_state(self, current_state: BTreeMap<String, ByteString>) -> Self {
+		Self { current_state, ..self }
+	}
+}
 
 impl ProvideRuntimeApi<Block> for TestApiV1 {
 	type Api = Self;
@@ -39,6 +65,12 @@ impl ProvideRuntimeApi<Block> for TestApiV1 {
 
 sp_api::mock_impl_runtime_apis! {
 	impl GovernedMapIDPApi<Block> for TestApiV1 {
+		fn is_initialized() -> bool {
+			self.initialized
+		}
+		fn get_current_state() -> BTreeMap<String, ByteString> {
+			self.current_state.clone()
+		}
 		fn get_main_chain_scripts() -> Option<MainChainScriptsV1> {
 			Some(Default::default())
 		}

--- a/toolkit/governed-map/primitives/src/tests.rs
+++ b/toolkit/governed-map/primitives/src/tests.rs
@@ -1,23 +1,58 @@
 #![allow(missing_docs)]
 
-impl crate::GovernedMapChangeV1 {
-	pub fn upsert(key: &str, new_value: &[u8]) -> Self {
-		Self { key: key.into(), new_value: Some(new_value.into()) }
-	}
-	pub fn delete(key: &str) -> Self {
-		Self { key: key.into(), new_value: None }
-	}
-}
-
 mod idp_v1 {
 	use crate::{GovernedMapInherentDataProvider, mock::*, *};
+	use pretty_assertions::assert_eq;
 	use sidechain_domain::McBlockHash;
 	use sp_inherents::{InherentData, InherentDataProvider};
-	use sp_runtime::traits::Block as BlockT;
+	use sp_runtime::{bounded_vec, traits::Block as BlockT};
+
+	#[tokio::test]
+	async fn calculates_changes_and_returns_active_when_pallet_needs_initializing() {
+		let api = TestApiV1::uninitialized().with_current_state(
+			[
+				("deleted_key".into(), vec![1, 2, 3, 4].into()),
+				("unchanged_key".into(), vec![1, 2, 3].into()),
+			]
+			.into(),
+		);
+		let data_source = MockGovernedMapDataSource {
+			data: [
+				("unchanged_key".into(), vec![1, 2, 3].into()),
+				("inserted_key_1".into(), vec![1, 2, 3, 4].into()),
+				("inserted_key_2".into(), vec![0, 0, 0, 0].into()),
+			]
+			.into(),
+			..Default::default()
+		};
+
+		let idp = GovernedMapInherentDataProvider::new(
+			&api,
+			<Block as BlockT>::Hash::default(),
+			McBlockHash::default(),
+			Some(McBlockHash::default()),
+			&data_source,
+		)
+		.await
+		.expect("Should succeed");
+
+		let GovernedMapInherentDataProvider::ActiveV1 { data } = idp else {
+			panic!("IDP should be active")
+		};
+
+		let expected_changes = [
+			("deleted_key".into(), None),
+			("inserted_key_1".into(), Some(vec![1, 2, 3, 4].into())),
+			("inserted_key_2".into(), Some(vec![0, 0, 0, 0].into())),
+		]
+		.into();
+
+		assert_eq!(data, expected_changes);
+	}
 
 	#[tokio::test]
 	async fn calculates_changes_and_returns_active_if_non_empty() {
-		let api = TestApiV1;
+		let api = TestApiV1::initialized();
 		let data_source = MockGovernedMapDataSource {
 			changes: vec![
 				("updated_key".into(), Some(vec![63].into())),
@@ -25,6 +60,7 @@ mod idp_v1 {
 				("deleted_key".into(), None),
 			]
 			.into(),
+			..Default::default()
 		};
 
 		let idp = GovernedMapInherentDataProvider::new(
@@ -37,23 +73,24 @@ mod idp_v1 {
 		.await
 		.expect("Should succeed");
 
-		let GovernedMapInherentDataProvider::ActiveV1 { changes } = idp else {
+		let GovernedMapInherentDataProvider::ActiveV1 { data } = idp else {
 			panic!("IDP should be active")
 		};
 
-		let expected_changes = vec![
-			GovernedMapChangeV1::delete("deleted_key"),
-			GovernedMapChangeV1::upsert("inserted_key".into(), &[1, 2, 3]),
-			GovernedMapChangeV1::upsert("updated_key", &[63]),
-		];
+		let expected_changes = [
+			("updated_key".into(), Some(bounded_vec![63])),
+			("inserted_key".into(), Some(bounded_vec![1, 2, 3])),
+			("deleted_key".into(), None),
+		]
+		.into();
 
-		assert_eq!(changes, expected_changes);
+		assert_eq!(data, expected_changes);
 	}
 
 	#[tokio::test]
 	async fn is_empty_when_there_are_no_changes() {
-		let api = TestApiV1;
-		let data_source = MockGovernedMapDataSource { changes: vec![] };
+		let api = TestApiV1::initialized();
+		let data_source = MockGovernedMapDataSource::default();
 
 		let idp = GovernedMapInherentDataProvider::new(
 			&api,
@@ -65,43 +102,29 @@ mod idp_v1 {
 		.await
 		.expect("Should succeed");
 
-		assert_eq!(idp, GovernedMapInherentDataProvider::ActiveV1 { changes: vec![] });
+		assert_eq!(idp, GovernedMapInherentDataProvider::ActiveV1 { data: [].into() });
 	}
 
 	#[tokio::test]
 	async fn provides_inherent_data_when_non_empty() {
-		let changes = vec![
-			GovernedMapChangeV1::delete("deleted_key"),
-			GovernedMapChangeV1::upsert("inserted_key", &[1, 2, 3]),
-			GovernedMapChangeV1::upsert("updated_key", &[63]),
-		];
+		let changes: BTreeMap<_, _> = [
+			("deleted_key".into(), None),
+			("inserted_key".into(), Some(bounded_vec![1, 2, 3])),
+			("updated_key".into(), Some(bounded_vec![63])),
+		]
+		.into();
 
-		let idp = GovernedMapInherentDataProvider::ActiveV1 { changes: changes.clone() };
+		let idp = GovernedMapInherentDataProvider::ActiveV1 { data: changes.clone() };
 
 		let mut inherent_data = InherentData::new();
 		idp.provide_inherent_data(&mut inherent_data).await.unwrap();
 
 		assert_eq!(
 			inherent_data
-				.get_data::<ChangesV1>(&INHERENT_IDENTIFIER)
+				.get_data::<GovernedMapInherentDataV1>(&INHERENT_IDENTIFIER)
 				.expect("Should succeed")
 				.expect("Data should be present"),
 			changes
-		);
-	}
-
-	#[tokio::test]
-	async fn does_not_provide_inherent_data_when_empty() {
-		let idp = GovernedMapInherentDataProvider::ActiveV1 { changes: Vec::new() };
-
-		let mut inherent_data = InherentData::new();
-		idp.provide_inherent_data(&mut inherent_data).await.unwrap();
-
-		assert!(
-			inherent_data
-				.get_data::<ChangesV1>(&INHERENT_IDENTIFIER)
-				.expect("Should succeed")
-				.is_none()
 		);
 	}
 
@@ -114,7 +137,7 @@ mod idp_v1 {
 
 		assert!(
 			inherent_data
-				.get_data::<ChangesV1>(&INHERENT_IDENTIFIER)
+				.get_data::<GovernedMapInherentDataV1>(&INHERENT_IDENTIFIER)
 				.expect("Should succeed")
 				.is_none()
 		);


### PR DESCRIPTION
# Description

* Correctly handles changing main chain scripts by tracking "initialized" state in the pallet and resetting it on script change
* Modifes the IDP to work differently for initialized and uninitialized pallet state:
    * uninitialized: fetches full Governed Map state, compares it with the pallet's storage and provides the changes as inherent data. This is necessary when the pallet needs to be re-initialized after main chain script change, but it already contains some data.
    * initialized: only fetches changes since last MC hash and provides them as inherent data
* Modifies the runtime API to also provide initialization status and current mappings
* Modifies the data source API to provide methods to both 1) query full state at block; 2) query changes between blocks
* Uses BTreeMap for changes in the pallet to force one-key-one-change invariant

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
