### PR TITLE
feat: add pc_getBlockProducerFees RPC method

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6384,11 +6384,26 @@ dependencies = [
  "frame-system",
  "parity-scale-codec",
  "scale-info",
+ "sp-block-producer-fees",
  "sp-consensus-slots",
  "sp-core",
  "sp-io",
  "sp-runtime",
  "sp-std",
+]
+
+[[package]]
+name = "pallet-block-producer-fees-rpc"
+version = "1.6.0"
+dependencies = [
+ "derive-new",
+ "jsonrpsee",
+ "parity-scale-codec",
+ "serde",
+ "sp-api",
+ "sp-block-producer-fees",
+ "sp-blockchain",
+ "sp-runtime",
 ]
 
 [[package]]
@@ -6982,6 +6997,7 @@ dependencies = [
  "hex-literal",
  "jsonrpsee",
  "log",
+ "pallet-block-producer-fees-rpc",
  "pallet-block-producer-metadata-rpc",
  "pallet-partner-chains-session",
  "pallet-session-validator-management",
@@ -7018,6 +7034,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-block-participation",
+ "sp-block-producer-fees",
  "sp-block-producer-metadata",
  "sp-block-production-log",
  "sp-blockchain",
@@ -7091,6 +7108,7 @@ dependencies = [
  "sp-api",
  "sp-block-builder",
  "sp-block-participation",
+ "sp-block-producer-fees",
  "sp-block-producer-metadata",
  "sp-block-production-log",
  "sp-consensus-aura",
@@ -10454,6 +10472,15 @@ dependencies = [
  "sp-runtime",
  "thiserror 2.0.12",
  "tokio",
+]
+
+[[package]]
+name = "sp-block-producer-fees"
+version = "1.6.0"
+dependencies = [
+ "parity-scale-codec",
+ "sp-api",
+ "sp-std",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,8 @@ members = [
 	"toolkit/block-participation/pallet",
 	"toolkit/block-participation/primitives",
 	"toolkit/block-producer-fees/pallet",
+	"toolkit/block-producer-fees/primitives",
+	"toolkit/block-producer-fees/rpc",
 	"toolkit/block-producer-metadata/pallet",
 	"toolkit/block-producer-metadata/primitives",
 	"toolkit/block-producer-metadata/rpc",
@@ -309,6 +311,8 @@ sp-block-participation = { path = "toolkit/block-participation/primitives", defa
 
 # block producer fees
 pallet-block-producer-fees = { path = "toolkit/block-producer-fees/pallet", default-features = false }
+pallet-block-producer-fees-rpc = { path = "toolkit/block-producer-fees/rpc", default-features = false }
+sp-block-producer-fees = { path = "toolkit/block-producer-fees/primitives", default-features = false }
 
 # block producer metadata
 pallet-block-producer-metadata = { path = "toolkit/block-producer-metadata/pallet", default-features = false }

--- a/demo/node/Cargo.toml
+++ b/demo/node/Cargo.toml
@@ -80,6 +80,8 @@ sp-blockchain = { workspace = true }
 sp-block-builder = { workspace = true }
 sc-basic-authorship = { workspace = true }
 substrate-frame-rpc-system = { workspace = true }
+pallet-block-producer-fees-rpc = { workspace = true }
+sp-block-producer-fees = { workspace = true }
 pallet-transaction-payment-rpc = { workspace = true }
 
 # These dependencies are used for runtime benchmarking
@@ -90,22 +92,22 @@ partner-chains-demo-runtime = { workspace = true }
 sidechain-mc-hash = { workspace = true, features = ["mock"] }
 sp-native-token-management = { workspace = true }
 partner-chains-db-sync-data-sources = { workspace = true, features = [
-    "block-source",
-    "candidate-source",
-    "governed-map",
-    "native-token",
-    "mc-hash",
-    "sidechain-rpc",
-    "block-participation",
+	"block-source",
+	"candidate-source",
+	"governed-map",
+	"native-token",
+	"mc-hash",
+	"sidechain-rpc",
+	"block-participation",
 ] }
 partner-chains-mock-data-sources = { workspace = true, features = [
-    "block-source",
-    "candidate-source",
-    "governed-map",
-    "native-token",
-    "mc-hash",
-    "sidechain-rpc",
-    "block-participation",
+	"block-source",
+	"candidate-source",
+	"governed-map",
+	"native-token",
+	"mc-hash",
+	"sidechain-rpc",
+	"block-participation",
 ] }
 tokio = { workspace = true }
 sp-block-participation = { workspace = true, features = ["std"] }

--- a/demo/node/src/rpc.rs
+++ b/demo/node/src/rpc.rs
@@ -11,6 +11,7 @@ use authority_selection_inherents::{
 	CommitteeMember, authority_selection_inputs::AuthoritySelectionInputs,
 };
 use jsonrpsee::RpcModule;
+use pallet_block_producer_fees_rpc::*;
 use pallet_block_producer_metadata_rpc::*;
 use pallet_session_validator_management_rpc::*;
 use pallet_sidechain_rpc::*;
@@ -77,6 +78,7 @@ where
 	C::Api: sidechain_slots::SlotApi<Block>,
 	C::Api: sp_sidechain::GetGenesisUtxo<Block>,
 	C::Api: sp_sidechain::GetSidechainStatus<Block>,
+	C::Api: sp_block_producer_fees::BlockProducerFeesApi<Block, AccountId>,
 	C::Api: sp_block_producer_metadata::BlockProducerMetadataApi<Block, BlockProducerMetadataType>,
 	C::Api: sp_session_validator_management::SessionValidatorManagementApi<
 			Block,
@@ -107,6 +109,7 @@ where
 		)
 		.into_rpc(),
 	)?;
+	module.merge(BlockProducerFeesRpc::new(client.clone()).into_rpc())?;
 	module.merge(BlockProducerMetadataRpc::new(client.clone()).into_rpc())?;
 
 	let GrandpaDeps {

--- a/demo/runtime/Cargo.toml
+++ b/demo/runtime/Cargo.toml
@@ -91,6 +91,7 @@ pallet-block-participation = { workspace = true }
 sp-block-participation = { workspace = true }
 pallet-governed-map = { workspace = true }
 sp-governed-map = { workspace = true }
+sp-block-producer-fees = { workspace = true }
 pallet-block-producer-fees = { workspace = true }
 
 [dev-dependencies]
@@ -126,6 +127,7 @@ std = [
 	"frame-try-runtime/std",
 	"pallet-aura/std",
 	"pallet-balances/std",
+	"pallet-block-producer-fees/std",
 	"pallet-block-production-log/std",
 	"pallet-grandpa/std",
 	"pallet-sudo/std",
@@ -140,6 +142,7 @@ std = [
 	"sp-block-producer-metadata/std",
 	"sp-api/std",
 	"sp-block-builder/std",
+	"sp-block-producer-fees/std",
 	"sp-consensus-aura/std",
 	"sp-consensus-grandpa/std",
 	"sp-consensus-slots/std",

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -1008,6 +1008,13 @@ impl_runtime_apis! {
 		}
 	}
 
+	impl sp_block_producer_fees::BlockProducerFeesApi<Block, AccountId> for Runtime
+	{
+		fn get_all_fees() -> Vec<(AccountId, sp_block_producer_fees::PerTenThousands)> {
+			BlockProducerFees::get_all_latest().map(|(account_id, (_slot, fee))| (account_id, fee)).collect()
+		}
+	}
+
 	#[api_version(2)]
 	impl sp_session_validator_management::SessionValidatorManagementApi<
 		Block,

--- a/toolkit/block-producer-fees/pallet/Cargo.toml
+++ b/toolkit/block-producer-fees/pallet/Cargo.toml
@@ -16,6 +16,7 @@ frame-support = { workspace = true }
 frame-system = { workspace = true }
 parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
+sp-block-producer-fees = { workspace = true }
 sp-consensus-slots = { workspace = true }
 sp-std = { workspace = true }
 
@@ -32,6 +33,7 @@ std = [
 	"frame-system/std",
 	"parity-scale-codec/std",
 	"scale-info/std",
+	"sp-block-producer-fees/std",
 	"sp-std/std",
 ]
 runtime-benchmarks = [

--- a/toolkit/block-producer-fees/pallet/src/lib.rs
+++ b/toolkit/block-producer-fees/pallet/src/lib.rs
@@ -30,6 +30,7 @@ pub mod pallet {
 	use super::*;
 	use frame_support::pallet_prelude::*;
 	use frame_system::pallet_prelude::*;
+	use sp_block_producer_fees::PerTenThousands;
 	use sp_consensus_slots::Slot;
 	use sp_std::collections::vec_deque::VecDeque;
 
@@ -55,9 +56,6 @@ pub mod pallet {
 		/// Benchmark helper type used for running benchmarks
 		type BenchmarkHelper: benchmarking::BenchmarkHelper<Self::AccountId>;
 	}
-
-	// Margin Fee precision is 0.01 of a percent, so 1/10000 is used as a unit.
-	type PerTenThousands = u16;
 
 	type FeeChange = (Slot, PerTenThousands);
 

--- a/toolkit/block-producer-fees/primitives/Cargo.toml
+++ b/toolkit/block-producer-fees/primitives/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "sp-block-producer-fees"
+version.workspace = true
+license = "Apache-2.0"
+description = "Primitives for the block producer fees"
+readme = "README.md"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true }
+sp-api = { workspace = true }
+sp-std = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["parity-scale-codec/std", "sp-api/std", "sp-std/std"]

--- a/toolkit/block-producer-fees/primitives/src/lib.rs
+++ b/toolkit/block-producer-fees/primitives/src/lib.rs
@@ -1,0 +1,17 @@
+//! Primitives for block producer fees feature
+#![cfg_attr(not(feature = "std"), no_std)]
+#![deny(missing_docs)]
+
+use parity_scale_codec::Decode;
+
+/// Margin Fee precision is 0.01 of a percent, so 1/10000 is used as a unit.
+pub type PerTenThousands = u16;
+
+sp_api::decl_runtime_apis! {
+	/// Runtime API for block producer fees. Required for convenient access to the data by RPC.
+	pub trait BlockProducerFeesApi<AccountId: Decode>
+	{
+		/// Retrieves the latests fees of all accounts that have set them.
+		fn get_all_fees() -> sp_std::vec::Vec<(AccountId, PerTenThousands)>;
+	}
+}

--- a/toolkit/block-producer-fees/rpc/Cargo.toml
+++ b/toolkit/block-producer-fees/rpc/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "pallet-block-producer-fees-rpc"
+version.workspace = true
+license = "Apache-2.0"
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+parity-scale-codec = { workspace = true, features = ['std'] }
+jsonrpsee = { workspace = true }
+serde = { workspace = true, features = ['std'] }
+sp-runtime = { workspace = true, features = ['std'] }
+sp-api = { workspace = true, features = ['std'] }
+sp-block-producer-fees = { workspace = true, features = ['std'] }
+sp-blockchain = { workspace = true }
+derive-new = { workspace = true }
+
+[features]
+default = []

--- a/toolkit/block-producer-fees/rpc/src/lib.rs
+++ b/toolkit/block-producer-fees/rpc/src/lib.rs
@@ -1,0 +1,108 @@
+//! Crate provides Json RPC method getting the Block Producer Fees
+//!
+//! ## Contents
+//!
+//! This crate provides the [BlockProducerFeesRpcApiServer] trait defining the JsonRPC method to display
+//! block producer fees and its concrete implementation [BlockProducerFeesRpc].
+//! ## Usage - PC Builders
+//!
+//! To use the Json RPC service defined in this crate, first make your runtime implement
+//! [sp_block_producer_fees::BlockProducerFeesApi]. Eg. assuming the pallet `BlockProducerFeesPallet`
+//! in your runtime uses `AccountId` as the account id type, the following should be included in your
+//! `impl_runtime_apis` block:
+//! ```rust, ignore
+//! impl BlockProducerFeesApi<Block, AccountId> for Runtime
+//! {
+//! 	fn get_all_fees() -> Vec<(AccountId, sp_block_producer_fees::PerTenThousands)> {
+//!			BlockProducerFees::get_all_latest().map(|(account_id, (_slot, fee))| (account_id, fee)).collect()
+//!		}
+//! }
+//! ```
+//!
+//! Afterwards, the [BlockProducerFeesRpc] Json RPC service can be added into the Json RPC stack of your node.
+//! Example where AccountId type parameter is set to AccountId32:
+//!
+//! ```rust
+//! use jsonrpsee::RpcModule;
+//! use std::sync::Arc;
+//! use sp_block_producer_fees::*;
+//! use pallet_block_producer_fees_rpc::*;
+//!
+//! fn create_rpc<C, Block>(client: Arc<C>) -> Result<RpcModule<()>, Box<dyn std::error::Error>>
+//! where
+//!   C: Send + Sync + 'static,
+//!   Block: sp_runtime::traits::Block,
+//!   C: sp_api::ProvideRuntimeApi<Block>,
+//!   C: sp_blockchain::HeaderBackend<Block>,
+//!   C::Api: BlockProducerFeesApi<Block, sp_runtime::AccountId32>
+//! {
+//!     let mut module = RpcModule::new(());
+//!     module.merge(BlockProducerFeesRpc::new(client.clone()).into_rpc())?;
+//!     // other RPC modules
+//!     Ok(module)
+//! }
+//! ```
+#![deny(missing_docs)]
+use derive_new::new;
+use jsonrpsee::{
+	core::{RpcResult, async_trait},
+	proc_macros::rpc,
+	types::{ErrorObject, ErrorObjectOwned},
+};
+use parity_scale_codec::Decode;
+use serde::{Deserialize, Serialize};
+use sp_api::ProvideRuntimeApi;
+use sp_block_producer_fees::BlockProducerFeesApi;
+use sp_blockchain::HeaderBackend;
+use sp_runtime::traits::Block as BlockT;
+use std::sync::Arc;
+
+/// Json RPC methods related to the Block Producer Metadata feature of Partner Chains Toolkit
+#[rpc(client, server, namespace = "pc")]
+pub trait BlockProducerFeesRpcApi<AccountId: Decode> {
+	/// Returns the latest recorded fees. To get all stored data query pallet storage directly.
+	#[method(name = "getBlockProducerFees")]
+	fn get_block_producer_fees(&self) -> RpcResult<Vec<FeesSettings<AccountId>>>;
+}
+
+/// Concrete implementation of [BlockProducerFeesRpcApiServer] that uses [BlockProducerFeesRpcApi] for querying runtime storage.
+#[derive(new)]
+pub struct BlockProducerFeesRpc<C, Block, AccountId> {
+	client: Arc<C>,
+	_marker: std::marker::PhantomData<(Block, AccountId)>,
+}
+
+/// Fees settings for given account
+#[derive(Clone, Deserialize, Serialize)]
+pub struct FeesSettings<AccountId> {
+	account_id: AccountId,
+	margin_fee: f64,
+}
+
+#[async_trait]
+impl<C, Block, AccountId: Decode + Sync + Send + 'static> BlockProducerFeesRpcApiServer<AccountId>
+	for BlockProducerFeesRpc<C, Block, AccountId>
+where
+	Block: BlockT,
+	C: Send + Sync + 'static,
+	C: ProvideRuntimeApi<Block>,
+	C: HeaderBackend<Block>,
+	C::Api: BlockProducerFeesApi<Block, AccountId>,
+{
+	fn get_block_producer_fees(&self) -> RpcResult<Vec<FeesSettings<AccountId>>> {
+		let api = self.client.runtime_api();
+		let best_block = self.client.info().best_hash;
+		let fees = api.get_all_fees(best_block).map_err(error_object_from)?;
+		Ok(fees
+			.into_iter()
+			.map(|(account_id, fee)| {
+				let fee: f64 = fee.into();
+				FeesSettings { account_id, margin_fee: fee / 100f64 }
+			})
+			.collect())
+	}
+}
+
+fn error_object_from<T: std::fmt::Debug>(err: T) -> ErrorObjectOwned {
+	ErrorObject::owned::<u8>(-1, format!("{err:?}"), None)
+}

--- a/toolkit/block-producer-fees/rpc/src/lib.rs
+++ b/toolkit/block-producer-fees/rpc/src/lib.rs
@@ -1,4 +1,4 @@
-//! Crate provides Json RPC method getting the Block Producer Fees
+//! Json RPC for the Block Producer Fees pallet
 //!
 //! ## Contents
 //!
@@ -59,7 +59,7 @@ use std::sync::Arc;
 
 /// Json RPC methods related to the Block Producer Metadata feature of Partner Chains Toolkit
 #[rpc(client, server, namespace = "pc")]
-pub trait BlockProducerFeesRpcApi<AccountId: Decode> {
+pub trait BlockProducerFeesRpc<AccountId: Decode> {
 	/// Returns the latest recorded fees. To get all stored data query pallet storage directly.
 	#[method(name = "getBlockProducerFees")]
 	fn get_block_producer_fees(&self) -> RpcResult<Vec<FeesSettings<AccountId>>>;
@@ -76,11 +76,12 @@ pub struct BlockProducerFeesRpc<C, Block, AccountId> {
 #[derive(Clone, Deserialize, Serialize)]
 pub struct FeesSettings<AccountId> {
 	account_id: AccountId,
+	/// Margin fee in percent
 	margin_fee: f64,
 }
 
 #[async_trait]
-impl<C, Block, AccountId: Decode + Sync + Send + 'static> BlockProducerFeesRpcApiServer<AccountId>
+impl<C, Block, AccountId: Decode + Sync + Send + 'static> BlockProducerFeesRpcServer<AccountId>
 	for BlockProducerFeesRpc<C, Block, AccountId>
 where
 	Block: BlockT,

--- a/toolkit/block-production-log/primitives/src/lib.rs
+++ b/toolkit/block-production-log/primitives/src/lib.rs
@@ -56,11 +56,11 @@ mod test;
 
 use parity_scale_codec::{Decode, Encode};
 use sp_inherents::{InherentIdentifier, IsFatalError};
-use sp_runtime::traits::Block as BlockT;
 #[cfg(feature = "std")]
 use {
 	sp_api::{ApiExt, ProvideRuntimeApi},
 	sp_inherents::InherentData,
+	sp_runtime::traits::Block as BlockT,
 };
 
 /// Inherent identifier used by the Block Production Log pallet


### PR DESCRIPTION
# Description

* Adds RPC method to retrieve current fees settings

```
curl -s -H "Content-Type:application/json" -d '{"jsonrpc":"2.0","method":"pc_getBlockProducerFees","params":[],"id":1}' localhost:9933 | jq .result
[
  {
    "account_id": "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
    "margin_fee": 10.0
  },
  {
    "account_id": "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
    "margin_fee": 1.25
  }
]
```

REF: ETCM-9326
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
