### PR TITLE
Simplify runtime related traits in partner-chains-cli

### DIFF
--- a/demo/node/src/cli.rs
+++ b/demo/node/src/cli.rs
@@ -1,7 +1,8 @@
 use authority_selection_inherents::CommitteeMember;
 use clap::command;
+use pallet_session_validator_management::Config as CommitteePalletConfig;
 use partner_chains_node_commands::{
-	PartnerChainRuntimeBindings, PartnerChainsSubcommand, RuntimeTypeWrapper,
+	PartnerChainRuntime, PartnerChainsSubcommand, RuntimeTypeWrapper,
 };
 use sc_cli::RunCmd;
 use sp_runtime::AccountId32;
@@ -20,7 +21,13 @@ pub struct WizardBindings;
 impl RuntimeTypeWrapper for WizardBindings {
 	type Runtime = partner_chains_demo_runtime::Runtime;
 }
-impl PartnerChainRuntimeBindings for WizardBindings {
+impl PartnerChainRuntime for WizardBindings {
+	type AuthorityId =
+		<<Self as RuntimeTypeWrapper>::Runtime as CommitteePalletConfig>::AuthorityId;
+	type AuthorityKeys =
+		<<Self as RuntimeTypeWrapper>::Runtime as CommitteePalletConfig>::AuthorityKeys;
+	type CommitteeMember =
+		<<Self as RuntimeTypeWrapper>::Runtime as CommitteePalletConfig>::CommitteeMember;
 	fn initial_member(id: Self::AuthorityId, keys: Self::AuthorityKeys) -> Self::CommitteeMember {
 		CommitteeMember::permissioned(id, keys)
 	}

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -8,9 +8,7 @@ use cli_commands::registration_signatures::RegistrationSignaturesCmd;
 use frame_support::sp_runtime::traits::NumberFor;
 use parity_scale_codec::{Decode, Encode};
 use partner_chains_cli::io::DefaultCmdRunContext;
-pub use partner_chains_cli::{
-	PartnerChainRuntime, PartnerChainRuntimeBindings, RuntimeTypeWrapper,
-};
+pub use partner_chains_cli::{PartnerChainRuntime, RuntimeTypeWrapper};
 use partner_chains_smart_contracts_commands::SmartContractsCmd;
 use sc_cli::{CliConfiguration, SharedParams, SubstrateCli};
 use sc_service::TaskManager;
@@ -79,7 +77,7 @@ impl CliConfiguration for RegistrationStatusCmd {
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
 pub enum PartnerChainsSubcommand<
-	RuntimeBindings: PartnerChainRuntime + PartnerChainRuntimeBindings,
+	RuntimeBindings: PartnerChainRuntime,
 	PartnerchainAddress: Clone + Sync + Send + FromStr + 'static,
 > {
 	/// Returns sidechain parameters
@@ -122,7 +120,7 @@ pub fn run<
 	CommitteeMember,
 	Client,
 	BlockProducerMetadata,
-	RuntimeBindings: PartnerChainRuntime + PartnerChainRuntimeBindings,
+	RuntimeBindings: PartnerChainRuntime,
 	PartnerchainAddress,
 >(
 	cli: &Cli,

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,4 +1,4 @@
-use super::{CreateChainSpecRuntimeBindings, PartnerChainRuntime};
+use super::PartnerChainRuntime;
 use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
 use crate::tests::{MockIO, MockIOContext};
@@ -44,8 +44,6 @@ impl PartnerChainRuntime for MockRuntime {
 	type AuthorityKeys = TestSessionKeys;
 	type AuthorityId = ecdsa::Public;
 	type CommitteeMember = TestMember;
-}
-impl CreateChainSpecRuntimeBindings for MockRuntime {
 	fn initial_member(id: Self::AuthorityId, keys: Self::AuthorityKeys) -> Self::CommitteeMember {
 		TestMember::Permissioned { id, keys }
 	}

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -25,7 +25,7 @@ mod tests;
 use clap::Parser;
 use io::*;
 use partner_chains_cardano_offchain::await_tx::FixedDelayRetries;
-pub use runtime_bindings::{PartnerChainRuntime, PartnerChainRuntimeBindings, RuntimeTypeWrapper};
+pub use runtime_bindings::{PartnerChainRuntime, RuntimeTypeWrapper};
 use std::time::Duration;
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -47,7 +47,7 @@ impl CommonArguments {
 #[command(
     after_long_help = HELP_EXAMPLES,
 )]
-pub enum Command<T: PartnerChainRuntime + PartnerChainRuntimeBindings> {
+pub enum Command<T: PartnerChainRuntime> {
 	/// This wizard generates the keys required for operating a partner-chains node, stores them in the keystore directory, and prints the public keys and keystore location.
 	GenerateKeys(generate_keys::GenerateKeysCmd),
 	/// Wizard to obtain the configuration needed for the partner-chain governance authority. This configuration should be shared with chain participants and used to create the chain spec json file.
@@ -58,7 +58,7 @@ pub enum Command<T: PartnerChainRuntime + PartnerChainRuntimeBindings> {
 	/// Uses 'chain config' obtained after running `prepare-configuration`.
 	SetupMainChainState(setup_main_chain_state::SetupMainChainStateCmd),
 	/// Wizard for starting a substrate node in the environment set up by `generate-keys`,
-	/// `prepare-config`, and `create-chain-spec`. It also assits in setting the `resources configuration`.
+	/// `prepare-config`, and `create-chain-spec`. It also assists in setting the `resources configuration`.
 	StartNode(start_node::StartNodeCmd),
 	/// The first step of registering as a committee candidate. Registration is split into three steps to allow the user to use their cold keys on a cold machine.
 	Register1(register::register1::Register1Cmd),
@@ -70,7 +70,7 @@ pub enum Command<T: PartnerChainRuntime + PartnerChainRuntimeBindings> {
 	Deregister(deregister::DeregisterCmd),
 }
 
-impl<T: PartnerChainRuntime + PartnerChainRuntimeBindings> Command<T> {
+impl<T: PartnerChainRuntime> Command<T> {
 	pub fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
 		match self {
 			Command::GenerateKeys(cmd) => cmd.run(context),

--- a/toolkit/partner-chains-cli/src/runtime_bindings.rs
+++ b/toolkit/partner-chains-cli/src/runtime_bindings.rs
@@ -1,4 +1,3 @@
-use pallet_session_validator_management::Config as CommitteePaletConfig;
 use serde::Serialize;
 use sp_core::{ecdsa, ed25519, sr25519};
 
@@ -10,20 +9,7 @@ pub trait PartnerChainRuntime {
 	type AuthorityId: Send + Sync + 'static + From<ecdsa::Public>;
 	type AuthorityKeys: Send + Sync + 'static + From<(sr25519::Public, ed25519::Public)> + Serialize;
 	type CommitteeMember: Serialize;
-}
 
-pub trait PartnerChainRuntimeBindings: PartnerChainRuntime {
+	/// Should construct initial [CommitteeMember] of the chain. Used for creating chain spec.
 	fn initial_member(id: Self::AuthorityId, keys: Self::AuthorityKeys) -> Self::CommitteeMember;
-}
-
-impl<T: RuntimeTypeWrapper<Runtime = R>, R> PartnerChainRuntime for T
-where
-	R: CommitteePaletConfig,
-	<R as CommitteePaletConfig>::AuthorityId: From<ecdsa::Public>,
-	<R as CommitteePaletConfig>::AuthorityKeys: From<(sr25519::Public, ed25519::Public)>,
-	<R as CommitteePaletConfig>::CommitteeMember: Serialize,
-{
-	type AuthorityId = <R as CommitteePaletConfig>::AuthorityId;
-	type AuthorityKeys = <R as CommitteePaletConfig>::AuthorityKeys;
-	type CommitteeMember = <R as CommitteePaletConfig>::CommitteeMember;
 }

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -727,8 +727,6 @@ fn verify_cli() {
 		type AuthorityKeys = (sr25519::Public, ed25519::Public);
 		type AuthorityId = ecdsa::Public;
 		type CommitteeMember = (Self::AuthorityId, Self::AuthorityKeys);
-	}
-	impl PartnerChainRuntimeBindings for MockRuntime {
 		fn initial_member(
 			id: Self::AuthorityId,
 			keys: Self::AuthorityKeys,


### PR DESCRIPTION
# Description

This PR merges trait `PartnerChainRuntimeBindings` into `PartnerChainRuntime`, and removes `CreateChainSpecRuntimeBindings` in favor of `PartnerChainRuntime`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
