### PR TITLE
fix: use echo -n to avoid having line feed byte in the hex of validator address

### DIFF
--- a/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
+++ b/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
@@ -211,7 +211,7 @@ jq '.genesis.runtimeGenesis.config.sessionCommitteeManagement.initialAuthorities
 ]' chain-spec.json > tmp.json && mv tmp.json chain-spec.json
 
 echo "Setting Governed Map scripts..."
-export GOVERNED_MAP_VALIDATOR_ADDRESS_HEX="0x$(echo $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
+export GOVERNED_MAP_VALIDATOR_ADDRESS_HEX="0x$(echo -n $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
 jq --arg address $GOVERNED_MAP_VALIDATOR_ADDRESS_HEX --arg policy_id $GOVERNED_MAP_POLICY_ID '.genesis.runtimeGenesis.config.governedMap.mainChainScripts = {
   "validator_address": $address,
   "asset_policy_id": $policy_id

--- a/dev/update-chain-spec.sh
+++ b/dev/update-chain-spec.sh
@@ -7,7 +7,7 @@ then
     echo "GOVERNED_MAP_VALIDATOR_ADDRESS is not set. Not attempting to update chain-spec value for it."
 else
     # -p for plain output, -c 128 to prevent wrapping lines
-    export ADDRESS_HEX="0x$(echo $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
+    export ADDRESS_HEX="0x$(echo -n $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
     jq --arg value $ADDRESS_HEX '.genesis.runtimeGenesis.config.governedMap.mainChainScripts.validator_address |= $value' $1 > chain-spec.json.tmp
     mv chain-spec.json.tmp $1
 fi


### PR DESCRIPTION
# Description

`echo $SOME_VAR` with `-n` output this var with line feed at the end. `xxd` was picking it up and adding to the hex representation.
