### PR TITLE
feat: make Ogmios requests timeout configurable and bigger by default

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -17,6 +17,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* `smart-contracts` commands can accept parameter to configure Ogmios requests timeout
 * `prepare-configuration` and `create-chain-spec` wizards are updated to setup `governedMap.MainChainScripts` in the chain-spec file.
 * `setup-main-chain-state` wizard uses Ogmios and `offchain` crate for getting the current D-parameter and Permissioned Candidates instead of invoking `<node-executable> ariadne-parameters` command.
 * `prepare-configuration` wizard suggests payment signing key hash as governance authority if there is no value in chain config stored so far.

--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -10,11 +10,12 @@ use partner_chains_cardano_offchain::permissioned_candidates::{
 use partner_chains_cardano_offchain::register::{Deregister, Register};
 use partner_chains_cardano_offchain::scripts_data::GetScriptsData;
 use sp_core::offchain::Timestamp;
-use std::path::PathBuf;
 use std::{
 	fs,
 	io::{BufRead, BufReader, Read},
+	path::PathBuf,
 	process::Stdio,
+	time::Duration,
 };
 use tempfile::{TempDir, TempPath};
 
@@ -197,9 +198,11 @@ impl IOContext for DefaultCmdRunContext {
 	fn offchain_impl(&self, ogmios_config: &ServiceConfig) -> anyhow::Result<Self::Offchain> {
 		let ogmios_address = ogmios_config.to_string();
 		let tokio_runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
-		tokio_runtime.block_on(client_for_url(&ogmios_address)).map_err(|_| {
-			anyhow!(format!("Couldn't open connection to Ogmios at {}", ogmios_address))
-		})
+		tokio_runtime
+			.block_on(client_for_url(&ogmios_address, Some(Duration::from_secs(180))))
+			.map_err(|_| {
+				anyhow!(format!("Couldn't open connection to Ogmios at {}", ogmios_address))
+			})
 	}
 }
 

--- a/toolkit/partner-chains-cli/src/ogmios/mod.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/mod.rs
@@ -5,6 +5,7 @@ use ogmios_client::{
 	types::OgmiosUtxo,
 };
 use sidechain_domain::NetworkType;
+use std::time::Duration;
 
 pub(crate) mod config;
 
@@ -71,7 +72,7 @@ pub struct UtxoValue {
 pub fn ogmios_request(addr: &str, req: OgmiosRequest) -> anyhow::Result<OgmiosResponse> {
 	let tokio_runtime = tokio::runtime::Runtime::new().map_err(|e| anyhow::anyhow!(e))?;
 	tokio_runtime.block_on(async {
-		let client = client_for_url(addr)
+		let client = client_for_url(addr, Some(Duration::from_secs(180)))
 			.await
 			.map_err(|e| anyhow::anyhow!("Failed to connect to Ogmios at {} with: {}", addr, e))?;
 		match req {

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -79,6 +79,9 @@ pub struct CommonArguments {
 	#[arg(default_value = "ws://localhost:1337", long, short = 'O', env)]
 	/// URL of the Ogmios server
 	ogmios_url: String,
+	#[arg(default_value = "180", long, env)]
+	/// Timeout in seconds for Ogmios requests.
+	ogmios_requests_timeout_seconds: u64,
 	#[arg(default_value = "5", long)]
 	/// Delay between retries in seconds. System will wait this long between
 	/// queries checking if transaction is included in the blockchain.
@@ -92,9 +95,12 @@ pub struct CommonArguments {
 impl CommonArguments {
 	/// Connects to the Ogmios server and returns a client
 	pub async fn get_ogmios_client(&self) -> crate::CmdResult<OgmiosClients> {
-		Ok(client_for_url(&self.ogmios_url).await.map_err(|e| {
-			format!("Failed to connect to Ogmios at {} with: {}", &self.ogmios_url, e)
-		})?)
+		Ok(client_for_url(
+			&self.ogmios_url,
+			Some(Duration::from_secs(self.ogmios_requests_timeout_seconds)),
+		)
+		.await
+		.map_err(|e| format!("Failed to connect to Ogmios at {} with: {}", &self.ogmios_url, e))?)
 	}
 
 	/// Builds a `FixedDelayRetries` instance for retrying failed operations

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -442,7 +442,7 @@ async fn initialize<'a>(container: &Container<'a, GenericImage>) -> OgmiosClient
 async fn await_ogmios(ogmios_port: u16) -> Result<OgmiosClients, String> {
 	let url = format!("ws://localhost:{}", ogmios_port);
 	Retry::spawn(FixedInterval::new(Duration::from_millis(100)).take(1000), || async {
-		let client = client_for_url(&url).await?;
+		let client = client_for_url(&url, None).await?;
 		let _ = client.shelley_genesis_configuration().await.map_err(|e| e.to_string())?;
 		Ok(client)
 	})

--- a/toolkit/utils/ogmios-client/src/jsonrpsee.rs
+++ b/toolkit/utils/ogmios-client/src/jsonrpsee.rs
@@ -9,6 +9,7 @@ use jsonrpsee::{
 };
 use serde::de::DeserializeOwned;
 use serde_json::json;
+use std::time::Duration;
 
 fn request_to_json(method: &str, params: impl ToRpcParams) -> Result<String, OgmiosClientError> {
 	let params = params
@@ -39,9 +40,13 @@ pub enum OgmiosClients {
 
 /// Returns client that works either with HTTP or WebSockets.
 /// HTTP does not return JSON-RPC error body in case of 400 Bad Request.
-pub async fn client_for_url(addr: &str) -> Result<OgmiosClients, String> {
+pub async fn client_for_url(
+	addr: &str,
+	timeout: Option<Duration>,
+) -> Result<OgmiosClients, String> {
 	if addr.starts_with("http") || addr.starts_with("https") {
 		let client = HttpClientBuilder::default()
+			.request_timeout(timeout.unwrap_or(Duration::from_secs(60)))
 			.build(addr)
 			.map_err(|e| format!("Couldn't create HTTP client: {}", e))?;
 
@@ -56,6 +61,7 @@ pub async fn client_for_url(addr: &str) -> Result<OgmiosClients, String> {
 		Ok(http_client)
 	} else if addr.starts_with("ws") || addr.starts_with("wss") {
 		let client = WsClientBuilder::default()
+			.request_timeout(timeout.unwrap_or(Duration::from_secs(60)))
 			.build(addr.to_owned())
 			.await
 			.map_err(|e| format!("Couldn't create WebSockets client: {}", e))?;

--- a/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
+++ b/toolkit/utils/ogmios-client/tests/query_ledger_state.rs
@@ -90,7 +90,7 @@ async fn era_summaries() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let era_summaries = client.era_summaries().await.unwrap();
 	assert_eq!(era_summaries.len(), 3);
 	assert_eq!(
@@ -167,7 +167,7 @@ async fn protocol_parameters() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let parameters = client.query_protocol_parameters().await.unwrap();
 
 	assert_eq!(
@@ -232,7 +232,7 @@ async fn query_utxos() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let utxos = client
 		.query_utxos(&[
 			"addr_test1vqezxrh24ts0775hulcg3ejcwj7hns8792vnn8met6z9gwsxt87zy".into(),
@@ -292,7 +292,7 @@ async fn query_utxos_by_tx_hash() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let utxo = client
 		.query_utxo_by_id(UtxoId::new(
 			hex!("106b0d7d1544c97941777041699412fb7c8b94855210987327199620c0599580"),

--- a/toolkit/utils/ogmios-client/tests/query_network.rs
+++ b/toolkit/utils/ogmios-client/tests/query_network.rs
@@ -43,7 +43,7 @@ async fn shelley_genesis_configuration() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let genesis_configuration = client.shelley_genesis_configuration().await.unwrap();
 	assert_eq!(
 		genesis_configuration,

--- a/toolkit/utils/ogmios-client/tests/transactions.rs
+++ b/toolkit/utils/ogmios-client/tests/transactions.rs
@@ -36,7 +36,7 @@ async fn evaluate_transaction() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let response = client.evaluate_transaction(&hex!("aabbccdd")).await.unwrap();
 	assert_eq!(
 		response[0],
@@ -60,7 +60,7 @@ async fn submit_transaction() {
 	})
 	.await
 	.unwrap();
-	let client = client_for_url(&format!("ws://{address}")).await.unwrap();
+	let client = client_for_url(&format!("ws://{address}"), None).await.unwrap();
 	let response = client.submit_transaction(&hex!("aabbccdd")).await.unwrap();
 	assert_eq!(
 		response,


### PR DESCRIPTION
# Description

There are reports that for Mainnet setup, default 1 minute Ogmios request is not always enough.
This PR adds possibility to configure the timeout. I don't think we can optimize queries in any way.

JIRA ref:ETCM-9855, ETCM-9856

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
