### PR TITLE
chore: move offchain command traits

### DIFF
--- a/toolkit/partner-chains-cli/src/cmd_traits.rs
+++ b/toolkit/partner-chains-cli/src/cmd_traits.rs
@@ -1,0 +1,98 @@
+use partner_chains_cardano_offchain::{
+	await_tx::FixedDelayRetries, cardano_keys::CardanoPaymentSigningKey,
+	governance::MultiSigParameters, multisig::MultiSigSmartContractResult,
+	scripts_data::ScriptsData,
+};
+use sidechain_domain::{
+	CandidateRegistration, DParameter, McTxHash, PermissionedCandidateData, StakePoolPublicKey,
+	UtxoId,
+};
+
+/// Initializes governance mechanism.
+pub trait InitGovernance {
+	/// Initializes governance mechanism with Cardano Native Script of type `atLeast` parametrized with values from
+	/// `governance_parameters`, for the chain identified by `genesis_utxo_id`.
+	#[allow(async_fn_in_trait)]
+	async fn init_governance(
+		&self,
+		await_tx: FixedDelayRetries,
+		governance_parameters: &MultiSigParameters,
+		payment_key: &CardanoPaymentSigningKey,
+		genesis_utxo_id: UtxoId,
+	) -> Result<McTxHash, String>;
+}
+
+/// For the given `genesis_utxo` it returns the [ScriptsData] of the partner chain smart contracts.
+pub trait GetScriptsData {
+	#[allow(async_fn_in_trait)]
+	/// For the given `genesis_utxo` it returns the [ScriptsData] of the partner chain smart contracts.
+	async fn get_scripts_data(&self, genesis_utxo: UtxoId) -> Result<ScriptsData, String>;
+}
+
+/// Upserts D-param.
+pub trait UpsertDParam {
+	#[allow(async_fn_in_trait)]
+	/// This function upserts D-param.
+	async fn upsert_d_param(
+		&self,
+		await_tx: FixedDelayRetries,
+		genesis_utxo: UtxoId,
+		d_parameter: &DParameter,
+		payment_signing_key: &CardanoPaymentSigningKey,
+	) -> anyhow::Result<Option<MultiSigSmartContractResult>>;
+}
+/// Returns D-parameter.
+pub trait GetDParam {
+	#[allow(async_fn_in_trait)]
+	/// Returns D-parameter.
+	async fn get_d_param(&self, genesis_utxo: UtxoId) -> anyhow::Result<Option<DParameter>>;
+}
+
+/// Registers a registered candidate.
+pub trait Register {
+	#[allow(async_fn_in_trait)]
+	/// This function submits a transaction to register a registered candidate.
+	async fn register(
+		&self,
+		await_tx: FixedDelayRetries,
+		genesis_utxo: UtxoId,
+		candidate_registration: &CandidateRegistration,
+		payment_signing_key: &CardanoPaymentSigningKey,
+	) -> Result<Option<McTxHash>, String>;
+}
+
+/// Deregisters a registered candidate.
+pub trait Deregister {
+	#[allow(async_fn_in_trait)]
+	/// This function submits a transaction to deregister a registered candidate.
+	async fn deregister(
+		&self,
+		await_tx: FixedDelayRetries,
+		genesis_utxo: UtxoId,
+		payment_signing_key: &CardanoPaymentSigningKey,
+		stake_ownership_pub_key: StakePoolPublicKey,
+	) -> Result<Option<McTxHash>, String>;
+}
+
+/// Upserts permissioned candidates list.
+pub trait UpsertPermissionedCandidates {
+	#[allow(async_fn_in_trait)]
+	/// Upserts permissioned candidates list.
+	async fn upsert_permissioned_candidates(
+		&self,
+		await_tx: FixedDelayRetries,
+		genesis_utxo: UtxoId,
+		candidates: &[PermissionedCandidateData],
+		payment_signing_key: &CardanoPaymentSigningKey,
+	) -> anyhow::Result<Option<MultiSigSmartContractResult>>;
+}
+
+/// Returns all permissioned candidates.
+pub trait GetPermissionedCandidates {
+	#[allow(async_fn_in_trait)]
+	/// Returns all permissioned candidates.
+	async fn get_permissioned_candidates(
+		&self,
+		genesis_utxo: UtxoId,
+	) -> anyhow::Result<Option<Vec<PermissionedCandidateData>>>;
+}

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -6,7 +6,6 @@ use crate::ogmios::config::tests::{
 use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
 use crate::{CmdRun, CommonArguments, verify_json};
 use hex_literal::hex;
-use partner_chains_cardano_offchain::OffchainError;
 use serde_json::json;
 use sidechain_domain::*;
 
@@ -45,7 +44,7 @@ fn errors_if_smart_contracts_dont_output_transaction_id() {
 		genesis_utxo(),
 		payment_signing_key(),
 		stake_ownership_pub_key(),
-		Err(OffchainError::InternalError("test error".to_string())),
+		Err("test error".to_string()),
 	);
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
@@ -61,7 +60,7 @@ fn errors_if_smart_contracts_dont_output_transaction_id() {
 	let result = deregister_cmd().run(&mock_context);
 	assert_eq!(
 		result.err().unwrap().to_string(),
-		r#"Candidate deregistration failed: InternalError("test error")!"#
+		r#"Candidate deregistration failed: "test error"!"#
 	);
 	verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, final_resources_config_content());
 }

--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -1,16 +1,10 @@
+use crate::cmd_traits::*;
 use crate::config::ServiceConfig;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse, ogmios_request};
 use anyhow::{Context, anyhow};
 use inquire::InquireError;
 use inquire::error::InquireResult;
 use ogmios_client::jsonrpsee::{OgmiosClients, client_for_url};
-use partner_chains_cardano_offchain::d_param::{GetDParam, UpsertDParam};
-use partner_chains_cardano_offchain::init_governance::InitGovernance;
-use partner_chains_cardano_offchain::permissioned_candidates::{
-	GetPermissionedCandidates, UpsertPermissionedCandidates,
-};
-use partner_chains_cardano_offchain::register::{Deregister, Register};
-use partner_chains_cardano_offchain::scripts_data::GetScriptsData;
 use sp_core::offchain::Timestamp;
 use std::{
 	fs,

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -2,6 +2,7 @@
 //! Interacts with Smart Contracts using [`partner_chains_cardano_offchain`] crate.
 
 pub(crate) mod cardano_key;
+mod cmd_traits;
 pub mod config;
 pub mod create_chain_spec;
 pub(crate) mod data_source;

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -1,3 +1,4 @@
+use super::InitGovernance;
 use crate::{
 	IOContext,
 	config::{
@@ -8,7 +9,7 @@ use crate::{
 use anyhow::anyhow;
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries, cardano_keys::CardanoPaymentSigningKey,
-	governance::MultiSigParameters, init_governance::InitGovernance,
+	governance::MultiSigParameters,
 };
 use sidechain_domain::{MainchainKeyHash, McTxHash, UtxoId};
 

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -1,3 +1,4 @@
+use super::GetScriptsData;
 use crate::config::ServiceConfig;
 use crate::config::config_fields::{
 	COMMITTEE_CANDIDATES_ADDRESS, D_PARAMETER_POLICY_ID, GOVERNED_MAP_POLICY_ID,
@@ -6,7 +7,6 @@ use crate::config::config_fields::{
 };
 use crate::io::IOContext;
 use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
-use partner_chains_cardano_offchain::scripts_data::GetScriptsData;
 use sidechain_domain::{PolicyId, UtxoId};
 
 pub fn prepare_main_chain_config<C: IOContext>(
@@ -14,8 +14,8 @@ pub fn prepare_main_chain_config<C: IOContext>(
 	ogmios_config: &ServiceConfig,
 	genesis_utxo: UtxoId,
 ) -> anyhow::Result<()> {
-	let cardano_parameteres = prepare_cardano_params(ogmios_config, context)?;
-	cardano_parameteres.save(context);
+	let cardano_params = prepare_cardano_params(ogmios_config, context)?;
+	cardano_params.save(context);
 	set_up_cardano_addresses(context, genesis_utxo, ogmios_config)?;
 
 	if INITIAL_PERMISSIONED_CANDIDATES.load_from_file(context).is_none() {

--- a/toolkit/partner-chains-cli/src/register/mod.rs
+++ b/toolkit/partner-chains-cli/src/register/mod.rs
@@ -1,7 +1,15 @@
+use ogmios_client::query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId};
+use ogmios_client::query_network::QueryNetwork;
+use ogmios_client::transactions::Transactions;
+use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
+use partner_chains_cardano_offchain::cardano_keys::CardanoPaymentSigningKey;
+use partner_chains_cardano_offchain::register::run_register;
 use plutus_datum_derive::ToDatum;
 use secp256k1::PublicKey;
 use sidechain_domain::*;
 use std::{convert::Infallible, fmt::Display, str::FromStr};
+
+use crate::cmd_traits::Register;
 
 pub mod register1;
 pub mod register2;
@@ -56,5 +64,22 @@ pub struct StakePoolSigningKeyParam(pub ed25519_zebra::SigningKey);
 impl From<[u8; 32]> for StakePoolSigningKeyParam {
 	fn from(key: [u8; 32]) -> Self {
 		Self(ed25519_zebra::SigningKey::from(key))
+	}
+}
+
+impl<T> Register for T
+where
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+{
+	async fn register(
+		&self,
+		await_tx: FixedDelayRetries,
+		genesis_utxo: UtxoId,
+		candidate_registration: &CandidateRegistration,
+		payment_signing_key: &CardanoPaymentSigningKey,
+	) -> Result<Option<McTxHash>, String> {
+		run_register(genesis_utxo, candidate_registration, payment_signing_key, self, await_tx)
+			.await
+			.map_err(|e| e.to_string())
 	}
 }

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -6,10 +6,11 @@ use crate::config::config_fields;
 use crate::data_source::set_data_sources_env;
 use crate::io::IOContext;
 use crate::ogmios::config::establish_ogmios_configuration;
+use crate::register::Register;
 use clap::Parser;
-use partner_chains_cardano_offchain::register::Register;
 use sidechain_domain::mainchain_epoch::{MainchainEpochConfig, MainchainEpochDerivation};
 use sidechain_domain::*;
+use sidechain_domain::{CandidateRegistration, UtxoId};
 
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -164,7 +165,6 @@ mod tests {
 		verify_json,
 	};
 	use hex_literal::hex;
-	use partner_chains_cardano_offchain::OffchainError;
 	use serde_json::json;
 	use sp_core::offchain::Timestamp;
 
@@ -209,7 +209,7 @@ mod tests {
 			genesis_utxo(),
 			new_candidate_registration(),
 			payment_signing_key(),
-			Err(OffchainError::InternalError("test error".to_string())),
+			Err("test error".to_string()),
 		);
 		let mock_context = MockIOContext::new()
 			.with_json_file("/path/to/payment.skey", payment_skey_content())

--- a/toolkit/smart-contracts/offchain/src/d_param/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/d_param/mod.rs
@@ -4,7 +4,7 @@
 //! The datum encodes D-parameter using VersionedGenericDatum envelope with the D-parameter being
 //! `datum` field being `[num_permissioned_candidates, num_registered_candidates]`.
 
-use crate::await_tx::{AwaitTx, FixedDelayRetries};
+use crate::await_tx::AwaitTx;
 use crate::cardano_keys::CardanoPaymentSigningKey;
 use crate::csl::{
 	CostStore, Costs, InputsBuilderExt, NetworkTypeExt, TransactionBuilderExt, TransactionContext,
@@ -28,36 +28,6 @@ use sidechain_domain::{DParameter, UtxoId};
 
 #[cfg(test)]
 mod tests;
-
-/// Upserts D-param.
-pub trait UpsertDParam {
-	#[allow(async_fn_in_trait)]
-	/// This function upserts D-param.
-	/// Arguments:
-	///  - `await_tx`: Configuration for the await logic of the transaction.
-	///  - `genesis_utxo`: UTxO identifying the Partner Chain.
-	///  - `d_parameter`: [DParameter] to be upserted.
-	///  - `payment_signing_key`: Signing key of the party paying fees.
-	async fn upsert_d_param(
-		&self,
-		await_tx: FixedDelayRetries,
-		genesis_utxo: UtxoId,
-		d_parameter: &DParameter,
-		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<MultiSigSmartContractResult>>;
-}
-
-impl<C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId> UpsertDParam for C {
-	async fn upsert_d_param(
-		&self,
-		await_tx: FixedDelayRetries,
-		genesis_utxo: UtxoId,
-		d_parameter: &DParameter,
-		payment_signing_key: &CardanoPaymentSigningKey,
-	) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
-		upsert_d_param(genesis_utxo, d_parameter, payment_signing_key, self, &await_tx).await
-	}
-}
 
 /// This function upserts D-param.
 /// Arguments:
@@ -275,19 +245,6 @@ fn update_d_param_tx(
 	)?;
 
 	Ok(tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses())
-}
-
-/// Returns D-parameter.
-pub trait GetDParam {
-	#[allow(async_fn_in_trait)]
-	/// Returns D-parameter.
-	async fn get_d_param(&self, genesis_utxo: UtxoId) -> anyhow::Result<Option<DParameter>>;
-}
-
-impl<C: QueryLedgerState + QueryNetwork> GetDParam for C {
-	async fn get_d_param(&self, genesis_utxo: UtxoId) -> anyhow::Result<Option<DParameter>> {
-		get_d_param(genesis_utxo, self).await
-	}
 }
 
 /// Returns D-parameter.

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -1,9 +1,5 @@
 use crate::{
-	OffchainError,
-	await_tx::{AwaitTx, FixedDelayRetries},
-	cardano_keys::CardanoPaymentSigningKey,
-	csl::Costs,
-	csl::key_hash_address,
+	await_tx::AwaitTx, cardano_keys::CardanoPaymentSigningKey, csl::Costs, csl::key_hash_address,
 	governance::MultiSigParameters,
 };
 use anyhow::anyhow;
@@ -18,44 +14,6 @@ use sidechain_domain::{McTxHash, UtxoId};
 mod tests;
 
 pub(crate) mod transaction;
-
-/// Initializes governance mechanism.
-pub trait InitGovernance {
-	/// Initializes governance mechanism with Cardano Native Script of type `atLeast` parametrized with values from
-	/// `governance_parameters`, for the chain identified by `genesis_utxo_id`.
-	#[allow(async_fn_in_trait)]
-	async fn init_governance(
-		&self,
-		await_tx: FixedDelayRetries,
-		governance_parameters: &MultiSigParameters,
-		payment_key: &CardanoPaymentSigningKey,
-		genesis_utxo_id: UtxoId,
-	) -> Result<McTxHash, OffchainError>;
-}
-
-impl<T> InitGovernance for T
-where
-	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
-{
-	async fn init_governance(
-		&self,
-		await_tx: FixedDelayRetries,
-		governance_parameters: &MultiSigParameters,
-		payment_key: &CardanoPaymentSigningKey,
-		genesis_utxo_id: UtxoId,
-	) -> Result<McTxHash, OffchainError> {
-		run_init_governance(
-			governance_parameters,
-			payment_key,
-			Some(genesis_utxo_id),
-			self,
-			await_tx,
-		)
-		.await
-		.map(|result| result.tx_hash)
-		.map_err(|e| OffchainError::InternalError(e.to_string()))
-	}
-}
 
 #[derive(serde::Serialize)]
 /// Result type of [run_init_governance].

--- a/toolkit/smart-contracts/offchain/src/lib.rs
+++ b/toolkit/smart-contracts/offchain/src/lib.rs
@@ -36,12 +36,3 @@ pub mod sign_tx;
 mod test_values;
 /// Supports governance updates
 pub mod update_governance;
-
-#[derive(Clone, Debug, PartialEq, Eq)]
-/// Error type representing errors in offchain code.
-pub enum OffchainError {
-	/// Error coming from a call to Ogmios
-	OgmiosError(String),
-	/// Generic internal error
-	InternalError(String),
-}

--- a/toolkit/smart-contracts/offchain/src/scripts_data.rs
+++ b/toolkit/smart-contracts/offchain/src/scripts_data.rs
@@ -1,5 +1,5 @@
 use crate::plutus_script;
-use crate::{OffchainError, csl::NetworkTypeExt, plutus_script::PlutusScript};
+use crate::{csl::NetworkTypeExt, plutus_script::PlutusScript};
 use cardano_serialization_lib::NetworkIdKind;
 use ogmios_client::query_network::QueryNetwork;
 use raw_scripts::{
@@ -57,26 +57,6 @@ pub struct PolicyIds {
 	pub version_oracle: PolicyId,
 	/// PolicyId of governed map minting policy
 	pub governed_map: PolicyId,
-}
-
-/// For the given `genesis_utxo` it returns the [ScriptsData] of the partner chain smart contracts.
-pub trait GetScriptsData {
-	#[allow(async_fn_in_trait)]
-	/// For the given `genesis_utxo` it returns the [ScriptsData] of the partner chain smart contracts.
-	async fn get_scripts_data(&self, genesis_utxo: UtxoId) -> Result<ScriptsData, OffchainError>;
-}
-
-impl<T: QueryNetwork> GetScriptsData for T {
-	async fn get_scripts_data(&self, genesis_utxo: UtxoId) -> Result<ScriptsData, OffchainError> {
-		let network = self
-			.shelley_genesis_configuration()
-			.await
-			.map_err(|e| OffchainError::OgmiosError(e.to_string()))?
-			.network
-			.to_csl();
-		get_scripts_data(genesis_utxo, network)
-			.map_err(|e| OffchainError::InternalError(e.to_string()))
-	}
 }
 
 /// Returns [ScriptsData] of the smart contracts for the partner chain identified by `genesis_utxo`.

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -19,13 +19,13 @@ use partner_chains_cardano_offchain::{
 	assemble_and_submit_tx,
 	await_tx::{AwaitTx, FixedDelayRetries},
 	cardano_keys::CardanoPaymentSigningKey,
+	csl::NetworkTypeExt,
 	d_param,
 	governance::MultiSigParameters,
 	governed_map::{run_get, run_insert, run_insert_with_force, run_list, run_remove, run_update},
 	init_governance,
 	multisig::{MultiSigSmartContractResult, MultiSigTransactionData},
-	permissioned_candidates::{self, GetPermissionedCandidates},
-	register::Register,
+	permissioned_candidates,
 	reserve::{self, release::release_reserve_funds},
 	scripts_data, sign_tx, update_governance,
 };
@@ -164,9 +164,13 @@ async fn upsert_permissioned_candidates() {
 	let container = client.run(image);
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_goveranance(&client).await;
+	let network = client.shelley_genesis_configuration().await.unwrap().network.to_csl();
 	assert!(run_upsert_permissioned_candidates(genesis_utxo, 77, &client).await.is_some());
 	assert_eq!(
-		client.get_permissioned_candidates(genesis_utxo).await.unwrap().unwrap(),
+		permissioned_candidates::get_permissioned_candidates(genesis_utxo, network, &client)
+			.await
+			.unwrap()
+			.unwrap(),
 		vec![make_candidate(77)]
 	);
 	assert!(run_upsert_permissioned_candidates(genesis_utxo, 77, &client).await.is_none());
@@ -693,26 +697,28 @@ async fn run_register<T: QueryLedgerState + Transactions + QueryNetwork + QueryU
 ) -> Option<McTxHash> {
 	let eve_utxos = client.query_utxos(&[EVE_ADDRESS.to_string()]).await.unwrap();
 	let registration_utxo = eve_utxos.first().unwrap().utxo_id();
-	client
-		.register(
-			FixedDelayRetries::five_minutes(),
-			genesis_utxo,
-			&CandidateRegistration {
-				stake_ownership: AdaBasedStaking {
-					pub_key: EVE_PUBLIC_KEY,
-					signature: MainchainSignature([19u8; 64]),
-				},
-				partner_chain_pub_key: SidechainPublicKey([20u8; 32].to_vec()),
-				partner_chain_signature: partnerchain_signature,
-				own_pkh: EVE_PUBLIC_KEY_HASH,
-				registration_utxo,
-				aura_pub_key: AuraPublicKey([22u8; 32].to_vec()),
-				grandpa_pub_key: GrandpaPublicKey([23u8; 32].to_vec()),
+
+	partner_chains_cardano_offchain::register::run_register(
+		genesis_utxo,
+		&CandidateRegistration {
+			stake_ownership: AdaBasedStaking {
+				pub_key: EVE_PUBLIC_KEY,
+				signature: MainchainSignature([19u8; 64]),
 			},
-			&eve_payment_key(),
-		)
-		.await
-		.unwrap()
+			partner_chain_pub_key: SidechainPublicKey([20u8; 32].to_vec()),
+			partner_chain_signature: partnerchain_signature,
+			own_pkh: EVE_PUBLIC_KEY_HASH,
+			registration_utxo,
+			aura_pub_key: AuraPublicKey([22u8; 32].to_vec()),
+			grandpa_pub_key: GrandpaPublicKey([23u8; 32].to_vec()),
+		},
+		&eve_payment_key(),
+		client,
+		FixedDelayRetries::five_minutes(),
+	)
+	.await
+	.map_err(|e| e.to_string())
+	.unwrap()
 }
 
 async fn assert_token_amount_eq<T: QueryLedgerState>(


### PR DESCRIPTION
# Description

`smart-contracts/offchain` provides traits that are used for mocking calls to offchain commands in `partner-chains-cli` testing. Since the traits are not used anywhere else it makes more sense for `partner-chains-cli` to provide them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
