### PR TITLE
change: ETCM-9687 small fixes and docs for db-sync data sources crate

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 # Unreleased
 
 ## Changed
+* `partner-chains-db-sync-data-sources` crate now exports all its public members from the root
 
 ## Removed
 

--- a/demo/node/src/data_sources.rs
+++ b/demo/node/src/data_sources.rs
@@ -1,10 +1,9 @@
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
 use pallet_sidechain_rpc::SidechainRpcDataSource;
 use partner_chains_db_sync_data_sources::{
-	block::BlockDataSourceImpl, candidates::CandidatesDataSourceImpl,
-	governed_map::GovernedMapDataSourceCachedImpl, mc_hash::McHashDataSourceImpl,
-	metrics::McFollowerMetrics, native_token::NativeTokenManagementDataSourceImpl,
-	sidechain_rpc::SidechainRpcDataSourceImpl, stake_distribution::StakeDistributionDataSourceImpl,
+	BlockDataSourceImpl, CandidatesDataSourceImpl, GovernedMapDataSourceCachedImpl,
+	McFollowerMetrics, McHashDataSourceImpl, NativeTokenManagementDataSourceImpl,
+	SidechainRpcDataSourceImpl, StakeDistributionDataSourceImpl,
 };
 use partner_chains_mock_data_sources::{
 	block::BlockDataSourceMock, candidate::AuthoritySelectionDataSourceMock,
@@ -73,7 +72,7 @@ pub const GOVERNED_MAP_CACHE_SIZE: u16 = 100;
 pub async fn create_cached_db_sync_data_sources(
 	metrics_opt: Option<McFollowerMetrics>,
 ) -> Result<DataSources, Box<dyn Error + Send + Sync + 'static>> {
-	let pool = partner_chains_db_sync_data_sources::data_sources::get_connection_from_env().await?;
+	let pool = partner_chains_db_sync_data_sources::get_connection_from_env().await?;
 	// block data source is reused between mc_hash and sidechain_rpc to share cache
 	let block = Arc::new(BlockDataSourceImpl::new_from_env(pool.clone()).await?);
 	Ok(DataSources {

--- a/demo/node/src/service.rs
+++ b/demo/node/src/service.rs
@@ -3,8 +3,8 @@
 use crate::data_sources::DataSources;
 use crate::inherent_data::{CreateInherentDataConfig, ProposalCIDP, VerifierCIDP};
 use crate::rpc::GrandpaDeps;
-use partner_chains_db_sync_data_sources::metrics::McFollowerMetrics;
-use partner_chains_db_sync_data_sources::metrics::register_metrics_warn_errors;
+use partner_chains_db_sync_data_sources::McFollowerMetrics;
+use partner_chains_db_sync_data_sources::register_metrics_warn_errors;
 use partner_chains_demo_runtime::{self, RuntimeApi, opaque::Block};
 use sc_client_api::BlockBackend;
 use sc_consensus_aura::{ImportQueueParams, SlotProportion, StartAuraParams};

--- a/toolkit/data-sources/cli/src/main.rs
+++ b/toolkit/data-sources/cli/src/main.rs
@@ -1,10 +1,6 @@
 use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
 use clap::Parser;
-use partner_chains_db_sync_data_sources::{
-	block::{BlockDataSourceImpl, DbSyncBlockDataSourceConfig},
-	candidates::CandidatesDataSourceImpl,
-	data_sources::{PgPool, read_mc_epoch_config},
-};
+use partner_chains_db_sync_data_sources::{BlockDataSourceImpl, CandidatesDataSourceImpl, PgPool};
 use sidechain_domain::*;
 use sp_timestamp::Timestamp;
 use std::error::Error;
@@ -86,7 +82,7 @@ mod data_source {
 	use super::*;
 
 	async fn pool() -> Result<PgPool> {
-		partner_chains_db_sync_data_sources::data_sources::get_connection_from_env().await
+		partner_chains_db_sync_data_sources::get_connection_from_env().await
 	}
 
 	pub struct BlockDataSourceWrapper {
@@ -118,11 +114,7 @@ mod data_source {
 
 	pub async fn block() -> Result<BlockDataSourceWrapper> {
 		Ok(BlockDataSourceWrapper {
-			inner: BlockDataSourceImpl::from_config(
-				pool().await?,
-				DbSyncBlockDataSourceConfig::from_env()?,
-				&read_mc_epoch_config()?,
-			),
+			inner: BlockDataSourceImpl::new_from_env(pool().await?).await?,
 		})
 	}
 

--- a/toolkit/data-sources/db-sync/src/candidates/datum.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/datum.rs
@@ -3,7 +3,7 @@ use partner_chains_plutus_data::permissioned_candidates::PermissionedCandidateDa
 use partner_chains_plutus_data::permissioned_candidates::PermissionedCandidateDatums;
 use sidechain_domain::*;
 
-pub fn raw_permissioned_candidate_data_from(
+pub(crate) fn raw_permissioned_candidate_data_from(
 	datum: PermissionedCandidateDatumV0,
 ) -> RawPermissionedCandidateData {
 	let PermissionedCandidateDatumV0 { sidechain_public_key, aura_public_key, grandpa_public_key } =
@@ -11,7 +11,7 @@ pub fn raw_permissioned_candidate_data_from(
 	RawPermissionedCandidateData { sidechain_public_key, aura_public_key, grandpa_public_key }
 }
 
-pub fn raw_permissioned_candidate_data_vec_from(
+pub(crate) fn raw_permissioned_candidate_data_vec_from(
 	datums: PermissionedCandidateDatums,
 ) -> Vec<RawPermissionedCandidateData> {
 	match datums {

--- a/toolkit/data-sources/db-sync/src/candidates/mod.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/mod.rs
@@ -1,3 +1,4 @@
+//! Db-Sync data source used by Partner Chain committee selection
 use crate::DataSourceError::*;
 use crate::db_model::{
 	self, Address, Asset, BlockNumber, EpochNumber, MainchainTxOutput, StakePoolEntry,
@@ -17,11 +18,11 @@ use sqlx::PgPool;
 use std::collections::HashMap;
 use std::error::Error;
 
-pub mod cached;
-pub mod datum;
+mod cached;
+mod datum;
 
 #[cfg(test)]
-pub mod tests;
+mod tests;
 
 #[derive(Clone, Debug)]
 struct ParsedCandidate {
@@ -45,8 +46,11 @@ struct RegisteredCandidate {
 	utxo_info: UtxoInfo,
 }
 
+/// Db-Sync data source serving data for Partner Chain committee selection
 pub struct CandidatesDataSourceImpl {
+	/// Postgres connection pool
 	pool: PgPool,
+	/// Prometheus metrics client
 	metrics_opt: Option<McFollowerMetrics>,
 }
 
@@ -121,6 +125,7 @@ impl AuthoritySelectionDataSource for CandidatesDataSourceImpl {
 });
 
 impl CandidatesDataSourceImpl {
+	/// Creates new instance of the data source
 	pub async fn new(
 		pool: PgPool,
 		metrics_opt: Option<McFollowerMetrics>,
@@ -130,6 +135,7 @@ impl CandidatesDataSourceImpl {
 		Ok(Self { pool, metrics_opt })
 	}
 
+	/// Creates a new caching instance of the data source
 	pub fn cached(
 		self,
 		candidates_for_epoch_cache_size: usize,

--- a/toolkit/data-sources/db-sync/src/governed_map/mod.rs
+++ b/toolkit/data-sources/db-sync/src/governed_map/mod.rs
@@ -1,3 +1,4 @@
+//! Db-Sync data source used by Partner Chain Governed Map feature
 use crate::DataSourceError::ExpectedDataNotFound;
 use crate::Result;
 use crate::block::BlockDataSourceImpl;
@@ -15,14 +16,20 @@ use std::cmp::{max, min};
 use std::sync::{Arc, Mutex};
 
 #[cfg(test)]
-pub mod tests;
+mod tests;
 
+/// Data source for the Governed Map feature of Partner Chains toolkit
+///
+/// See documentation of [sp_governed_map] for a description of the feature
 pub struct GovernedMapDataSourceImpl {
+	/// Postgres connection pool
 	pub pool: PgPool,
+	/// Prometheus metrics client
 	pub metrics_opt: Option<McFollowerMetrics>,
 }
 
 impl GovernedMapDataSourceImpl {
+	/// Creates a new instance of the data source
 	pub async fn new(
 		pool: PgPool,
 		metrics_opt: Option<McFollowerMetrics>,
@@ -105,15 +112,24 @@ async fn get_mappings_entries(
 	Ok(mappings)
 }
 
+/// Cached data source serving the Governed Map feature of Partner Chains toolkit
+///
+/// See documentation of [sp_governed_map] for a description of the feature
 pub struct GovernedMapDataSourceCachedImpl {
+	/// Postgres connection pool
 	pub pool: PgPool,
+	/// Prometheus metrics client
 	pub metrics_opt: Option<McFollowerMetrics>,
+	/// Internal data cache size
 	cache_size: u16,
+	/// Internal cache
 	cache: Arc<Mutex<Cache>>,
+	/// [BlockDataSourceImpl] instance shared with other data sources for cache reuse.
 	blocks: Arc<BlockDataSourceImpl>,
 }
 
 impl GovernedMapDataSourceCachedImpl {
+	/// Constructs a new Governed Map data source
 	pub async fn new(
 		pool: PgPool,
 		metrics_opt: Option<McFollowerMetrics>,

--- a/toolkit/data-sources/db-sync/src/lib.rs
+++ b/toolkit/data-sources/db-sync/src/lib.rs
@@ -1,55 +1,141 @@
-//! Provides implementations of Data Sources that read from db-sync postgres.
+//! Crate providing implementations of Partner Chain Data Sources that read from Db-Sync Postgres.
+//!
+//! # Usage
+//!
+//! ## Adding to the node
+//!
+//! All data sources defined in this crate require a Postgres connection pool [PgPool] to run
+//! queries, which should be shared between all data sources. For convenience, this crate provides
+//! a helper function [get_connection_from_env] that will create a connection pool based on
+//! configuration read from node environment.
+//!
+//! Each data source also accepts an optional Prometheus metrics client [McFollowerMetrics] for
+//! reporting metrics to the Substrate's Prometheus metrics service. This client can be obtained
+//! using the [register_metrics_warn_errors] function.
+//!
+//! In addition to these two common arguments, some data sources depend on [BlockDataSourceImpl]
+//! which provides basic queries about blocks, and additional configuration for their data cache
+//! size.
+//!
+//! An example node code that creates the data sources can look like the following:
+//!
+//! ```rust
+//! # use std::error::Error;
+//! # use std::sync::Arc;
+//! use partner_chains_db_sync_data_sources::*;
+//!
+//! pub const CANDIDATES_FOR_EPOCH_CACHE_SIZE: usize = 64;
+//! pub const STAKE_CACHE_SIZE: usize = 100;
+//! pub const GOVERNED_MAP_CACHE_SIZE: u16 = 100;
+//!
+//! async fn create_data_sources(
+//!     metrics_registry_opt: Option<&substrate_prometheus_endpoint::Registry>
+//! ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//!     let metrics = register_metrics_warn_errors(metrics_registry_opt);
+//!     let pool = get_connection_from_env().await?;
+//!
+//!     // Block data source is shared by others for cache reuse
+//!     let block = Arc::new(BlockDataSourceImpl::new_from_env(pool.clone()).await?);
+//!
+//!     let sidechain_rpc = SidechainRpcDataSourceImpl::new(block.clone(), metrics.clone());
+//!
+//!     let mc_hash = Arc::new(McHashDataSourceImpl::new(block.clone(), metrics.clone()));
+//!
+//!     let authority_selection =
+//!         CandidatesDataSourceImpl::new(pool.clone(), metrics.clone())
+//!     	.await?
+//!     	.cached(CANDIDATES_FOR_EPOCH_CACHE_SIZE)?;
+//!
+//!     let native_token =
+//!         NativeTokenManagementDataSourceImpl::new_from_env(pool.clone(), metrics.clone()).await?;
+//!
+//!     let block_participation =
+//!     	StakeDistributionDataSourceImpl::new(pool.clone(), metrics.clone(), STAKE_CACHE_SIZE);
+//!
+//!     let governed_map =
+//!         GovernedMapDataSourceCachedImpl::new(pool, metrics.clone(), GOVERNED_MAP_CACHE_SIZE, block).await?;
+//!     Ok(())
+//! }
+//! ```
 //!
 //! ## Cardano DB Sync configuration
-//! Cardano DB Sync instance requires specific configuration to maintain schema and data required by Partner Chains.
-//! See [configuration doc](https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md).
 //!
-//! `insert_options.tx_out.value` - if present then it has to be `"enable"` (default) or `"consumed"`.
-//!  When `"consumed"` is used then `tx_out.force_tx_in` has to be `true`.
-//!  Code in this module depends on `tx_in` table.
+//! Partner Chains data sources require specific Db-Sync configuration to be set for them to
+//! operate correctly:
+//! - `insert_options.tx_out.value`: must be either `"enable"` (default) or `"consumed"`.
+//!   When `"consumed"` is used then `tx_out.force_tx_in` has to be `true`.
+//!   Code in this crate depends on `tx_in` table being present.
+//! - `insert_options.tx_out.use_address_table`: must be `false` (default).
+//! - `insert_options.ledger`: must be `"enable"` (default).
+//! - `insert_options.multi_asset`: must be `true` (default).
+//! - `insert_options.governance`: must `"enable"` (default).
+//! - `insert_options.remove_jsonb_from_schema`: must be `"disable"` (default).
 //!
-//! `insert_options.tx_out.use_address_table` - if present then it has to be `false` (default).
-//!
-//! `insert_options.ledger` - if present then it has to be `"enable"` (default).
-//!
-//! `insert_options.multi_asset` - if present then it has to be `true` (default).
-//!
-//! `insert_options.governance` - if present then it has to be `"enable"` (default).
-//!
-//! `insert_options.remove_jsonb_from_schema` - if present then it has to be `"disable"` (default).
-//!
-//! The default Cardano DB Sync configuration meets these requirements.
-//! It is enough to not provide a custom configuration.
+//! The default Cardano DB Sync configuration meets these requirements, so Partner Chain node
+//! operators that do not wish to use any custom configuration can use the defaults, otherwise
+//! they must preserve the values described above. See [Db-Sync configuration docs] for more
+//! information.
 //!
 //! ## Custom Indexes
-//! Cardano DB Sync creates a number of indexes for its own purpose.
-//! Queries used in this module depend on some of them to be executed efficiently.
-//! What is more, additional indexes are required:
-//! * `idx_ma_tx_out_ident ON ma_tx_out(ident)`
-//! * `idx_tx_out_address ON tx_out USING hash (address)`
-//! This module provides functionality to automatically create such indexes on the node startup.
-use cardano_serialization_lib::PlutusData;
+//!
+//! In addition to indexes automatically created by Db-Sync itself, data sources in this crate
+//! require additional ones to be created for some of the queries to execute efficiently. These
+//! indexes are:
+//! - `idx_ma_tx_out_ident ON ma_tx_out(ident)`
+//! - `idx_tx_out_address ON tx_out USING hash (address)`
+//!
+//! The data sources in this crate automatically create these indexes when needed at node startup.
+//!
+//! [PgPool]: sqlx::PgPool
+//! [BlockDataSourceImpl]: crate::block::BlockDataSourceImpl
+//! [McFollowerMetrics]: crate::metrics::McFollowerMetrics
+//! [get_connection_from_env]: crate::data_sources::get_connection_from_env
+//! [register_metrics_warn_errors]: crate::metrics::register_metrics_warn_errors
+//! [Db-Sync configuration docs]: https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/configuration.md
+#![deny(missing_docs)]
+#![allow(rustdoc::private_intra_doc_links)]
 
-pub mod data_sources;
-mod db_datum;
-mod db_model;
-pub mod metrics;
+pub use crate::{
+	data_sources::{ConnectionConfig, PgPool, get_connection_from_env, read_mc_epoch_config},
+	metrics::{McFollowerMetrics, register_metrics_warn_errors},
+};
 
 #[cfg(feature = "block-source")]
-pub mod block;
+pub use crate::block::{BlockDataSourceImpl, DbSyncBlockDataSourceConfig};
 #[cfg(feature = "candidate-source")]
-pub mod candidates;
+pub use crate::candidates::CandidatesDataSourceImpl;
 #[cfg(feature = "governed-map")]
-pub mod governed_map;
+pub use crate::governed_map::{GovernedMapDataSourceCachedImpl, GovernedMapDataSourceImpl};
 #[cfg(feature = "mc-hash")]
-pub mod mc_hash;
+pub use crate::mc_hash::McHashDataSourceImpl;
 #[cfg(feature = "native-token")]
-pub mod native_token;
+pub use crate::native_token::NativeTokenManagementDataSourceImpl;
 #[cfg(feature = "sidechain-rpc")]
-pub mod sidechain_rpc;
+pub use crate::sidechain_rpc::SidechainRpcDataSourceImpl;
 #[cfg(feature = "block-participation")]
-pub mod stake_distribution;
+pub use crate::stake_distribution::StakeDistributionDataSourceImpl;
 
+mod data_sources;
+mod db_datum;
+mod db_model;
+mod metrics;
+
+#[cfg(feature = "block-source")]
+mod block;
+#[cfg(feature = "candidate-source")]
+mod candidates;
+#[cfg(feature = "governed-map")]
+mod governed_map;
+#[cfg(feature = "mc-hash")]
+mod mc_hash;
+#[cfg(feature = "native-token")]
+mod native_token;
+#[cfg(feature = "sidechain-rpc")]
+mod sidechain_rpc;
+#[cfg(feature = "block-participation")]
+mod stake_distribution;
+
+/// Wrapper error type for [sqlx::Error]
 pub struct SqlxError(sqlx::Error);
 
 impl From<sqlx::Error> for SqlxError {
@@ -70,27 +156,29 @@ impl From<SqlxError> for Box<dyn std::error::Error + Send + Sync> {
 	}
 }
 
+/// Error type returned by Db-Sync based data sources
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum DataSourceError {
+	/// Indicates that the Db-Sync database rejected a request as invalid
 	#[error("Bad request: `{0}`.")]
 	BadRequest(String),
+	/// Indicates that an internal error occured when querying the Db-Sync database
 	#[error("Internal error of data source: `{0}`.")]
 	InternalDataSourceError(String),
-	#[error(
-		"Could not decode {datum:?} to {to:?}, this means that there is an error in Plutus scripts or the data source is outdated."
-	)]
-	DatumDecodeError { datum: PlutusData, to: String },
+	/// Indicates that expected data was not found when querying the Db-Sync database
 	#[error(
 		"'{0}' not found. Possible causes: data source configuration error, db-sync not synced fully, or data not set on the main chain."
 	)]
 	ExpectedDataNotFound(String),
+	/// Indicates that data returned by the Db-Sync database is invalid
 	#[error(
 		"Invalid data. {0} Possible cause is an error in Plutus scripts or data source is outdated."
 	)]
 	InvalidData(String),
 }
 
-pub type Result<T> = std::result::Result<T, DataSourceError>;
+/// Result type used by Db-Sync data sources
+pub(crate) type Result<T> = std::result::Result<T, DataSourceError>;
 
 #[cfg(test)]
 mod tests {

--- a/toolkit/data-sources/db-sync/src/mc_hash/mod.rs
+++ b/toolkit/data-sources/db-sync/src/mc_hash/mod.rs
@@ -1,15 +1,22 @@
+//! Db-Sync data source used by Partner Chain MC Reference feature
 use crate::{block::BlockDataSourceImpl, metrics::McFollowerMetrics, observed_async_trait};
 use sidechain_domain::{MainchainBlock, McBlockHash};
 use sidechain_mc_hash::McHashDataSource;
 use sp_timestamp::Timestamp;
 use std::sync::Arc;
 
+/// Db-Sync data source used by the Main Chain Reference feature of Partner Chain toolkit.
+///
+/// See [sidechain_mc_hash] a detailed explanation of its purpose.
 pub struct McHashDataSourceImpl {
+	/// [BlockDataSourceImpl] instance shared with other data sources for cache reuse.
 	inner: Arc<BlockDataSourceImpl>,
+	/// Prometheus metrics client
 	metrics_opt: Option<McFollowerMetrics>,
 }
 
 impl McHashDataSourceImpl {
+	/// Creates a new MC Hash data source by wrapping an instance of [BlockDataSourceImpl]
 	pub fn new(inner: Arc<BlockDataSourceImpl>, metrics_opt: Option<McFollowerMetrics>) -> Self {
 		Self { inner, metrics_opt }
 	}

--- a/toolkit/data-sources/db-sync/src/metrics.rs
+++ b/toolkit/data-sources/db-sync/src/metrics.rs
@@ -1,8 +1,10 @@
+//! Substrate Prometheus metrics client for Db-Sync-based Partner Chain data sources
 use log::warn;
 use substrate_prometheus_endpoint::{
 	CounterVec, HistogramOpts, HistogramVec, Opts, PrometheusError, Registry, U64, register,
 };
 
+/// Substrate Prometheus metrics client used by Partner Chain data sources
 #[derive(Clone)]
 pub struct McFollowerMetrics {
 	time_elapsed: HistogramVec,
@@ -10,13 +12,13 @@ pub struct McFollowerMetrics {
 }
 
 impl McFollowerMetrics {
-	pub fn time_elapsed(&self) -> &HistogramVec {
+	pub(crate) fn time_elapsed(&self) -> &HistogramVec {
 		&self.time_elapsed
 	}
-	pub fn call_count(&self) -> &CounterVec<U64> {
+	pub(crate) fn call_count(&self) -> &CounterVec<U64> {
 		&self.call_count
 	}
-	pub fn register(registry: &Registry) -> Result<Self, PrometheusError> {
+	pub(crate) fn register(registry: &Registry) -> Result<Self, PrometheusError> {
 		Ok(Self {
 			time_elapsed: register(
 				HistogramVec::new(
@@ -42,6 +44,7 @@ impl McFollowerMetrics {
 	}
 }
 
+/// Registers new metrics with Substrate Prometheus metrics service and returns a client instance
 pub fn register_metrics_warn_errors(
 	metrics_registry_opt: Option<&Registry>,
 ) -> Option<McFollowerMetrics> {
@@ -93,11 +96,11 @@ macro_rules! observed_async_trait {
 }
 
 #[cfg(test)]
-pub mod mock {
+pub(crate) mod mock {
 	use crate::metrics::McFollowerMetrics;
 	use substrate_prometheus_endpoint::{CounterVec, HistogramOpts, HistogramVec, Opts};
 
-	pub fn test_metrics() -> McFollowerMetrics {
+	pub(crate) fn test_metrics() -> McFollowerMetrics {
 		McFollowerMetrics {
 			time_elapsed: HistogramVec::new(HistogramOpts::new("test", "test"), &["method_name"])
 				.unwrap(),

--- a/toolkit/data-sources/db-sync/src/native_token/mod.rs
+++ b/toolkit/data-sources/db-sync/src/native_token/mod.rs
@@ -1,3 +1,4 @@
+//! Db-Sync data source used by Partner Chain Native Token Management feature
 use crate::db_model::{Block, BlockNumber};
 use crate::metrics::McFollowerMetrics;
 use crate::observed_async_trait;
@@ -11,11 +12,19 @@ use std::sync::{Arc, Mutex};
 #[cfg(test)]
 mod tests;
 
+/// Db-Sync data source for the Native Token Management feature of the Partner Chains toolkit.
+///
+/// See documentation for [sp_native_token_management] for information about the feature.
 pub struct NativeTokenManagementDataSourceImpl {
+	/// Postgres connection pool
 	pub pool: PgPool,
+	/// Prometheus metrics client
 	pub metrics_opt: Option<McFollowerMetrics>,
+	/// Cardano security parameter, ie. the number of confirmations needed to stabilize a block
 	security_parameter: u32,
+	/// Size of internal data cache
 	cache_size: u16,
+	/// Internal data cache
 	cache: Arc<Mutex<Cache>>,
 }
 
@@ -69,6 +78,7 @@ impl NativeTokenManagementDataSource for NativeTokenManagementDataSourceImpl {
 });
 
 impl NativeTokenManagementDataSourceImpl {
+	/// Creates a new instance of the data source
 	pub async fn new(
 		pool: PgPool,
 		metrics_opt: Option<McFollowerMetrics>,
@@ -80,6 +90,7 @@ impl NativeTokenManagementDataSourceImpl {
 		Ok(Self { pool, metrics_opt, security_parameter, cache_size, cache })
 	}
 
+	/// Creates a new instance of the data source, reading configuration from the environment
 	pub async fn new_from_env(
 		pool: PgPool,
 		metrics_opt: Option<McFollowerMetrics>,

--- a/toolkit/data-sources/db-sync/src/sidechain_rpc/mod.rs
+++ b/toolkit/data-sources/db-sync/src/sidechain_rpc/mod.rs
@@ -1,14 +1,19 @@
+//! Db-Sync data source used by Partner Chain Json RPC
 use crate::{block::BlockDataSourceImpl, metrics::McFollowerMetrics, observed_async_trait};
 use pallet_sidechain_rpc::SidechainRpcDataSource;
 use sidechain_domain::MainchainBlock;
 use std::sync::Arc;
 
+/// Db-Sync data source serving basic Cardano block data
 pub struct SidechainRpcDataSourceImpl {
+	/// [BlockDataSourceImpl] instance shared with other data sources for cache reuse.
 	inner: Arc<BlockDataSourceImpl>,
+	/// Prometheus metrics client
 	metrics_opt: Option<McFollowerMetrics>,
 }
 
 impl SidechainRpcDataSourceImpl {
+	/// Creates a Sidechain new data source by wrapping the given instance of [BlockDataSourceImpl]
 	pub fn new(inner: Arc<BlockDataSourceImpl>, metrics_opt: Option<McFollowerMetrics>) -> Self {
 		Self { inner, metrics_opt }
 	}

--- a/toolkit/data-sources/db-sync/src/stake_distribution/mod.rs
+++ b/toolkit/data-sources/db-sync/src/stake_distribution/mod.rs
@@ -1,3 +1,5 @@
+//! Db-Sync data source serving information about Cardano stake delegation.
+//! Used by the Partner Chain Block Participation feature.
 use crate::db_model::{EpochNumber, StakePoolDelegationOutputRow};
 use crate::metrics::McFollowerMetrics;
 use crate::observed_async_trait;
@@ -10,13 +12,18 @@ use std::sync::{Arc, Mutex};
 #[cfg(test)]
 mod tests;
 
+/// Db-Sync data source serving data about Cardano delegations
 pub struct StakeDistributionDataSourceImpl {
+	/// Postgres connection poool
 	pub pool: PgPool,
+	/// Prometheus metrics client
 	metrics_opt: Option<McFollowerMetrics>,
+	/// Internal data cache
 	cache: Cache,
 }
 
 impl StakeDistributionDataSourceImpl {
+	/// Creates a Stake Distribution new data source instance
 	pub fn new(pool: PgPool, metrics_opt: Option<McFollowerMetrics>, cache_size: usize) -> Self {
 		StakeDistributionDataSourceImpl { pool, metrics_opt, cache: Cache::new(cache_size) }
 	}


### PR DESCRIPTION
# Description

- Documents the `partner-chains-db-sync-data-sources` crate
- Fixes visibility of some members that should not be public
- Simplifies some code using already existing helpers
- Re-exports all public members of the crate from its root and makes individual modules private, so they're easier to import


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
