### PR TITLE
Reserve release datum fix

### DIFF
--- a/toolkit/smart-contracts/offchain/src/plutus_script.rs
+++ b/toolkit/smart-contracts/offchain/src/plutus_script.rs
@@ -207,7 +207,7 @@ macro_rules! plutus_script {
 			plutus_script!(@inner, script $(,$args)*)
 		}
 	);
-	(@inner, $ps:expr) => (Ok($ps));
+	(@inner, $ps:expr) => (Ok::<crate::plutus_script::PlutusScript, anyhow::Error>($ps));
     (@inner, $ps:expr, $arg:expr $(,$args:expr)*) => (
 		$ps.apply_data_uplc($crate::plutus_script::PlutusDataWrapper::from($arg).0)
 	    	.and_then(|ps| plutus_script!(@inner, ps $(,$args)*))

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -34,7 +34,7 @@ use ogmios_client::{
 	query_ledger_state::*, query_network::QueryNetwork, transactions::Transactions,
 	types::OgmiosUtxo,
 };
-use partner_chains_plutus_data::reserve::ReserveRedeemer;
+use partner_chains_plutus_data::reserve::{IlliquidCirculationSupplyDatum, ReserveRedeemer};
 use sidechain_domain::{McTxHash, UtxoId};
 use std::num::NonZero;
 
@@ -126,7 +126,7 @@ fn reserve_release_tx(
 		reserve_data.scripts.illiquid_circulation_supply_validator.bytes.len(),
 	);
 
-	// Mint v-function tokens in the number equal to the *total* number of tokens transfered.
+	// Mint v-function tokens in the number equal to the *total* number of tokens transferred.
 	// This serves as a validation of the v-function value.
 	let v_function = v_function_from_utxo(reference_utxo)?;
 	tx_builder.add_mint_script_token_using_reference_script(
@@ -150,7 +150,7 @@ fn reserve_release_tx(
 			.with_address(
 				&reserve_data.scripts.illiquid_circulation_supply_validator.address(ctx.network),
 			)
-			.with_plutus_data(&PlutusData::new_empty_constr_plutus_data(&0u64.into()))
+			.with_plutus_data(&IlliquidCirculationSupplyDatum.into())
 			.next()?
 			.with_minimum_ada_and_asset(&token.to_multi_asset(amount_to_transfer)?, ctx)?
 			.build()?

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -408,7 +408,7 @@ async fn governance_action_can_be_initiated_by_non_governance() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let tx_to_sign = run_upsert_d_param(genesis_utxo, 1, 1, &eve_payment_key(), &client)
 		.await
 		.unwrap();

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -97,7 +97,7 @@ async fn governance_flow() {
 	let cli = Cli::default();
 	let container = cli.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let _ = run_update_governance(&client, genesis_utxo).await;
 
 	let upsert_candidates_1_result =
@@ -133,7 +133,7 @@ async fn upsert_d_param() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	assert!(
 		run_upsert_d_param(genesis_utxo, 0, 1, &governance_authority_payment_key(), &client)
 			.await
@@ -161,7 +161,7 @@ async fn upsert_permissioned_candidates() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let network = client.shelley_genesis_configuration().await.unwrap().network.to_csl();
 	assert!(run_upsert_permissioned_candidates(genesis_utxo, 77, &client).await.is_some());
 	assert_eq!(
@@ -181,7 +181,7 @@ async fn reserve_management_scenario() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let _ = run_update_governance(&client, genesis_utxo).await;
 	let results = run_init_reserve_management(genesis_utxo, &client).await;
 	assert_eq!(results.len(), 3);
@@ -235,7 +235,7 @@ async fn reserve_release_to_zero_scenario() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let txs = run_init_reserve_management(genesis_utxo, &client).await;
 	assert_eq!(txs.len(), 3);
 	let _ = run_create_reserve_management(genesis_utxo, V_FUNCTION_HASH, &client).await;
@@ -253,7 +253,7 @@ async fn register() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let signature = SidechainSignature([21u8; 33].to_vec());
 	let other_signature = SidechainSignature([121u8; 33].to_vec());
 	assert!(run_register(genesis_utxo, signature.clone(), &client).await.is_some());
@@ -268,7 +268,7 @@ async fn governed_map_operations() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let await_tx = FixedDelayRetries::new(Duration::from_millis(500), 100);
 	// Use the governance authority key
 	let skey = governance_authority_payment_key();
@@ -359,7 +359,7 @@ async fn governed_map_update() {
 	let client = Cli::default();
 	let container = client.run(image);
 	let client = initialize(&container).await;
-	let genesis_utxo = run_init_goveranance(&client).await;
+	let genesis_utxo = run_init_governance(&client).await;
 	let await_tx = FixedDelayRetries::new(Duration::from_millis(500), 100);
 	// Use the governance authority key
 	let skey = governance_authority_payment_key();
@@ -462,7 +462,7 @@ async fn initial_transaction<T: Transactions + QueryUtxoByUtxoId>(
 	Ok(tx_hash)
 }
 
-async fn run_init_goveranance<
+async fn run_init_governance<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 >(
 	client: &T,

--- a/toolkit/smart-contracts/plutus-data/src/reserve.rs
+++ b/toolkit/smart-contracts/plutus-data/src/reserve.rs
@@ -187,6 +187,21 @@ fn decode_token_id_datum(pd: &PlutusData) -> Option<AssetId> {
 	})
 }
 
+#[derive(Debug, Clone)]
+/// Redeemer for illiquid circulation supply
+pub enum IlliquidCirculationSupplyRedeemer {
+	/// Deposit tokens to the supply
+	DepositMoreToSupply = 0,
+	/// Withdraw from the illiquid supply
+	WithdrawFromSupply = 1,
+}
+
+impl From<IlliquidCirculationSupplyRedeemer> for PlutusData {
+	fn from(value: IlliquidCirculationSupplyRedeemer) -> Self {
+		PlutusData::new_integer(&BigInt::from(value as u64))
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use cardano_serialization_lib::PlutusData;

--- a/toolkit/smart-contracts/plutus-data/src/reserve.rs
+++ b/toolkit/smart-contracts/plutus-data/src/reserve.rs
@@ -227,11 +227,11 @@ mod tests {
 	use pretty_assertions::assert_eq;
 	use sidechain_domain::{AssetName, PolicyId};
 
-	use crate::test_helpers::test_plutus_data;
+	use crate::{reserve::IlliquidCirculationSupplyDatum, test_helpers::test_plutus_data};
 
 	use super::{ReserveDatum, ReserveImmutableSettings, ReserveMutableSettings, ReserveStats};
 
-	fn test_datum() -> ReserveDatum {
+	fn test_reserve_datum() -> ReserveDatum {
 		ReserveDatum {
 			immutable_settings: ReserveImmutableSettings {
 				t0: 0,
@@ -248,7 +248,7 @@ mod tests {
 		}
 	}
 
-	fn test_datum_plutus_data() -> PlutusData {
+	fn test_reserve_datum_plutus_data() -> PlutusData {
 		test_plutus_data!({"list":[
 			{"list":[
 				{"list":[
@@ -270,12 +270,27 @@ mod tests {
 	}
 
 	#[test]
-	fn encode() {
-		assert_eq!(PlutusData::from(test_datum()), test_datum_plutus_data())
+	fn encode_reserve_datum() {
+		assert_eq!(PlutusData::from(test_reserve_datum()), test_reserve_datum_plutus_data())
 	}
 
 	#[test]
-	fn decode() {
-		assert_eq!(ReserveDatum::try_from(test_datum_plutus_data()).unwrap(), test_datum())
+	fn decode_reserve_datum() {
+		assert_eq!(
+			ReserveDatum::try_from(test_reserve_datum_plutus_data()).unwrap(),
+			test_reserve_datum()
+		)
+	}
+
+	#[test]
+	fn encode_ics_datum() {
+		assert_eq!(
+			PlutusData::from(IlliquidCirculationSupplyDatum),
+			test_plutus_data!({"list":[
+				{"constructor":0,"fields":[]},
+				{"constructor":0,"fields":[]},
+				{"int":0}
+			]})
+		)
 	}
 }

--- a/toolkit/smart-contracts/plutus-data/src/reserve.rs
+++ b/toolkit/smart-contracts/plutus-data/src/reserve.rs
@@ -202,6 +202,25 @@ impl From<IlliquidCirculationSupplyRedeemer> for PlutusData {
 	}
 }
 
+#[derive(Debug, Clone, PartialEq)]
+/// Datum of the illiquid circulation supply.
+pub struct IlliquidCirculationSupplyDatum;
+
+impl From<IlliquidCirculationSupplyDatum> for PlutusData {
+	fn from(_value: IlliquidCirculationSupplyDatum) -> Self {
+		VersionedGenericDatum {
+			datum: PlutusData::new_empty_constr_plutus_data(
+				&cardano_serialization_lib::BigNum::zero(),
+			),
+			appendix: PlutusData::new_empty_constr_plutus_data(
+				&cardano_serialization_lib::BigNum::zero(),
+			),
+			version: 0,
+		}
+		.into()
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use cardano_serialization_lib::PlutusData;


### PR DESCRIPTION
# Description

* fix ICS UTXO being created with incorrect datum in `reserve release` command
* fix typos
* add ICS redeemer type (will be needed in the future)
* improves `plutus_scripts!` macro: it explicitly specifies the error type as `anyhow::Error` since that's what `apply_data_uplc` returns anyways, and this lets one write `plutus_script![SOME_SCRIPT]` without anything being applied.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
