### PR TITLE
fix: ETCM-9836 governed map changes query

### DIFF
--- a/dev/local-environment/envrc
+++ b/dev/local-environment/envrc
@@ -25,7 +25,7 @@ else
     export MC__SLOT_DURATION_MILLIS=$(jq '.slotLength * 1000' $SHELLEY_GENESIS_FILE)
     export MC__EPOCH_DURATION_MILLIS=$(jq '.epochLength * 1000' $SHELLEY_GENESIS_FILE)
     export CARDANO_SECURITY_PARAMETER=$(jq '.securityParam' $SHELLEY_GENESIS_FILE)
-    export CARDANO_ACTIVE_SLOTS_COEFF=$(jq '.activeSlotCoeff' $SHELLEY_GENESIS_FILE)
+    export CARDANO_ACTIVE_SLOTS_COEFF=$(jq '.activeSlotsCoeff' $SHELLEY_GENESIS_FILE)
 
     if [ -f "$PC_GENESIS_UTXO_FILE" ]; then
         export GENESIS_UTXO=$(cat $PC_GENESIS_UTXO_FILE)

--- a/toolkit/data-sources/db-sync/src/db_model.rs
+++ b/toolkit/data-sources/db-sync/src/db_model.rs
@@ -387,7 +387,7 @@ pub(crate) async fn get_changes(
 ) -> Result<Vec<DatumChangeOutput>, SqlxError> {
 	let query = "
 		((SELECT
-			datum.value as datum, origin_block.block_no as block_no, origin_tx.block_index as block_index, 'upsert' as action
+			datum.value as datum, origin_block.block_no as block_no, origin_tx.block_index as block_index, 'upsert' as action, 1 as action_order
 		FROM tx_out
 		INNER JOIN tx origin_tx			ON tx_out.tx_id = origin_tx.id
 		INNER JOIN block origin_block	ON origin_tx.block_id = origin_block.id
@@ -400,7 +400,7 @@ pub(crate) async fn get_changes(
 			AND multi_asset.name = $5)
 		UNION
 		(SELECT
-			datum.value as datum, consuming_block.block_no as block_no, consuming_tx.block_index as block_index, 'remove' as action
+			datum.value as datum, consuming_block.block_no as block_no, consuming_tx.block_index as block_index, 'remove' as action, -1 as action_order
 		FROM tx_out
 		LEFT JOIN tx_in consuming_tx_in	ON tx_out.tx_id = consuming_tx_in.tx_out_id AND tx_out.index = consuming_tx_in.tx_out_index
 		LEFT JOIN tx consuming_tx		ON consuming_tx_in.tx_in_id = consuming_tx.id
@@ -413,7 +413,7 @@ pub(crate) async fn get_changes(
 			AND (consuming_tx_in.id IS NOT NULL AND ($2 IS NULL OR consuming_block.block_no > $2) AND consuming_block.block_no <= $3)
 			AND multi_asset.policy = $4
 			AND multi_asset.name = $5))
-		ORDER BY block_no, block_index ASC";
+		ORDER BY block_no, block_index, action_order ASC";
 	Ok(sqlx::query_as::<_, DatumChangeOutput>(query)
 		.bind(&address.0)
 		.bind(after_block)


### PR DESCRIPTION
# Description

Fixes an issue where our query for changes in the governed map would sometimes put utxo spend event before new utxo creation, resulting in an updated key being interpreted as deleted.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
