### PR TITLE
feat: do not fail on 10MB Ogmios responses

### DIFF
--- a/toolkit/utils/ogmios-client/src/jsonrpsee.rs
+++ b/toolkit/utils/ogmios-client/src/jsonrpsee.rs
@@ -46,6 +46,7 @@ pub enum OgmiosClients {
 pub async fn client_for_url(addr: &str, timeout: Duration) -> Result<OgmiosClients, String> {
 	if addr.starts_with("http") || addr.starts_with("https") {
 		let client = HttpClientBuilder::default()
+			.max_response_size(u32::MAX)
 			.request_timeout(timeout)
 			.build(addr)
 			.map_err(|e| format!("Couldn't create HTTP client: {}", e))?;
@@ -61,6 +62,7 @@ pub async fn client_for_url(addr: &str, timeout: Duration) -> Result<OgmiosClien
 		Ok(http_client)
 	} else if addr.starts_with("ws") || addr.starts_with("wss") {
 		let client = WsClientBuilder::default()
+			.max_response_size(u32::MAX)
 			.request_timeout(timeout)
 			.build(addr.to_owned())
 			.await

--- a/toolkit/utils/ogmios-client/src/jsonrpsee.rs
+++ b/toolkit/utils/ogmios-client/src/jsonrpsee.rs
@@ -46,7 +46,7 @@ pub enum OgmiosClients {
 pub async fn client_for_url(addr: &str, timeout: Duration) -> Result<OgmiosClients, String> {
 	if addr.starts_with("http") || addr.starts_with("https") {
 		let client = HttpClientBuilder::default()
-			.max_response_size(u32::MAX)
+			.max_response_size(250 * 1024 * 1024)
 			.request_timeout(timeout)
 			.build(addr)
 			.map_err(|e| format!("Couldn't create HTTP client: {}", e))?;
@@ -62,7 +62,7 @@ pub async fn client_for_url(addr: &str, timeout: Duration) -> Result<OgmiosClien
 		Ok(http_client)
 	} else if addr.starts_with("ws") || addr.starts_with("wss") {
 		let client = WsClientBuilder::default()
-			.max_response_size(u32::MAX)
+			.max_response_size(250 * 1024 * 1024)
 			.request_timeout(timeout)
 			.build(addr.to_owned())
 			.await


### PR DESCRIPTION
# Description

Overrides default 10 MB max response size. This is order to not fail when there are many UTXOs at the registrations validator address.

Before:
```
./target/debug/partner-chains-demo-node smart-contracts register ...
2025-06-13T09:37:35.347745439+02:00 WARN soketto::connection - b6ca6eaa: accumulated message length exceeds maximum
Error: Application(JsonRPC request failed: 'The background task closed message too large: len >= 14705278, maximum = 10485760; restart required')
```
After:
```
./target/debug/partner-chains-demo-node smart-contracts register ...
2025-06-13T09:43:33.113725973+02:00 INFO partner_chains_cardano_offchain::register - ✅ Transaction submitted. ID: 977bfa7a5cf1e5d5805962e2ea0c2d2189ddf175df5e6c6e503ebe604177ce2a
```

REF: ETCM-9399
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
