### PR TITLE
feat: handle Ctrl-C and ESC in wizards without panic

### DIFF
--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -1,6 +1,8 @@
 use crate::config::ServiceConfig;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse, ogmios_request};
 use anyhow::{Context, anyhow};
+use inquire::InquireError;
+use inquire::error::InquireResult;
 use ogmios_client::jsonrpsee::{OgmiosClients, client_for_url};
 use partner_chains_cardano_offchain::d_param::{GetDParam, UpsertDParam};
 use partner_chains_cardano_offchain::init_governance::InitGovernance;
@@ -123,15 +125,15 @@ impl IOContext for DefaultCmdRunContext {
 			prompt = prompt.with_default(default)
 		};
 
-		prompt.prompt().unwrap()
+		handle_inquire_result(prompt.prompt())
 	}
 
 	fn prompt_yes_no(&self, prompt: &str, default: bool) -> bool {
-		inquire::Confirm::new(prompt).with_default(default).prompt().unwrap()
+		handle_inquire_result(inquire::Confirm::new(prompt).with_default(default).prompt())
 	}
 
 	fn prompt_multi_option(&self, msg: &str, options: Vec<String>) -> String {
-		inquire::Select::new(msg, options).prompt().unwrap().to_string()
+		handle_inquire_result(inquire::Select::new(msg, options).prompt()).to_string()
 	}
 
 	fn write_file(&self, path: &str, content: &str) {
@@ -206,4 +208,16 @@ impl IOContext for DefaultCmdRunContext {
 pub fn prompt_can_write<C: IOContext>(name: &str, path: &str, context: &C) -> bool {
 	!context.file_exists(path)
 		|| context.prompt_yes_no(&format!("{name} {path} exists - overwrite it?"), false)
+}
+
+fn handle_inquire_result<T>(result: InquireResult<T>) -> T {
+	match result {
+		Ok(result) => result,
+		Err(InquireError::OperationInterrupted) => {
+			eprintln!("Ctrl-C pressed. Exiting Wizard.");
+			std::process::exit(0)
+		},
+		Err(InquireError::OperationCanceled) => std::process::exit(0),
+		result => result.unwrap(),
+	}
 }


### PR DESCRIPTION
# Description

ECS pressed:
```
./partner-chains-demo-node wizards prepare-configuration
This 🧙 wizard will generate chain config file
? node base path <canceled>
```
Ctrl-C:
```
./partner-chains-demo-node wizards prepare-configuration
This 🧙 wizard will generate chain config file
? node base path (./data)
Ctrl-C pressed. Exiting Wizard.
```

REF: ETCM-11879
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
