### PR TITLE
feat: make wizards set governedMap.MainChainScripts in the chain-spec file

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -16,6 +16,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* `prepare-configuration` and `create-chain-spec` wizards are updated to setup `governedMap.MainChainScripts` in the chain-spec file.
 * `prepare-configuration` wizard suggests payment signing key hash as governance authority if there is no value in chain config stored so far.
 * Automatically create required index on `tx_out` table `address` column. Constructor signatures have changed - this change is not source compatible.
 * BREAKING: Wizards are not generating keys nor looking for them in `<base_path>/chains/partner_chains_template` but use `<base_path>` instead.

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -543,6 +543,24 @@ pub mod config_fields {
 			_marker: PhantomData,
 		};
 
+	pub const GOVERNED_MAP_VALIDATOR_ADDRESS: ConfigFieldDefinition<'static, String> =
+		ConfigFieldDefinition {
+			config_file: CHAIN_CONFIG_FILE_PATH,
+			path: &["cardano_addresses", "governed_map", "validator_address"],
+			name: "Governed Map Validator Address",
+			default: None,
+			_marker: PhantomData,
+		};
+
+	pub const GOVERNED_MAP_POLICY_ID: ConfigFieldDefinition<'static, String> =
+		ConfigFieldDefinition {
+			config_file: CHAIN_CONFIG_FILE_PATH,
+			path: &["cardano_addresses", "governed_map", "policy_id"],
+			name: "Governed Map Policy Id",
+			default: None,
+			_marker: PhantomData,
+		};
+
 	pub const CARDANO_SECURITY_PARAMETER: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -203,6 +203,12 @@ fn test_chain_spec_content() -> serde_json::Value {
 								"permissioned_candidates_policy_id": "0x5678"
 							}
 						},
+						"governedMap": {
+							"mainChainScripts": {
+								"validator_address": "",
+								"asset_policy_id": "0x0000"
+							}
+						}
 					}
 				}
 			},
@@ -237,6 +243,10 @@ fn cardano_addresses_json() -> serde_json::Value {
 			},
 			"illiquid_supply_address": "addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz"
 		},
+		"governed_map": {
+			"validator_address": "addr_test1wqpjpjq08treyvmqjca0qy5kw8xgq4awgt945v46jsxgyhsafz4ws",
+			"policy_id": "c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000"
+		}
 	})
 }
 
@@ -267,6 +277,13 @@ fn show_chain_parameters() -> MockIO {
 		),
 		MockIO::print(
 			"- illiquid supply address: addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz",
+		),
+		MockIO::print("Governed Map Configuration:"),
+		MockIO::print(
+			"- validator address: addr_test1wqpjpjq08treyvmqjca0qy5kw8xgq4awgt945v46jsxgyhsafz4ws",
+		),
+		MockIO::print(
+			"- asset policy ID: c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000",
 		),
 	])
 }
@@ -376,6 +393,12 @@ fn updated_chain_spec() -> serde_json::Value {
 								"permissioned_candidates_policy_id": "0x5678"
 							}
 						},
+						"governedMap": {
+							"mainChainScripts": {
+								"asset_policy_id": "0xc814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000",
+								"validator_address": "0x616464725f74657374317771706a706a71303874726579766d716a6361307179356b773878677134617767743934357634366a73786779687361667a347773"
+							}
+						}
 					}
 				}
 			},

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -1,8 +1,8 @@
 use crate::config::ServiceConfig;
 use crate::config::config_fields::{
-	COMMITTEE_CANDIDATES_ADDRESS, D_PARAMETER_POLICY_ID, ILLIQUID_SUPPLY_ADDRESS,
-	INITIAL_PERMISSIONED_CANDIDATES, NATIVE_TOKEN_ASSET_NAME, NATIVE_TOKEN_POLICY,
-	PERMISSIONED_CANDIDATES_POLICY_ID,
+	COMMITTEE_CANDIDATES_ADDRESS, D_PARAMETER_POLICY_ID, GOVERNED_MAP_POLICY_ID,
+	GOVERNED_MAP_VALIDATOR_ADDRESS, ILLIQUID_SUPPLY_ADDRESS, INITIAL_PERMISSIONED_CANDIDATES,
+	NATIVE_TOKEN_ASSET_NAME, NATIVE_TOKEN_POLICY, PERMISSIONED_CANDIDATES_POLICY_ID,
 };
 use crate::io::IOContext;
 use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
@@ -42,16 +42,22 @@ fn set_up_cardano_addresses<C: IOContext>(
 	let permissioned_candidates_policy_id =
 		hex::encode(scripts_data.policy_ids.permissioned_candidates.0);
 	let illiquid_supply_addr = scripts_data.addresses.illiquid_circulation_supply_validator;
+	let governed_map_validator_addr = scripts_data.addresses.governed_map_validator;
+	let governed_map_policy_id = hex::encode(scripts_data.policy_ids.governed_map.0);
 	COMMITTEE_CANDIDATES_ADDRESS.save_to_file(&committee_candidate_validator_addr, context);
 	D_PARAMETER_POLICY_ID.save_to_file(&d_parameter_policy_id, context);
 	PERMISSIONED_CANDIDATES_POLICY_ID.save_to_file(&permissioned_candidates_policy_id, context);
 	ILLIQUID_SUPPLY_ADDRESS.save_to_file(&illiquid_supply_addr, context);
+	GOVERNED_MAP_VALIDATOR_ADDRESS.save_to_file(&governed_map_validator_addr, context);
+	GOVERNED_MAP_POLICY_ID.save_to_file(&governed_map_policy_id, context);
 	context.print(&format!(
 		"Cardano addresses have been set up:
 - Committee Candidates Address: {committee_candidate_validator_addr}
 - D Parameter Policy ID: {d_parameter_policy_id}
 - Permissioned Candidates Policy ID: {permissioned_candidates_policy_id}
-- Illiquid Supply Address: {illiquid_supply_addr}"
+- Illiquid Supply Address: {illiquid_supply_addr}
+- Governed Map Validator Address: {governed_map_validator_addr}
+- Governed Map Policy Id: {governed_map_policy_id}"
 	));
 	Ok(())
 }
@@ -121,6 +127,10 @@ mod tests {
 		"13db1ba564b3b264f45974fece44b2beb0a2326b10e65a0f7f300dfb";
 	const TEST_ILLIQUID_SUPPLY_ADDRESS: &str =
 		"addr_test1wqn2pkvvmesmxtfa4tz7w8gh8vumr52lpkrhcs4dkg30uqq77h5z4";
+	const TEST_GOVERNED_MAP_VALIDATOR_ADDRESS: &str =
+		"addr_test1wqcyptcm4ueft86vjnqng0k70gdazzukmyknuhmsjhmvfts7c0000";
+	const TEST_GOVERNED_MAP_POLICY_ID: &str =
+		"c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000";
 
 	fn ogmios_config() -> ServiceConfig {
 		ServiceConfig {
@@ -247,7 +257,9 @@ mod tests {
 - Committee Candidates Address: {TEST_COMMITTEE_CANDIDATES_ADDRESS}
 - D Parameter Policy ID: {TEST_D_PARAMETER_POLICY_ID}
 - Permissioned Candidates Policy ID: {TEST_PERMISSIONED_CANDIDATES_POLICY_ID}
-- Illiquid Supply Address: {TEST_ILLIQUID_SUPPLY_ADDRESS}",
+- Illiquid Supply Address: {TEST_ILLIQUID_SUPPLY_ADDRESS}
+- Governed Map Validator Address: {TEST_GOVERNED_MAP_VALIDATOR_ADDRESS}
+- Governed Map Policy Id: {TEST_GOVERNED_MAP_POLICY_ID}",
 		))
 	}
 
@@ -258,6 +270,7 @@ mod tests {
 				addresses: Addresses {
 					committee_candidate_validator: TEST_COMMITTEE_CANDIDATES_ADDRESS.to_string(),
 					illiquid_circulation_supply_validator: TEST_ILLIQUID_SUPPLY_ADDRESS.to_string(),
+					governed_map_validator: TEST_GOVERNED_MAP_VALIDATOR_ADDRESS.to_string(),
 					..Default::default()
 				},
 				policy_ids: PolicyIds {
@@ -265,6 +278,7 @@ mod tests {
 						TEST_PERMISSIONED_CANDIDATES_POLICY_ID,
 					),
 					d_parameter: PolicyId::from_hex_unsafe(TEST_D_PARAMETER_POLICY_ID),
+					governed_map: PolicyId::from_hex_unsafe(TEST_GOVERNED_MAP_POLICY_ID),
 					..Default::default()
 				},
 			}),
@@ -287,6 +301,10 @@ mod tests {
 				"committee_candidates_address": TEST_COMMITTEE_CANDIDATES_ADDRESS,
 				"d_parameter_policy_id": TEST_D_PARAMETER_POLICY_ID,
 				"permissioned_candidates_policy_id": TEST_PERMISSIONED_CANDIDATES_POLICY_ID,
+				"governed_map": {
+					"policy_id": TEST_GOVERNED_MAP_POLICY_ID,
+					"validator_address": TEST_GOVERNED_MAP_VALIDATOR_ADDRESS,
+				},
 				"native_token": {
 					"illiquid_supply_address": TEST_ILLIQUID_SUPPLY_ADDRESS,
 					"asset": {

--- a/toolkit/sidechain/domain/Cargo.toml
+++ b/toolkit/sidechain/domain/Cargo.toml
@@ -52,6 +52,7 @@ std = [
 	"bech32/std",
 	"sp-io/std",
 	"secp256k1/std",
+	"secp256k1/global-context",
 	"ed25519-zebra",
 	"ed25519-zebra/std",
 ]


### PR DESCRIPTION
# Description

This updates governedMap.MainChainScripts in the same way as initial validators are set and differently to how other MainChainScripts are set.

This is intentionally ditching reliance on the node `chain-spec` command, and in turn its reliance on env variables.

Please read questions in the comments.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
