### PR TITLE
Fix python setup

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -79,6 +79,7 @@
               pkgs.lib.makeLibraryPath [
                 rustToolchain
                 pkgs.libz
+                pkgs.stdenv.cc.cc
               ]
             }"
 
@@ -87,6 +88,7 @@
             export OPENSSL_INCLUDE_DIR="${pkgs.openssl.dev}/include"
             export OPENSSL_LIB_DIR="${pkgs.openssl.out}/lib"
 
+            export PYTHONNOUSERSITE=1
             export CRATE_CC_NO_DEFAULTS=1
             ${if isLinux then "export CFLAGS=-DJEMALLOC_STRERROR_R_RETURNS_CHAR_WITH_GNU_SOURCE" else ""}
           '';


### PR DESCRIPTION
# Description

Fix numpy compile problems:

Adding stdenv.cc.c to the LIBRARY_PATH is necessary to make NumPy happy which otherwise fails when trying to run the e2e tests

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
