### PR TITLE
feat: make setting bootnodes optional in `prepare-configuration`

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 # Unreleased
 
 * Added extra constant burn fee in `pallet-address-association` to discourage attacks on pallet storage.
+* Wizards don't require `generate-keys` for `prepare-configuration`. Altered recommended order of `create-chain-spec` and `setup-main-chain-state`.
 
 ## Changed
 

--- a/dev/local-environment/configurations/wizard/governance-authority/entrypoint.sh
+++ b/dev/local-environment/configurations/wizard/governance-authority/entrypoint.sh
@@ -60,6 +60,8 @@ spawn ./partner-chains-node wizards prepare-configuration
 set timeout 180
 expect "node base path (./data)"
 send "\r"
+expect "Do you want to configure a single bootnode with"
+send "Y\r"
 expect "Your bootnode should be accessible via:"
 send "\r"
 expect "Enter bootnode TCP port (3033)"
@@ -76,7 +78,7 @@ expect "path to the payment signing key file (payment.skey)"
 send "/keys/funded_address.skey\r"
 expect "Select an UTXO to use as the genesis UTXO"
 send "\r"
-expect "Space separated keys hashes of the initial Multisig Governance Authorities (0x$GOVERNANCE_AUTHORITY)"
+expect "Enter the space separated keys hashes of the initial Multisig Governance Authorities"
 send "\r"
 expect "Initial Multisig Governance Threshold (1)"
 send "\r"
@@ -164,8 +166,7 @@ expect "Enter R, the number of registered candidates seats, as a non-negative in
 send "1\r"
 expect "path to the payment signing key file (/keys/funded_address.skey)"
 send "\r"
-expect "Done. Main chain state is set."
-expect eof
+expect "Done."
 EOF
 
 touch /shared/partner-chains-node-1.ready

--- a/docs/user-guides/chain-builder.md
+++ b/docs/user-guides/chain-builder.md
@@ -12,8 +12,8 @@ Partner Chain builders are organizations that want to build their own blockchain
 3. Run the prepare-configuration wizard
     1. Set chain parameters
     2. Provide signing key
-4. Run the create-chain-spec wizard
-5. Run the setup-main-chain-state wizard
+4. Run the setup-main-chain-state wizard
+5. Run the create-chain-spec wizard
 6. Run the start-node wizard
 7. Distribute chain files to participants
 
@@ -334,19 +334,7 @@ A sample file:
 }
 ```
 
-### 4. Run the create-chain-spec wizard
-
-The wizard reads the file `pc-chain-config.json`. This file should be present and identical for every node participating in the chain.
-
-1. Start the wizard: `./partner-chains-node wizards create-chain-spec`
-
-The wizard displays the contents of `chain_parameters` and `initial_permissioned_candidates` from the `pc-chain-config.json` file. You can manually modify these values before running this wizard.
-
-The wizard creates the chain specification file `chain-spec.json` using these values.
-
-The wizard informs you of the full path to the `chain-spec.json` file. You can now distribute this file to block production committee candidates.
-
-### 5. Run the setup-main-chain-state wizard
+### 4. Run the setup-main-chain-state wizard
 
 1. Start the wizard: `./partner-chains-node wizards setup-main-chain-state`
 
@@ -364,6 +352,18 @@ The default value of R is zero, and the default value of P is the number of entr
 The configuration of the chain is stored in the file `pc-chain-config.json`. This file should be present and identical for every node participating in the network.
 
 Information about the resources used by each node is stored in the file `partner-chain-cli-resources-config.json`. This file should be present for every node participating in the chain, but its contents are specific to each node.
+
+### 5. Run the create-chain-spec wizard
+
+The wizard reads the file `pc-chain-config.json`. This file should be present and identical for every node participating in the chain.
+
+1. Start the wizard: `./partner-chains-node wizards create-chain-spec`
+
+The wizard displays the contents of `chain_parameters` and `initial_permissioned_candidates` from the `pc-chain-config.json` file. You can manually modify these values before running this wizard.
+
+The wizard creates the chain specification file `chain-spec.json` using these values.
+
+The wizard informs you of the full path to the `chain-spec.json` file. You can now distribute this file to block production committee candidates.
 
 ### 6. Run the partner chain node
 

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -44,7 +44,7 @@ impl<'a> ConfigFieldDefinition<'a, String> {
 		if let Some(value) = self.load_from_file_and_print(context) {
 			value
 		} else {
-			let value = context.prompt(self.name, self.default);
+			let value = context.prompt(&format!("Enter the {}", self.name), self.default);
 			self.save_to_file(&value, context);
 			value
 		}
@@ -55,8 +55,10 @@ impl<'a> ConfigFieldDefinition<'a, String> {
 		&self,
 		context: &C,
 	) -> String {
-		let value =
-			context.prompt(self.name, self.load_from_file(context).as_deref().or(self.default));
+		let value = context.prompt(
+			&format!("Enter the {}", self.name),
+			self.load_from_file(context).as_deref().or(self.default),
+		);
 		self.save_to_file(&value, context);
 		value
 	}
@@ -72,7 +74,7 @@ impl<'a, T> ConfigFieldDefinition<'a, T> {
 	{
 		let loaded_value = self.load_from_file(context).map(|v| v.to_string());
 		let default_value = loaded_value.as_deref().or(self.default);
-		let value = context.prompt(self.name, default_value);
+		let value = context.prompt(&format!("Enter the {}", self.name), default_value);
 		let parsed_value: T = value.parse()?;
 		self.save_to_file(&parsed_value, context);
 		Ok(parsed_value)
@@ -655,7 +657,7 @@ pub(crate) mod config_fields {
 	> = ConfigFieldDefinition {
 		config_file: CHAIN_CONFIG_FILE_PATH,
 		path: &["initial_governance", "authorities"],
-		name: "Space separated keys hashes of the initial Multisig Governance Authorities",
+		name: "space separated keys hashes of the initial Multisig Governance Authorities",
 		default: Some("[]"),
 		_marker: PhantomData,
 	};

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -39,7 +39,6 @@ impl<T: PartnerChainRuntime> CmdRun for CreateChainSpecCmd<T> {
 			context.print(
 				"If you are the governance authority, you can distribute it to the validators.",
 			);
-			context.print("Run 'setup-main-chain-state' command to set D-parameter and permissioned candidates on Cardano.");
 			Ok(())
 		} else {
 			context.print("Aborted.");

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -411,8 +411,5 @@ fn show_outro() -> MockIO {
 		MockIO::print(
 			"If you are the governance authority, you can distribute it to the validators.",
 		),
-		MockIO::print(
-			"Run 'setup-main-chain-state' command to set D-parameter and permissioned candidates on Cardano.",
-		),
 	])
 }

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -140,11 +140,19 @@ fn read_keys_io() -> MockIO {
 }
 
 fn read_payment_signing_key() -> MockIO {
-	MockIO::prompt("path to the payment signing key file", Some("payment.skey"), MY_PAYMEMENT_SKEY)
+	MockIO::prompt(
+		"Enter the path to the payment signing key file",
+		Some("payment.skey"),
+		MY_PAYMEMENT_SKEY,
+	)
 }
 
 fn read_cold_verification_key() -> MockIO {
-	MockIO::prompt("path to the cold verification key file", Some("cold.vkey"), MY_COLD_VKEY)
+	MockIO::prompt(
+		"Enter the path to the cold verification key file",
+		Some("cold.vkey"),
+		MY_COLD_VKEY,
+	)
 }
 
 fn test_chain_config_content() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/generate_keys/tests.rs
+++ b/toolkit/partner-chains-cli/src/generate_keys/tests.rs
@@ -39,7 +39,7 @@ pub mod scenarios {
 	}
 
 	pub fn prompt_all_config_fields() -> MockIO {
-		MockIO::prompt("node base path", Some("./data"), DATA_PATH)
+		MockIO::prompt("Enter the node base path", Some("./data"), DATA_PATH)
 	}
 
 	pub fn resources_file_content() -> serde_json::Value {

--- a/toolkit/partner-chains-cli/src/lib.rs
+++ b/toolkit/partner-chains-cli/src/lib.rs
@@ -55,11 +55,11 @@ pub enum Command<T: PartnerChainRuntime> {
 	GenerateKeys(generate_keys::GenerateKeysCmd),
 	/// Wizard to obtain the configuration needed for the partner-chain governance authority. This configuration should be shared with chain participants and used to create the chain spec json file.
 	PrepareConfiguration(prepare_configuration::PrepareConfigurationCmd),
-	/// Wizard for creating a chain spec json file based on the chain configuration (see `prepare-configuration`).
-	CreateChainSpec(create_chain_spec::CreateChainSpecCmd<T>),
 	/// Wizard for setting D-parameter and Permissioned Candidates list on the main chain.
 	/// Uses 'chain config' obtained after running `prepare-configuration`.
 	SetupMainChainState(setup_main_chain_state::SetupMainChainStateCmd),
+	/// Wizard for creating a chain spec json file based on the chain configuration (see `prepare-configuration`).
+	CreateChainSpec(create_chain_spec::CreateChainSpecCmd<T>),
 	/// Wizard for starting a substrate node in the environment set up by `generate-keys`,
 	/// `prepare-config`, and `create-chain-spec`. It also assists in setting the `resources configuration`.
 	StartNode(start_node::StartNodeCmd),
@@ -107,8 +107,8 @@ const HELP_EXAMPLES: &str = r#"
 ║ Governance Authority:                                                          ║
 ║   1. generate-keys         : generate necessary cryptographic keys             ║
 ║   2. prepare-configuration : set up the partner chain configuration            ║
-║   3. create-chain-spec     : create the chain specification file               ║
-║   4. setup-main-chain-state: configure the main chain parameters               ║
+║   3. setup-main-chain-state: configure the main chain parameters               ║
+║   4. create-chain-spec     : create the chain specification file               ║
 ║   5. start-node            : start the validator node                          ║
 ╟────────────────────────────────────────────────────────────────────────────────╢
 ║ Registered Validator:                                                          ║

--- a/toolkit/partner-chains-cli/src/ogmios/config.rs
+++ b/toolkit/partner-chains-cli/src/ogmios/config.rs
@@ -16,7 +16,10 @@ pub(crate) fn prompt_ogmios_configuration<C: IOContext>(
 	context: &C,
 ) -> anyhow::Result<ServiceConfig> {
 	let ogmios_protocol = OGMIOS_PROTOCOL
-		.select_options_with_default_from_file_and_save(OGMIOS_PROTOCOL.name, context)
+		.select_options_with_default_from_file_and_save(
+			&format!("Select {}", OGMIOS_PROTOCOL.name),
+			context,
+		)
 		.map_err(anyhow::Error::msg)?;
 	let ogmios_hostname = OGMIOS_HOSTNAME.prompt_with_default_from_file_and_save(context);
 	let ogmios_port = OGMIOS_PORT.prompt_with_default_from_file_parse_and_save(context)?;

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -115,12 +115,12 @@ mod tests {
 			.with_expected_io(vec![
 				MockIO::eprint("Please provide the initial chain governance key hashes:"),
 				MockIO::prompt(
-					"Space separated keys hashes of the initial Multisig Governance Authorities",
+					"Enter the space separated keys hashes of the initial Multisig Governance Authorities",
 					Some(test_private_key_hash()),
 					"00000000000000000000000000000000000000000000000000000000  \n\t0x01010101010101010101010101010101010101010101010101010101",
 				),
 				MockIO::prompt(
-					"Initial Multisig Governance Threshold",
+					"Enter the Initial Multisig Governance Threshold",
 					Some("1"),
 					"2",
 				),

--- a/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -3,7 +3,6 @@ use crate::cmd_traits::{GetScriptsData, InitGovernance};
 use crate::config::config_fields::{BOOTNODES, SUBSTRATE_NODE_DATA_BASE_PATH};
 use crate::generate_keys::network_key_path;
 use crate::io::IOContext;
-use crate::prepare_configuration::PrepareConfigurationError::NetworkKeyNotFoundError;
 use crate::prepare_configuration::prepare_main_chain_config::prepare_main_chain_config;
 use crate::prepare_configuration::select_genesis_utxo::select_genesis_utxo;
 use anyhow::Context;
@@ -20,7 +19,6 @@ use sidechain_domain::{McTxHash, UtxoId};
 use std::net::Ipv4Addr;
 use std::str::FromStr;
 use std::vec;
-use thiserror::Error;
 
 mod init_governance;
 mod prepare_cardano_params;
@@ -35,6 +33,7 @@ pub struct PrepareConfigurationCmd {
 
 impl CmdRun for PrepareConfigurationCmd {
 	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
+		context.eprint(INTRO);
 		establish_bootnodes(context)?;
 		let (genesis_utxo, private_key, ogmios_config) = select_genesis_utxo(context)?;
 		if let Some(_tx_id) = init_governance::run_init_governance(
@@ -45,7 +44,7 @@ impl CmdRun for PrepareConfigurationCmd {
 			context,
 		)? {
 			prepare_main_chain_config(context, &ogmios_config, genesis_utxo)?;
-			context.eprint("🚀 All done!");
+			context.eprint("🚀 Chain configuration wizards completed successufully!");
 			Ok(())
 		} else {
 			context
@@ -56,10 +55,33 @@ impl CmdRun for PrepareConfigurationCmd {
 }
 
 fn establish_bootnodes(context: &impl IOContext) -> anyhow::Result<()> {
-	context.eprint(INTRO);
+	match peer_id_from_config(context)? {
+		Some(peer_id) => {
+			let configure = context.prompt_yes_no(
+				&format!(
+					"Do you want to configure a single bootnode with your peer id '{peer_id}'?"
+				),
+				true,
+			);
+			if configure {
+				configure_bootnode(peer_id, context)
+			} else {
+				Ok(BOOTNODES.save_to_file(&vec![], context))
+			}
+		},
+		None => {
+			let continue_without_bootnode =
+				context.prompt_yes_no("Could not read network secret key from the base directory. Do you want to continue without configuring bootnode?", true);
+			if continue_without_bootnode {
+				Ok(BOOTNODES.save_to_file(&vec![], context))
+			} else {
+				std::process::exit(0)
+			}
+		},
+	}
+}
 
-	let peer_id = peer_id_from_config(context)?;
-
+fn configure_bootnode(peer_id: String, context: &impl IOContext) -> anyhow::Result<()> {
 	let (default_protocol, default_hostname_or_ip, default_port) = read_bootnode_defaults(context);
 
 	let protocol = choose_protocol(context, default_protocol);
@@ -123,18 +145,18 @@ fn deconstruct_bootnode(bootnode_opt: Option<String>) -> Option<(Protocol, Strin
 	Some((protocol, hostname, port))
 }
 
-fn peer_id_from_config(context: &impl IOContext) -> anyhow::Result<String> {
+fn peer_id_from_config(context: &impl IOContext) -> anyhow::Result<Option<String>> {
 	let substrate_node_base_path =
 		SUBSTRATE_NODE_DATA_BASE_PATH.prompt_with_default_from_file_and_save(context);
 
 	let network_key_path = network_key_path(&substrate_node_base_path);
-
-	peer_id_from_network_key(
-		context
-			.read_file(&network_key_path)
-			.as_deref()
-			.ok_or(NetworkKeyNotFoundError(network_key_path))?,
-	)
+	Ok(match context.read_file(&network_key_path).as_deref() {
+		Some(network_key) => Some(peer_id_from_network_key(network_key)?),
+		None => {
+			context.print(&format!("Could not read network key from {}", network_key_path));
+			None
+		},
+	})
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -173,7 +195,12 @@ impl FromStr for Protocol {
 	}
 }
 
-const INTRO: &str = "This 🧙 wizard will generate chain config file";
+const INTRO: &str =
+	"This 🧙 wizard will:
+* establish single bootnode configuration (to be later included in chain-spec file)
+* choose Genesis UTXO on Cardano
+* initialize Partner Chains Governance on Cardano
+* establish Partner Chains Smart Contracts addresses and policies (to be later included in chain-spec file)";
 
 fn outro() -> String {
 	format!(
@@ -189,12 +216,6 @@ const DEFAULT_PORT: u16 = 3033;
 const CHOOSE_HOSTNAME_PROMPT: &str = "Enter bootnode hostname";
 
 const CHOOSE_IP_ADDRESS_PROMPT: &str = "Enter bootnode IP address";
-
-#[derive(Error, Debug)]
-enum PrepareConfigurationError {
-	#[error("⚠️ Network key not found under {0}. Please run the `generate-keys` command first")]
-	NetworkKeyNotFoundError(String),
-}
 
 fn dns_bootnode(hostname: &str, port: u16, peer_id: &str) -> String {
 	format!("/dns/{}/tcp/{}/p2p/{}", hostname, port, peer_id)
@@ -249,11 +270,10 @@ impl<T: QueryNetwork> GetScriptsData for T {
 #[cfg(test)]
 pub mod tests {
 	use super::*;
-	use crate::config::config_fields::{BOOTNODES, SUBSTRATE_NODE_DATA_BASE_PATH};
+	use crate::config::config_fields::BOOTNODES;
 	use crate::config::{
 		CHAIN_CONFIG_FILE_PATH, ConfigFieldDefinition, RESOURCES_CONFIG_FILE_PATH, SelectOptions,
 	};
-	use crate::prepare_configuration::PrepareConfigurationError::NetworkKeyNotFoundError;
 	use crate::prepare_configuration::Protocol::{Dns, Ipv4};
 	use crate::tests::{MockIO, MockIOContext};
 	use crate::{CommonArguments, verify_json};
@@ -271,7 +291,13 @@ pub mod tests {
 		use crate::prepare_configuration::Protocol::{Dns, Ipv4};
 
 		pub fn show_intro() -> MockIO {
-			MockIO::Group(vec![MockIO::eprint("This 🧙 wizard will generate chain config file")])
+			MockIO::Group(vec![MockIO::eprint(
+				"This 🧙 wizard will:
+* establish single bootnode configuration (to be later included in chain-spec file)
+* choose Genesis UTXO on Cardano
+* initialize Partner Chains Governance on Cardano
+* establish Partner Chains Smart Contracts addresses and policies (to be later included in chain-spec file)",
+			)])
 		}
 
 		pub fn read_config() -> MockIO {
@@ -280,6 +306,15 @@ pub mod tests {
 				SUBSTRATE_NODE_DATA_BASE_PATH.default,
 				DATA_PATH,
 			)])
+		}
+
+		pub fn choose_to_configure_bootnode(choice: bool) -> MockIO {
+			MockIO::PromptYN {
+				prompt: "Do you want to configure a single bootnode with your peer id '12D3KooWSi9ys81fpG9ibuVWh6w6egfcTUM8L1iSJSpfFtMLMLG9'?"
+					.to_string(),
+				default: true,
+				choice,
+			}
 		}
 
 		pub fn pick_ip_protocol_with_defaults() -> MockIO {
@@ -369,8 +404,8 @@ pub mod tests {
 	#[test]
 	fn happy_path_ip() {
 		let mock_context = context_with_config(KEY).with_expected_io(vec![
-			scenarios::show_intro(),
 			scenarios::read_config(),
+			scenarios::choose_to_configure_bootnode(true),
 			scenarios::pick_ip_protocol_with_defaults(),
 			MockIO::eprint(&outro()),
 		]);
@@ -388,8 +423,8 @@ pub mod tests {
 	#[test]
 	fn happy_path_hostname() {
 		let mock_context = context_with_config(KEY).with_expected_io(vec![
-			scenarios::show_intro(),
 			scenarios::read_config(),
+			scenarios::choose_to_configure_bootnode(true),
 			scenarios::pick_dns_protocol_with_defaults(),
 			MockIO::eprint(&outro()),
 		]);
@@ -405,6 +440,17 @@ pub mod tests {
 	}
 
 	#[test]
+	fn happy_path_no_bootnode() {
+		let mock_context = context_with_config(KEY).with_expected_io(vec![
+			scenarios::read_config(),
+			scenarios::choose_to_configure_bootnode(false),
+		]);
+		let result = establish_bootnodes(&mock_context);
+		result.expect("should succeed");
+		verify_json!(mock_context, CHAIN_CONFIG_FILE_PATH, serde_json::json!({"bootnodes": []}));
+	}
+
+	#[test]
 	fn propose_saved_defaults_but_pick_different() {
 		let mock_context = context_with_config(KEY)
 			.with_json_file(
@@ -414,8 +460,8 @@ pub mod tests {
 				}),
 			)
 			.with_expected_io(vec![
-				scenarios::show_intro(),
 				scenarios::read_config(),
+				scenarios::choose_to_configure_bootnode(true),
 				scenarios::pick_dns_protocol(
 					vec![Ipv4.into(), Dns.into()],
 					3034,
@@ -440,8 +486,8 @@ pub mod tests {
 				}),
 			)
 			.with_expected_io(vec![
-				scenarios::show_intro(),
 				scenarios::read_config(),
+				scenarios::choose_to_configure_bootnode(true),
 				scenarios::pick_ip_protocol(
 					vec![Ipv4.into(), Dns.into()],
 					3034,
@@ -457,28 +503,30 @@ pub mod tests {
 	}
 
 	#[test]
-	fn error_without_network_key_file() {
+	fn continue_without_network_key_file_when_user_agrees() {
 		let mock_context = MockIOContext::new()
 			.with_json_file(RESOURCES_CONFIG_FILE_PATH, serde_json::json!({}))
-			.with_expected_io(vec![scenarios::show_intro(), scenarios::read_config()]);
+			.with_expected_io(vec![
+				scenarios::read_config(),
+				MockIO::print(&format!("Could not read network key from {}", network_key_file())),
+				MockIO::prompt_yes_no(
+					"Could not read network secret key from the base directory. Do you want to continue without configuring bootnode?",
+					true,
+					true,
+				),
+			]);
 
-		let result =
-			PrepareConfigurationCmd { common_arguments: common_arguments() }.run(&mock_context);
-
-		let error = result.expect_err("should return error");
-		assert_eq!(error.to_string(), NetworkKeyNotFoundError(network_key_file()).to_string());
+		let result = establish_bootnodes(&mock_context);
+		result.expect("should succeed");
+		verify_json!(mock_context, CHAIN_CONFIG_FILE_PATH, serde_json::json!({"bootnodes": []}));
 	}
 
 	#[test]
 	fn do_not_error_without_resources_config_file() {
 		let mock_context =
 			MockIOContext::new().with_file(&network_key_file(), KEY).with_expected_io(vec![
-				scenarios::show_intro(),
-				MockIO::prompt(
-					SUBSTRATE_NODE_DATA_BASE_PATH.name,
-					SUBSTRATE_NODE_DATA_BASE_PATH.default,
-					DATA_PATH,
-				),
+				scenarios::read_config(),
+				scenarios::choose_to_configure_bootnode(true),
 				scenarios::pick_ip_protocol_with_defaults(),
 				MockIO::eprint(&outro()),
 			]);
@@ -503,6 +551,7 @@ pub mod tests {
 		let mock_context = context_with_config(KEY).with_expected_io(vec![
 			scenarios::show_intro(),
 			scenarios::read_config(),
+			scenarios::choose_to_configure_bootnode(true),
 			scenarios::pick_chosen_ip_protocol(
 				vec![Dns.into(), Ipv4.into()],
 				DEFAULT_PORT,
@@ -532,7 +581,7 @@ pub mod tests {
 		default: Option<&str>,
 		value: &str,
 	) -> MockIO {
-		MockIO::prompt(field_definition.name, default, value)
+		MockIO::prompt(&format!("Enter the {}", field_definition.name), default, value)
 	}
 
 	pub fn prompt_multi_option_with_default<T: SelectOptions>(
@@ -541,7 +590,7 @@ pub mod tests {
 		value: &str,
 	) -> MockIO {
 		MockIO::prompt_multi_option(
-			field_definition.name,
+			&format!("Select {}", field_definition.name),
 			T::select_options_with_default(default),
 			value,
 		)

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -99,7 +99,7 @@ If you intend to run a chain with permissioned candidates, you must manually set
   ]
 }
 
-After setting up the permissioned candidates, execute the 'create-chain-spec' command to generate the final chain specification."#;
+After setting up the permissioned candidates, execute the 'setup-main-chain-state' command to write required data to Cardano, and run the 'create-chain-spec' command to generate the final chain specification."#;
 
 #[cfg(test)]
 mod tests {
@@ -158,11 +158,15 @@ mod tests {
 					true,
 				),
 				MockIO::prompt(
-					NATIVE_TOKEN_POLICY.name,
+					&format!("Enter the {}", NATIVE_TOKEN_POLICY.name),
 					None,
 					"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 				),
-				MockIO::prompt(NATIVE_TOKEN_ASSET_NAME.name, None, "5043546f6b656e44656d6f"),
+				MockIO::prompt(
+					&format!("Enter the {}", NATIVE_TOKEN_ASSET_NAME.name),
+					None,
+					"5043546f6b656e44656d6f",
+				),
 			])
 		}
 	}

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -131,6 +131,10 @@ mod tests {
 	}
 
 	fn prompt_payment_vkey_and_read_it_to_derive_address() -> MockIO {
-		MockIO::prompt("path to the payment signing key file", Some("payment.skey"), "payment.skey")
+		MockIO::prompt(
+			"Enter the path to the payment signing key file",
+			Some("payment.skey"),
+			"payment.skey",
+		)
 	}
 }

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -454,7 +454,7 @@ mod tests {
 
 	fn prompt_cardano_payment_verification_key_file_io() -> MockIO {
 		MockIO::prompt(
-			"path to the payment verification file",
+			"Enter the path to the payment verification file",
 			Some(PAYMENT_VKEY_PATH),
 			PAYMENT_VKEY_PATH,
 		)

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -274,7 +274,7 @@ mod tests {
 
 	fn prompt_mc_payment_key_path_io() -> Vec<MockIO> {
 		vec![MockIO::prompt(
-			"path to the payment signing key file",
+			"Enter the path to the payment signing key file",
 			Some("payment.skey"),
 			"/path/to/payment.skey",
 		)]
@@ -301,7 +301,7 @@ mod tests {
 			),
 			MockIO::current_timestamp(mock_timestamp()),
 			MockIO::prompt(
-				"DB-Sync Postgres connection string",
+				"Enter the DB-Sync Postgres connection string",
 				POSTGRES_CONNECTION_STRING.default,
 				POSTGRES_CONNECTION_STRING.default.unwrap(),
 			),


### PR DESCRIPTION
# Description

This allows to run `prepare-configuration` without running `generate-keys`, making generation of keys optional.

Also, recommended order of running wizards has changed, moving `setup-main-chain-state` before `create-chain-spec`, although both can be run independently.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [x] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
