### PR TITLE
change: Sidechain primitives crates cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1477,8 +1477,12 @@ dependencies = [
  "serde",
  "serde_json",
  "sidechain-domain",
+ "sp-api",
  "sp-block-producer-metadata",
+ "sp-blockchain",
  "sp-io",
+ "sp-runtime",
+ "sp-sidechain",
  "thiserror 2.0.12",
 ]
 
@@ -10979,10 +10983,8 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "serde_json",
  "sidechain-domain",
  "sp-api",
- "sp-blockchain",
  "sp-runtime",
 ]
 

--- a/changelog.md
+++ b/changelog.md
@@ -41,6 +41,8 @@ to provide it in your IDP stack.
 * Made `mock` module of `pallet-session-validator-management` private
 * Updated dependecies
 * Updated polkadot-sdk to polkadot-stable2503-2
+* Deprecated the `GetSidechainStatus` runtime API in `sp-sidechain` crate. Code
+that needs data that it served should define its own runtime API instead.
 
 ## Removed
 
@@ -52,6 +54,8 @@ Its functionality was merged into `pallet-partner-chains-session` under the feat
 the feature `pallet-session-compat`.
 * `TryFrom<&serde_json::Value> for Datum` and `From<&Datum> for serde_json::Value` instances from `plutus`.
 * `ATMSPlainAggregatePubKey`, `ValidatorHash` and `SidechainPublicKeysSorted` types from `domain`.
+* `SidechainApi` trait from `sp-sidechain` and its return type `SidechainStatus`. Code that uses it should directly use
+the APIs that were grouped into this trait or ideally define its own runtime API instead (see deprecation of `GetSidechainStatus`).
 
 ## Fixed
 

--- a/demo/node/src/lib.rs
+++ b/demo/node/src/lib.rs
@@ -1,4 +1,5 @@
 //! A fresh FRAME-based Substrate node, ready for hacking.
+#![allow(deprecated)]
 
 pub mod chain_spec;
 mod data_sources;

--- a/demo/node/src/main.rs
+++ b/demo/node/src/main.rs
@@ -1,5 +1,6 @@
 //! Substrate Node Template CLI library.
 #![warn(missing_docs)]
+#![allow(deprecated)]
 
 mod chain_spec;
 mod cli;

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 // `construct_runtime!` does a lot of recursion and requires us to increase the limit to 256.
 #![recursion_limit = "256"]
+#![allow(deprecated)]
 
 #[cfg(feature = "runtime-benchmarks")]
 #[macro_use]

--- a/toolkit/cli/commands/Cargo.toml
+++ b/toolkit/cli/commands/Cargo.toml
@@ -23,7 +23,11 @@ plutus-datum-derive = { workspace = true }
 secp256k1 = { workspace = true, features = ["std", "global-context"] }
 k256 = { workspace = true, features = ["serde"] }
 sidechain-domain = { workspace = true, features = ["std"] }
+sp-api = { workspace = true, features = ["std"] }
 sp-io = { workspace = true, features = ["std"] }
+sp-runtime = { workspace = true, features = ["std"] }
+sp-sidechain = { workspace = true, features = ["std"] }
+sp-blockchain = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/toolkit/cli/commands/src/get_genesis_utxo.rs
+++ b/toolkit/cli/commands/src/get_genesis_utxo.rs
@@ -1,11 +1,13 @@
-use crate::GetGenesisUtxo;
 use sidechain_domain::UtxoId;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
+use sp_sidechain::GetGenesisUtxo;
 use std::sync::Arc;
 
-pub async fn get_genesis_utxo<B, C>(client: Arc<C>) -> Result<String, String>
+/// Retrieves the genesis UTXO from the on-chain storage.
+/// This function should be used by a CLI command.
+pub async fn execute<B, C>(client: Arc<C>) -> Result<String, String>
 where
 	B: BlockT,
 	C: ProvideRuntimeApi<B> + Send + Sync + 'static,
@@ -21,6 +23,6 @@ where
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Debug)]
-pub struct Output {
+struct Output {
 	pub genesis_utxo: UtxoId,
 }

--- a/toolkit/cli/commands/src/lib.rs
+++ b/toolkit/cli/commands/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod address_association_signatures;
 pub mod block_producer_metadata_signatures;
+pub mod get_genesis_utxo;
 pub mod key_params;
 pub mod registration_signatures;

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -24,6 +24,7 @@ use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
 use sp_session_validator_management::SessionValidatorManagementApi;
 use sp_session_validator_management_query::SessionValidatorManagementQuery;
 use sp_session_validator_management_query::commands::*;
+#[allow(deprecated)]
 use sp_sidechain::{GetGenesisUtxo, GetSidechainStatus};
 use std::future::Future;
 use std::str::FromStr;
@@ -114,6 +115,7 @@ pub enum PartnerChainsSubcommand<
 	Wizards(partner_chains_cli::Command<RuntimeBindings>),
 }
 
+#[allow(deprecated)]
 pub fn run<
 	Cli,
 	Block,
@@ -156,7 +158,7 @@ where
 			let runner = cli.create_runner(&cmd)?;
 			runner.async_run(|config| {
 				let (client, task_manager, _) = get_deps(config)?;
-				Ok((print_result(sp_sidechain::query::get_genesis_utxo(client)), task_manager))
+				Ok((print_result(cli_commands::get_genesis_utxo::execute(client)), task_manager))
 			})
 		},
 		PartnerChainsSubcommand::RegistrationStatus(cmd) => {

--- a/toolkit/committee-selection/query/src/lib.rs
+++ b/toolkit/committee-selection/query/src/lib.rs
@@ -21,6 +21,7 @@ use sp_runtime::traits::{Block as BlockT, Zero};
 use sp_session_validator_management::{
 	CommitteeMember as CommitteeMemberT, SessionValidatorManagementApi,
 };
+#[allow(deprecated)]
 use sp_sidechain::{GetGenesisUtxo, GetSidechainStatus};
 use std::sync::Arc;
 use types::*;
@@ -129,6 +130,7 @@ where
 }
 
 #[async_trait]
+#[allow(deprecated)]
 impl<C, Block, CommitteeMember> SessionValidatorManagementQueryApi
 	for SessionValidatorManagementQuery<C, Block, CommitteeMember>
 where

--- a/toolkit/committee-selection/query/src/tests/mod.rs
+++ b/toolkit/committee-selection/query/src/tests/mod.rs
@@ -14,6 +14,7 @@ use sp_core::bytes::to_hex;
 use sp_core::crypto::Ss58Codec;
 use sp_core::{Pair, ecdsa, ed25519};
 use sp_runtime::{MultiSigner, traits::IdentifyAccount};
+#[allow(deprecated)]
 use sp_sidechain::SidechainStatus;
 use std::borrow::BorrowMut;
 use std::collections::HashMap;

--- a/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
+++ b/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
@@ -8,6 +8,8 @@ use mock::*;
 use sidechain_domain::*;
 use sp_core::{Decode, Encode};
 use sp_session_validator_management::MainChainScripts;
+#[allow(deprecated)]
+use sp_sidechain::GetSidechainStatus;
 use std::str::FromStr;
 
 pub type Block = sp_runtime::generic::Block<
@@ -31,6 +33,7 @@ impl TryFrom<SidechainPublicKey> for CrossChainPublic {
 }
 
 sp_api::mock_impl_runtime_apis! {
+	#[allow(deprecated)]
 	impl GetSidechainStatus<Block> for TestRuntimeApi {
 		#[advanced]
 		fn get_sidechain_status(at: <Block as BlockT>::Hash) -> Result<SidechainStatus, sp_api::ApiError> {

--- a/toolkit/sidechain/primitives/Cargo.toml
+++ b/toolkit/sidechain/primitives/Cargo.toml
@@ -20,9 +20,7 @@ parity-scale-codec = { workspace = true }
 scale-info = { workspace = true }
 sp-api = { workspace = true }
 sp-runtime = { workspace = true }
-sp-blockchain = { workspace = true, optional = true }
 serde = { workspace = true, optional = true }
-serde_json = { workspace = true, optional = true }
 
 [features]
 default = ["std"]
@@ -36,6 +34,4 @@ std = [
     "sp-api/std",
     "sp-runtime/std",
 	"serde",
-	"serde_json",
-	"sp-blockchain"
 ]

--- a/toolkit/sidechain/primitives/src/lib.rs
+++ b/toolkit/sidechain/primitives/src/lib.rs
@@ -4,15 +4,11 @@ use frame_support::pallet_prelude::Weight;
 use parity_scale_codec::{Decode, Encode};
 use scale_info::TypeInfo;
 use sidechain_domain::{ScEpochNumber, ScSlotNumber, UtxoId};
-#[cfg(feature = "std")]
-use sp_runtime::traits::Block as BlockT;
-
-#[cfg(feature = "std")]
-pub mod query;
 
 #[cfg(test)]
 mod tests;
 
+#[deprecated(since = "1.8.0", note = "See deprecation notes for [GetSidechainStatus]")]
 #[derive(TypeInfo, Clone, Encode, Decode)]
 pub struct SidechainStatus {
 	pub epoch: ScEpochNumber,
@@ -48,23 +44,20 @@ on_new_epoch_tuple_impl!(A, B);
 on_new_epoch_tuple_impl!(A, B, C);
 on_new_epoch_tuple_impl!(A, B, C, D);
 
-sp_api::decl_runtime_apis! {
-	pub trait GetGenesisUtxo {
-		fn genesis_utxo() -> UtxoId;
-	}
-	pub trait GetSidechainStatus {
-		fn get_sidechain_status() -> SidechainStatus;
+#[allow(deprecated)]
+mod api_declarations {
+	use super::*;
+	sp_api::decl_runtime_apis! {
+		pub trait GetGenesisUtxo {
+			fn genesis_utxo() -> UtxoId;
+		}
+		#[deprecated(since = "1.8.0", note = "Code that needs this data should define its own runtime API instead.")]
+		pub trait GetSidechainStatus {
+			fn get_sidechain_status() -> SidechainStatus;
+		}
 	}
 }
-
-#[cfg(feature = "std")]
-pub trait SidechainApi<Block: BlockT>: GetSidechainStatus<Block> + GetGenesisUtxo<Block> {}
-
-#[cfg(feature = "std")]
-impl<Block: BlockT, T: GetGenesisUtxo<Block> + GetSidechainStatus<Block>> SidechainApi<Block>
-	for T
-{
-}
+pub use api_declarations::*;
 
 #[cfg(feature = "std")]
 pub fn read_genesis_utxo_from_env_with_defaults() -> Result<UtxoId, envy::Error> {

--- a/toolkit/sidechain/rpc/src/tests/mod.rs
+++ b/toolkit/sidechain/rpc/src/tests/mod.rs
@@ -9,13 +9,13 @@ use rpc_mock::*;
 
 mod get_status_tests {
 	use super::*;
+	use crate::GetParamsOutput;
 	use mock::SidechainRpcDataSourceMock;
 	use pretty_assertions::assert_eq;
 	use sidechain_domain::mainchain_epoch::{Duration, MainchainEpochConfig};
 	use sidechain_domain::*;
 	use sp_consensus_slots::SlotDuration;
 	use sp_core::offchain::Timestamp;
-	use sp_sidechain::query::Output;
 
 	#[tokio::test]
 	async fn should_return_correct_status() {
@@ -36,13 +36,8 @@ mod get_status_tests {
 		let slot_duration = SlotDuration::from_millis(60);
 		let slots_per_epoch = 10;
 
-		let client = Arc::new(TestApi {
-			runtime_api: TestRuntimeApi {
-				sidechain_status: vec![],
-				slot_duration,
-				slots_per_epoch,
-			},
-		});
+		let client =
+			Arc::new(TestApi { runtime_api: TestRuntimeApi { slot_duration, slots_per_epoch } });
 		let current_time_millis: u64 = 1_000_000_000_000;
 		let time_source = Arc::new(MockedTimeSource { current_time_millis });
 
@@ -103,7 +98,7 @@ mod get_status_tests {
 
 		assert_eq!(
 			response.expect("Response should not be an error"),
-			Output { genesis_utxo: crate::tests::mock::mock_utxo_id() },
+			GetParamsOutput { genesis_utxo: crate::tests::mock::mock_utxo_id() },
 		)
 	}
 }

--- a/toolkit/sidechain/rpc/src/tests/rpc_mock.rs
+++ b/toolkit/sidechain/rpc/src/tests/rpc_mock.rs
@@ -3,7 +3,6 @@ use sp_api::{ApiRef, ProvideRuntimeApi};
 use sp_blockchain::HeaderBackend;
 use sp_consensus_slots::SlotDuration;
 use sp_runtime::traits::{Block as BlockT, NumberFor, Zero};
-use sp_sidechain::SidechainStatus;
 
 #[derive(Default)]
 pub struct TestApi {
@@ -12,18 +11,13 @@ pub struct TestApi {
 
 #[derive(Clone)]
 pub struct TestRuntimeApi {
-	pub sidechain_status: Vec<(<Block as BlockT>::Hash, SidechainStatus)>,
 	pub slot_duration: SlotDuration,
 	pub slots_per_epoch: u64,
 }
 
 impl Default for TestRuntimeApi {
 	fn default() -> Self {
-		Self {
-			slot_duration: SlotDuration::from_millis(6000),
-			slots_per_epoch: 10,
-			sidechain_status: Default::default(),
-		}
+		Self { slot_duration: SlotDuration::from_millis(6000), slots_per_epoch: 10 }
 	}
 }
 

--- a/toolkit/sidechain/rpc/src/tests/runtime_api_mock.rs
+++ b/toolkit/sidechain/rpc/src/tests/runtime_api_mock.rs
@@ -3,7 +3,7 @@ use mock::*;
 use rpc_mock::*;
 use sidechain_domain::UtxoId;
 use sidechain_slots::{ScSlotConfig, SlotsPerEpoch};
-use sp_sidechain::{GetGenesisUtxo, SidechainStatus};
+use sp_sidechain::GetGenesisUtxo;
 
 sp_api::mock_impl_runtime_apis! {
 	impl GetGenesisUtxo<Block> for TestRuntimeApi {
@@ -16,18 +16,6 @@ sp_api::mock_impl_runtime_apis! {
 				slot_duration: self.slot_duration,
 				slots_per_epoch: SlotsPerEpoch(self.slots_per_epoch as u32)
 			}
-		}
-	}
-
-	impl GetSidechainStatus<Block> for TestRuntimeApi {
-		#[advanced]
-		fn get_sidechain_status(at: <Block as BlockT>::Hash) -> Result<SidechainStatus, sp_api::ApiError> {
-			for (hash, status) in self.sidechain_status.iter() {
-				if *hash == at {
-					return Ok(status.clone())
-				}
-			}
-			panic!("Unexpected get_sidechain_status call for hash {at}");
 		}
 	}
 }

--- a/toolkit/sidechain/sidechain-block-search/src/impl_block_info.rs
+++ b/toolkit/sidechain/sidechain-block-search/src/impl_block_info.rs
@@ -2,6 +2,7 @@ use sp_api::ApiError;
 
 use super::*;
 
+#[allow(deprecated)]
 impl<C, Block> SidechainInfo<Block> for C
 where
 	C: Client<Block> + Send + Sync + 'static,

--- a/toolkit/sidechain/sidechain-block-search/src/lib.rs
+++ b/toolkit/sidechain/sidechain-block-search/src/lib.rs
@@ -12,6 +12,7 @@ use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::traits::Block as BlockT;
 use sp_runtime::traits::NumberFor;
+#[allow(deprecated)]
 use sp_sidechain::GetSidechainStatus;
 use std::cmp::Ordering;
 use std::ops::Range;

--- a/toolkit/sidechain/sidechain-block-search/src/tests/runtime_api_mock.rs
+++ b/toolkit/sidechain/sidechain-block-search/src/tests/runtime_api_mock.rs
@@ -1,9 +1,11 @@
 use super::*;
 use rpc_mock::*;
 use sidechain_domain::*;
+#[allow(deprecated)]
 use sp_sidechain::SidechainStatus;
 
 sp_api::mock_impl_runtime_apis! {
+#[allow(deprecated)]
 	impl GetSidechainStatus<Block> for TestRuntimeApi {
 		#[advanced]
 		fn get_sidechain_status(at: <Block as BlockT>::Hash) -> Result<SidechainStatus, sp_api::ApiError> {


### PR DESCRIPTION
# Description

- Moves the logic in `query` module out of the crate completely. It contained a json-string-returning function used on only by a CLI command, which the primitives should not know anything about, and an output struct shared between rpc and cli, which they should not share
- Deprecates the `GetSidechainStatus` runtime API and its returned type `SidechainStatus` (and removes some unnecessary uses of it). This API is mis-named (doesn't serve any status), returns a structure out of which each user code needs only one field, and one field is not used at all. Ideally, each functionality should define the runtime API it consumes instead of sharing one with other unrelated functionalities.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
