### PR TITLE
chore: use McTxHash in await_tx_output

### DIFF
--- a/toolkit/smart-contracts/offchain/src/assemble_and_submit_tx.rs
+++ b/toolkit/smart-contracts/offchain/src/assemble_and_submit_tx.rs
@@ -5,7 +5,7 @@ use ogmios_client::query_ledger_state::QueryUtxoByUtxoId;
 use ogmios_client::{
 	query_ledger_state::QueryLedgerState, query_network::QueryNetwork, transactions::Transactions,
 };
-use sidechain_domain::{McTxHash, UtxoId};
+use sidechain_domain::McTxHash;
 
 /// Adds `witnesses` to `transaction` and submits it with `ogmios_client`.
 pub async fn assemble_and_submit_tx<
@@ -38,7 +38,7 @@ pub async fn assemble_and_submit_tx<
 	let tx_id = McTxHash(res.transaction.id);
 	log::info!("Transaction submitted: {}", hex::encode(tx_id.0));
 
-	await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_id.0, 0)).await?;
+	await_tx.await_tx_output(ogmios_client, tx_id).await?;
 
 	Ok(tx_id)
 }

--- a/toolkit/smart-contracts/offchain/src/d_param/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/d_param/mod.rs
@@ -87,7 +87,7 @@ pub async fn upsert_d_param<
 		},
 	};
 	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
-		await_tx.await_tx_output(client, UtxoId::new(tx_hash.0, 0)).await?;
+		await_tx.await_tx_output(client, tx_hash).await?;
 	}
 	Ok(tx_hash_opt)
 }

--- a/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/governed_map/mod.rs
@@ -74,7 +74,7 @@ pub async fn run_insert<
 		},
 	};
 	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
-		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+		await_tx.await_tx_output(ogmios_client, tx_hash).await?;
 	}
 	Ok(tx_hash_opt)
 }
@@ -205,7 +205,7 @@ pub async fn run_update<
 	};
 
 	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
-		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+		await_tx.await_tx_output(ogmios_client, tx_hash).await?;
 	}
 	Ok(tx_hash_opt)
 }
@@ -338,7 +338,7 @@ pub async fn run_remove<
 		),
 	};
 	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
-		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+		await_tx.await_tx_output(ogmios_client, tx_hash).await?;
 	}
 	Ok(tx_hash_opt)
 }
@@ -501,7 +501,7 @@ pub async fn run_insert_with_force<
 	);
 
 	if let Some(TransactionSubmitted(tx_hash)) = tx_hash_opt {
-		await_tx.await_tx_output(ogmios_client, UtxoId::new(tx_hash.0, 0)).await?;
+		await_tx.await_tx_output(ogmios_client, tx_hash).await?;
 	}
 	Ok(tx_hash_opt)
 }

--- a/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/init_governance/mod.rs
@@ -76,6 +76,6 @@ pub async fn run_init_governance<
 	let result = client.submit_transaction(&signed_transaction.to_bytes()).await?;
 	let tx_id = result.transaction.id;
 	log::info!("✅ Transaction submitted. ID: {}", hex::encode(tx_id));
-	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 	Ok(InitGovernanceResult { tx_hash: McTxHash(tx_id), genesis_utxo: genesis_utxo.utxo_id() })
 }

--- a/toolkit/smart-contracts/offchain/src/multisig.rs
+++ b/toolkit/smart-contracts/offchain/src/multisig.rs
@@ -17,7 +17,7 @@ use ogmios_client::{
 	transactions::Transactions,
 };
 use serde::{Serialize, Serializer};
-use sidechain_domain::{McTxHash, UtxoId, UtxoIndex, crypto::blake2b};
+use sidechain_domain::{McTxHash, crypto::blake2b};
 
 /// Successful smart contracts offchain results in either transaction submission or creating transaction that has to be signed by the governance authorities
 #[derive(Clone, Debug, Serialize)]
@@ -173,7 +173,7 @@ async fn transfer_to_temporary_wallet<T: Transactions + QueryUtxoByUtxoId, A: Aw
 		&hex::encode(tx_hash)
 	);
 	client.submit_transaction(&payment_ctx.sign(&funding_tx).to_bytes()).await?;
-	await_tx.await_tx_output(client, UtxoId::new(tx_hash, 0)).await?;
+	await_tx.await_tx_output(client, McTxHash(tx_hash)).await?;
 	Ok(())
 }
 
@@ -232,12 +232,7 @@ where
 	})?;
 	let tx_id = McTxHash(res.transaction.id);
 	log::info!("'{}' transaction submitted: {}", tx_name, hex::encode(tx_id.0));
-	await_tx
-		.await_tx_output(
-			client,
-			UtxoId { tx_hash: McTxHash(res.transaction.id), index: UtxoIndex(0) },
-		)
-		.await?;
+	await_tx.await_tx_output(client, McTxHash(res.transaction.id)).await?;
 	Ok(tx_id)
 }
 

--- a/toolkit/smart-contracts/offchain/src/register.rs
+++ b/toolkit/smart-contracts/offchain/src/register.rs
@@ -83,7 +83,7 @@ pub async fn run_register<
 	})?;
 	let tx_id = result.transaction.id;
 	log::info!("✅ Transaction submitted. ID: {}", hex::encode(result.transaction.id));
-	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 
 	Ok(Some(McTxHash(result.transaction.id)))
 }
@@ -136,7 +136,7 @@ pub async fn run_deregister<
 	})?;
 	let tx_id = result.transaction.id;
 	log::info!("✅ Transaction submitted. ID: {}", hex::encode(result.transaction.id));
-	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 
 	Ok(Some(McTxHash(result.transaction.id)))
 }

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -86,7 +86,7 @@ pub async fn release_reserve_funds<
 	})?;
 	let tx_id = res.transaction.id;
 	log::info!("Reserve release transaction submitted: {}", hex::encode(tx_id));
-	await_tx.await_tx_output(client, UtxoId::new(tx_id, 0)).await?;
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 
 	Ok(McTxHash(tx_id))
 }

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -443,7 +443,7 @@ async fn initial_transaction<T: Transactions + QueryUtxoByUtxoId>(
 		.map_err(|e| e.to_string())
 		.map(|response| McTxHash(response.transaction.id))?;
 	FixedDelayRetries::new(Duration::from_millis(500), 100)
-		.await_tx_output(client, UtxoId::new(tx_hash.0, 0))
+		.await_tx_output(client, tx_hash)
 		.await
 		.map_err(|e| e.to_string())?;
 	Ok(tx_hash)


### PR DESCRIPTION
# Description

`await_tx_output` takes UtxoId, but since we are not looking for a specific UTXO just that the transaction is on the chain, we have to construct a UtxoId from the transaction hash and a 0 index.
This PR makes `await_tx_output` take a McTxHash and constructs the 0 index UtxoId internally to clean up the interface.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
