### PR TITLE
feat: make Chain Config File and Resources Config File configurable by env vars

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * Added extra constant burn fee in `pallet-address-association` to discourage attacks on pallet storage.
 * Wizards don't require `generate-keys` for `prepare-configuration`. Altered recommended order of `create-chain-spec` and `setup-main-chain-state`.
 * `MainchainAddress` is now serialized as plain String instead of hexstring of its bytes
+* Wizards use optional env vars: PC_CHAIN_CONFIG_FILE and PC_RESOURCES_CONFIG_FILE env variables to
 
 ## Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -8,6 +8,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * Wizards don't require `generate-keys` for `prepare-configuration`. Altered recommended order of `create-chain-spec` and `setup-main-chain-state`.
 * `MainchainAddress` is now serialized as plain String instead of hexstring of its bytes
 * Wizards use optional env vars: PC_CHAIN_CONFIG_FILE and PC_RESOURCES_CONFIG_FILE env variables to
+locate the chain config and resources config files
 
 ## Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,14 +4,13 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 # Unreleased
 
+## Changed
+
 * Added extra constant burn fee in `pallet-address-association` to discourage attacks on pallet storage.
 * Wizards don't require `generate-keys` for `prepare-configuration`. Altered recommended order of `create-chain-spec` and `setup-main-chain-state`.
 * `MainchainAddress` is now serialized as plain String instead of hexstring of its bytes
 * Wizards use optional env vars: PC_CHAIN_CONFIG_FILE and PC_RESOURCES_CONFIG_FILE env variables to
 locate the chain config and resources config files
-
-## Changed
-
 * `pallet-block-producer-metadata` is updated with a configurable fee for inserting the metadata, to make attacks on unbounded storage economically infeasible
 * Added `valid_before` argument to the signed message and all extrinsics in `pallet_block_producer_metadata`. This is to
 prevent unauthorized re-submission of metadata updates. The `sign-block-producer-metadata` command was updated to

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -17,7 +17,7 @@ pub(crate) struct ConfigFieldDefinition<'a, T> {
 	/// Config field name
 	pub(crate) name: &'a str,
 	/// Config file name
-	pub(crate) config_file: &'a str,
+	pub(crate) config_file: ConfigFile,
 	/// Path to config field in config file
 	pub(crate) path: &'a [&'a str],
 	/// Optional default value for config field
@@ -29,7 +29,7 @@ pub(crate) struct ConfigFieldDefinition<'a, T> {
 impl<'a, T> ConfigFieldDefinition<'a, T> {
 	pub(crate) fn new(
 		name: &'a str,
-		config_file: &'a str,
+		config_file: ConfigFile,
 		path: &'a [&'a str],
 		default: Option<&'a str>,
 	) -> Self {
@@ -110,7 +110,11 @@ impl<'a, T> ConfigFieldDefinition<'a, T> {
 		T: DeserializeOwned + std::fmt::Display,
 	{
 		let value = self.load_from_file(context)?;
-		context.eprint(&self.loaded_from_config_msg(&value));
+		context.eprint(&format!(
+			"🛠️ Loaded {} from config ({}): {value}",
+			self.name,
+			context.config_file_path(self.config_file)
+		));
 		Some(value)
 	}
 
@@ -131,7 +135,10 @@ impl<'a, T> ConfigFieldDefinition<'a, T> {
 			head = &mut head[field];
 		}
 		*head = serde_json::to_value(value).unwrap();
-		context.write_file(self.config_file, &serde_json::to_string_pretty(&json).unwrap());
+		context.write_file(
+			&context.config_file_path(self.config_file),
+			&serde_json::to_string_pretty(&json).unwrap(),
+		);
 	}
 
 	pub(crate) fn save_if_empty<C: IOContext>(&self, value: T, context: &C) -> T
@@ -164,33 +171,22 @@ impl<'a, T> ConfigFieldDefinition<'a, T> {
 
 	/// loads the whole content of the config fields relevant config file
 	pub(crate) fn load_file<C: IOContext>(&self, context: &C) -> Option<serde_json::Value> {
-		if !context.file_exists(self.config_file) {
+		let path = context.config_file_path(self.config_file);
+		if !context.file_exists(&path) {
 			return None;
 		}
 
-		if let Some(file_content_string) = context.read_file(self.config_file) {
+		if let Some(file_content_string) = context.read_file(&path) {
 			if let Ok(value) = serde_json::from_str(&file_content_string) {
 				return Some(value);
 			}
 		}
 
-		self.report_corrupted_file_and_quit()
-	}
-
-	/// Print error message and exit.
-	fn report_corrupted_file_and_quit(&self) -> ! {
-		eprintln!(
+		context.eprint(&format!(
 			"Config file {} is broken. Delete it or fix manually and restart this wizard",
-			self.config_file
-		);
+			path
+		));
 		exit(-1)
-	}
-
-	fn loaded_from_config_msg(&self, value: &T) -> String
-	where
-		T: std::fmt::Display,
-	{
-		format!("🛠️ Loaded {} from config ({}): {value}", self.name, self.config_file)
 	}
 }
 
@@ -380,18 +376,23 @@ pub(crate) struct ChainConfig {
 	pub(crate) cardano_addresses: MainChainAddresses,
 }
 
+#[derive(Copy, Clone)]
+pub enum ConfigFile {
+	Chain,
+	Resources,
+}
+
 pub(crate) const KEYS_FILE_PATH: &str = "partner-chains-public-keys.json";
-pub(crate) const CHAIN_CONFIG_FILE_PATH: &str = "pc-chain-config.json";
-pub(crate) const RESOURCES_CONFIG_FILE_PATH: &str = "pc-resources-config.json";
 pub(crate) const CHAIN_SPEC_PATH: &str = "chain-spec.json";
 
 pub(crate) fn load_chain_config(context: &impl IOContext) -> anyhow::Result<ChainConfig> {
-	if let Some(chain_config_file) = context.read_file(CHAIN_CONFIG_FILE_PATH) {
+	let chain_config_file_path = context.config_file_path(ConfigFile::Chain);
+	if let Some(chain_config_file) = context.read_file(&chain_config_file_path) {
 		serde_json::from_str::<ChainConfig>(&chain_config_file)
-			.map_err(|err| anyhow::anyhow!(format!("⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} is invalid: {err}. Run prepare-configuration wizard or fix errors manually.")))
+			.map_err(|err| anyhow::anyhow!(format!("⚠️ Chain config file {chain_config_file_path} is invalid: {err}. Run prepare-configuration wizard or fix errors manually.")))
 	} else {
 		Err(anyhow::anyhow!(format!(
-			"⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} does not exists. Run prepare-configuration wizard first."
+			"⚠️ Chain config file {chain_config_file_path} does not exists. Run prepare-configuration wizard first."
 		)))
 	}
 }
@@ -402,7 +403,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const NATIVE_TOKEN_POLICY: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "native_token", "asset", "policy_id"],
 			name: "native token policy ID",
 			default: None,
@@ -411,7 +412,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const NATIVE_TOKEN_ASSET_NAME: ConfigFieldDefinition<'static, AssetName> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "native_token", "asset", "asset_name"],
 			name: "native token asset name in hex",
 			default: None,
@@ -420,7 +421,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const ILLIQUID_SUPPLY_ADDRESS: ConfigFieldDefinition<'static, MainchainAddress> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "native_token", "illiquid_supply_address"],
 			name: "native token illiquid token supply address",
 			default: None,
@@ -429,7 +430,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const SUBSTRATE_NODE_DATA_BASE_PATH: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["substrate_node_base_path"],
 			name: "node base path",
 			default: Some("./data"),
@@ -438,7 +439,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_PAYMENT_VERIFICATION_KEY_FILE: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["cardano_payment_verification_key_file"],
 			name: "path to the payment verification file",
 			default: Some("payment.vkey"),
@@ -447,7 +448,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_PAYMENT_SIGNING_KEY_FILE: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["cardano_payment_signing_key_file"],
 			name: "path to the payment signing key file",
 			default: Some("payment.skey"),
@@ -456,7 +457,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_COLD_VERIFICATION_KEY_FILE: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["cardano_cold_verification_key_file"],
 			name: "path to the cold verification key file",
 			default: Some("cold.vkey"),
@@ -464,7 +465,7 @@ pub(crate) mod config_fields {
 		};
 
 	pub(crate) const GENESIS_UTXO: ConfigFieldDefinition<'static, UtxoId> = ConfigFieldDefinition {
-		config_file: CHAIN_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Chain,
 		path: &["chain_parameters", "genesis_utxo"],
 		name: "genesis utxo",
 		default: None,
@@ -473,7 +474,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const BOOTNODES: ConfigFieldDefinition<'static, Vec<String>> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["bootnodes"],
 			name: "bootnodes",
 			default: None,
@@ -484,7 +485,7 @@ pub(crate) mod config_fields {
 		'static,
 		Vec<crate::permissioned_candidates::PermissionedCandidateKeys>,
 	> = ConfigFieldDefinition {
-		config_file: CHAIN_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Chain,
 		path: &["initial_permissioned_candidates"],
 		name: "initial permissioned candidates",
 		default: None,
@@ -493,7 +494,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const POSTGRES_CONNECTION_STRING: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["db_sync_postgres_connection_string"],
 			name: "DB-Sync Postgres connection string",
 			default: Some("postgresql://postgres-user:postgres-password@localhost:5432/cexplorer"),
@@ -502,7 +503,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const OGMIOS_PROTOCOL: ConfigFieldDefinition<'static, NetworkProtocol> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["ogmios", "protocol"],
 			name: "Ogmios protocol (http/https)",
 			default: Some("http"),
@@ -511,7 +512,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const OGMIOS_HOSTNAME: ConfigFieldDefinition<'static, String> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["ogmios", "hostname"],
 			name: "Ogmios hostname",
 			default: Some("localhost"),
@@ -519,7 +520,7 @@ pub(crate) mod config_fields {
 		};
 
 	pub(crate) const OGMIOS_PORT: ConfigFieldDefinition<'static, u16> = ConfigFieldDefinition {
-		config_file: RESOURCES_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Resources,
 		path: &["ogmios", "port"],
 		name: "Ogmios port",
 		default: Some("1337"),
@@ -528,7 +529,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const OGMIOS_REQUEST_TIMEOUT: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: RESOURCES_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Resources,
 			path: &["ogmios", "request_timeout"],
 			name: "Ogmios request timeout [seconds]",
 			default: Some("180"),
@@ -539,7 +540,7 @@ pub(crate) mod config_fields {
 		'static,
 		MainchainAddress,
 	> = ConfigFieldDefinition {
-		config_file: CHAIN_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Chain,
 		path: &["cardano_addresses", "committee_candidates_address"],
 		name: "Committee candidates address",
 		default: None,
@@ -548,7 +549,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const D_PARAMETER_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "d_parameter_policy_id"],
 			name: "D parameter policy id",
 			default: None,
@@ -557,7 +558,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const PERMISSIONED_CANDIDATES_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "permissioned_candidates_policy_id"],
 			name: "permissioned candidates policy id",
 			default: None,
@@ -568,7 +569,7 @@ pub(crate) mod config_fields {
 		'static,
 		MainchainAddress,
 	> = ConfigFieldDefinition {
-		config_file: CHAIN_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Chain,
 		path: &["cardano_addresses", "governed_map", "validator_address"],
 		name: "Governed Map Validator Address",
 		default: None,
@@ -577,7 +578,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const GOVERNED_MAP_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano_addresses", "governed_map", "policy_id"],
 			name: "Governed Map Policy Id",
 			default: None,
@@ -586,7 +587,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_SECURITY_PARAMETER: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "security_parameter"],
 			name: "cardano security parameter",
 			default: None,
@@ -595,7 +596,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_ACTIVE_SLOTS_COEFF: ConfigFieldDefinition<'static, f64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "active_slots_coeff"],
 			name: "cardano active slot coefficient",
 			default: None,
@@ -604,7 +605,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_FIRST_EPOCH_NUMBER: ConfigFieldDefinition<'static, u32> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "first_epoch_number"],
 			name: "cardano first epoch number in shelley era",
 			default: None,
@@ -613,7 +614,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_FIRST_SLOT_NUMBER: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "first_slot_number"],
 			name: "cardano first slot number in shelley era",
 			default: None,
@@ -622,7 +623,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_EPOCH_DURATION_MILLIS: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "epoch_duration_millis"],
 			name: "cardano epoch duration in millis",
 			default: None,
@@ -631,7 +632,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_FIRST_EPOCH_TIMESTAMP_MILLIS: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "first_epoch_timestamp_millis"],
 			name: "cardano first shelley epoch timestamp in millis",
 			default: None,
@@ -640,7 +641,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const CARDANO_SLOT_DURATION_MILLIS: ConfigFieldDefinition<'static, u64> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["cardano", "slot_duration_millis"],
 			name: "cardano slot duration in millis",
 			default: Some("1000"),
@@ -648,7 +649,7 @@ pub(crate) mod config_fields {
 		};
 
 	pub(crate) const NODE_P2P_PORT: ConfigFieldDefinition<'static, u16> = ConfigFieldDefinition {
-		config_file: RESOURCES_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Resources,
 		path: &["node_p2p_port"],
 		name: "substrate-node p2p protocol TCP port",
 		default: Some("30333"),
@@ -659,7 +660,7 @@ pub(crate) mod config_fields {
 		'static,
 		GovernanceAuthoritiesKeyHashes,
 	> = ConfigFieldDefinition {
-		config_file: CHAIN_CONFIG_FILE_PATH,
+		config_file: ConfigFile::Chain,
 		path: &["initial_governance", "authorities"],
 		name: "space separated keys hashes of the initial Multisig Governance Authorities",
 		default: Some("[]"),
@@ -668,7 +669,7 @@ pub(crate) mod config_fields {
 
 	pub(crate) const INITIAL_GOVERNANCE_THRESHOLD: ConfigFieldDefinition<'static, u8> =
 		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
+			config_file: ConfigFile::Chain,
 			path: &["initial_governance", "threshold"],
 			name: "Initial Multisig Governance Threshold",
 			default: Some("1"),

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -86,7 +86,8 @@ impl<T: PartnerChainRuntime> CreateChainSpecCmd<T> {
 			context.print("WARNING: The list of initial permissioned candidates is empty. Generated chain spec will not allow the chain to start.".red().to_string().as_str());
 			let update_msg = format!(
 				"Update 'initial_permissioned_candidates' field of {} file with keys of initial committee.",
-				config_fields::INITIAL_PERMISSIONED_CANDIDATES.config_file
+				context
+					.config_file_path(config_fields::INITIAL_PERMISSIONED_CANDIDATES.config_file)
 			);
 			context.print(update_msg.red().to_string().as_str());
 			context.print(INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE.yellow().to_string().as_str());
@@ -248,8 +249,8 @@ fn load_config_field<C: IOContext, T: DeserializeOwned>(
 	field: &ConfigFieldDefinition<T>,
 ) -> Result<T, anyhow::Error> {
 	field.load_from_file(context).ok_or_else(|| {
-		context.eprint(format!("The '{}' configuration file is missing or invalid.\nIf you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\nIf you are a validator, you can obtain the chain configuration file from the governance authority.", field.config_file).as_str());
-	anyhow!("failed to read '{}'", field.path.join("."))
+		context.eprint(format!("The '{}' configuration file is missing or invalid.\nIf you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.\nIf you are a validator, you can obtain the chain configuration file from the governance authority.", context.config_file_path(field.config_file)).as_str());
+		anyhow!("failed to read '{}'", field.path.join("."))
 	})
 }
 

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -1,7 +1,6 @@
 use super::PartnerChainRuntime;
-use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::create_chain_spec::{CreateChainSpecCmd, INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE};
-use crate::tests::{MockIO, MockIOContext};
+use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext};
 use crate::{CmdRun, verify_json};
 use anyhow::anyhow;
 use colored::Colorize;
@@ -79,7 +78,7 @@ fn shows_warning_when_initial_candidates_are_empty() {
 			show_intro(),
 			show_chain_parameters(),
 			MockIO::print(&"WARNING: The list of initial permissioned candidates is empty. Generated chain spec will not allow the chain to start.".red().to_string()),
-			MockIO::print(&"Update 'initial_permissioned_candidates' field of pc-chain-config.json file with keys of initial committee.".red().to_string()),
+			MockIO::print(&"Update 'initial_permissioned_candidates' field of test-pc-chain-config.json file with keys of initial committee.".red().to_string()),
 			MockIO::print(&INITIAL_PERMISSIONED_CANDIDATES_EXAMPLE.yellow().to_string()),
 			MockIO::prompt_yes_no("Do you want to continue?", true, false),
 			MockIO::print("Aborted."),
@@ -94,7 +93,7 @@ fn instruct_user_when_config_file_is_invalid() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_without_initial_permissioned_candidates())
 		.with_expected_io(vec![
-			MockIO::eprint("The 'pc-chain-config.json' configuration file is missing or invalid.
+			MockIO::eprint("The 'test-pc-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);
@@ -107,7 +106,7 @@ fn instruct_user_when_config_file_has_a_field_in_wrong_format() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_config_content_with_a_field_in_wrong_format())
 		.with_expected_io(vec![
-			MockIO::eprint("The 'pc-chain-config.json' configuration file is missing or invalid.
+			MockIO::eprint("The 'test-pc-chain-config.json' configuration file is missing or invalid.
 If you are the governance authority, please make sure you have run the `prepare-configuration` command to generate the chain configuration file.
 If you are a validator, you can obtain the chain configuration file from the governance authority."),
 		]);

--- a/toolkit/partner-chains-cli/src/deregister/mod.rs
+++ b/toolkit/partner-chains-cli/src/deregister/mod.rs
@@ -6,7 +6,6 @@ use crate::cardano_key::{
 	get_mc_payment_signing_key_from_file, get_stake_pool_verification_key_from_file,
 };
 use crate::cmd_traits::Deregister;
-use crate::config::CHAIN_CONFIG_FILE_PATH;
 use crate::config::config_fields::{
 	CARDANO_COLD_VERIFICATION_KEY_FILE, CARDANO_PAYMENT_SIGNING_KEY_FILE,
 };
@@ -68,7 +67,7 @@ fn read_chain_config_file<C: IOContext>(
 	chain_config
 		.map_err(|_|anyhow!(
 			"Couldn't parse chain configuration file {}. The chain configuration file that was used for registration is required in the working directory.",
-			CHAIN_CONFIG_FILE_PATH))
+			context.chain_config_file_path()))
 }
 
 impl<T> Deregister for T

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -1,9 +1,11 @@
-use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
 use crate::deregister::DeregisterCmd;
 use crate::ogmios::config::tests::{
 	default_ogmios_config_json, default_ogmios_service_config, establish_ogmios_configuration_io,
 };
-use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
+use crate::tests::{
+	CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, OffchainMock, OffchainMocks,
+	RESOURCES_CONFIG_FILE_PATH,
+};
 use crate::{CmdRun, CommonArguments, verify_json};
 use hex_literal::hex;
 use serde_json::json;
@@ -72,7 +74,7 @@ fn fails_when_chain_config_is_not_valid() {
 	let result = deregister_cmd().run(&mock_context);
 	assert_eq!(
 		result.err().unwrap().to_string(),
-		"Couldn't parse chain configuration file pc-chain-config.json. The chain configuration file that was used for registration is required in the working directory."
+		"Couldn't parse chain configuration file test-pc-chain-config.json. The chain configuration file that was used for registration is required in the working directory."
 	);
 }
 

--- a/toolkit/partner-chains-cli/src/generate_keys/tests.rs
+++ b/toolkit/partner-chains-cli/src/generate_keys/tests.rs
@@ -1,6 +1,5 @@
 use super::*;
 use crate::CmdRun;
-use crate::config::RESOURCES_CONFIG_FILE_PATH;
 use crate::tests::*;
 use scenarios::key_file_content;
 use scenarios::resources_file_content;

--- a/toolkit/partner-chains-cli/src/io.rs
+++ b/toolkit/partner-chains-cli/src/io.rs
@@ -1,5 +1,5 @@
 use crate::cmd_traits::*;
-use crate::config::ServiceConfig;
+use crate::config::{ConfigFile, ServiceConfig};
 use crate::ogmios::{OgmiosRequest, OgmiosResponse, ogmios_request};
 use anyhow::{Context, anyhow};
 use inquire::InquireError;
@@ -50,6 +50,11 @@ pub trait IOContext {
 		req: OgmiosRequest,
 	) -> anyhow::Result<OgmiosResponse>;
 	fn offchain_impl(&self, ogmios_config: &ServiceConfig) -> anyhow::Result<Self::Offchain>;
+	fn config_file_path(&self, file: ConfigFile) -> String;
+
+	fn chain_config_file_path(&self) -> String {
+		self.config_file_path(ConfigFile::Chain)
+	}
 }
 
 /// Default context implementation using standard IO.
@@ -201,6 +206,16 @@ impl IOContext for DefaultCmdRunContext {
 			.map_err(|_| {
 				anyhow!(format!("Couldn't open connection to Ogmios at {}", ogmios_address))
 			})
+	}
+
+	fn config_file_path(&self, file: ConfigFile) -> String {
+		match file {
+			ConfigFile::Chain => {
+				std::env::var("PC_CHAIN_CONFIG_PATH").unwrap_or("pc-chain-config.json".to_owned())
+			},
+			ConfigFile::Resources => std::env::var("PC_RESOURCES_CONFIG_PATH")
+				.unwrap_or("pc-resources-config.json".to_owned()),
+		}
 	}
 }
 

--- a/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/init_governance.rs
@@ -68,7 +68,7 @@ fn prompt_initial_governance<C: IOContext>(
 		|err| anyhow!(
 			"Initial Governance data is invalid: '{}'. Please run the wizard again and provide correct value or edit values in '{}' and the run the wizard again. Example: '{}'",
 			err,
-			INITIAL_GOVERNANCE_AUTHORITIES.config_file,
+			context.config_file_path(INITIAL_GOVERNANCE_AUTHORITIES.config_file),
 			&example_governance_auth()
 		)
 	)
@@ -91,11 +91,11 @@ fn example_governance_auth() -> serde_json::Value {
 mod tests {
 	use super::run_init_governance;
 	use crate::{
-		config::{
-			CHAIN_CONFIG_FILE_PATH, NetworkProtocol, ServiceConfig,
-			config_fields::{GENESIS_UTXO, OGMIOS_PROTOCOL},
+		config::{NetworkProtocol, ServiceConfig},
+		tests::{
+			CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, OffchainMock, OffchainMocks,
+			RESOURCES_CONFIG_FILE_PATH,
 		},
-		tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks},
 		verify_json,
 	};
 	use hex_literal::hex;
@@ -109,8 +109,8 @@ mod tests {
 	#[test]
 	fn happy_path() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(GENESIS_UTXO.config_file, serde_json::json!({}))
-			.with_json_file(OGMIOS_PROTOCOL.config_file, serde_json::json!({}))
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, serde_json::json!({}))
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, serde_json::json!({}))
 			.with_offchain_mocks(preprod_offchain_mocks())
 			.with_expected_io(vec![
 				MockIO::eprint("Please provide the initial chain governance key hashes:"),

--- a/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/mod.rs
@@ -111,7 +111,7 @@ fn configure_bootnode(peer_id: String, context: &impl IOContext) -> anyhow::Resu
 	};
 
 	BOOTNODES.save_to_file(&vec![bootnode], context);
-	context.eprint(&outro());
+	context.eprint(&outro(context.chain_config_file_path()));
 	Ok(())
 }
 
@@ -202,10 +202,10 @@ const INTRO: &str =
 * initialize Partner Chains Governance on Cardano
 * establish Partner Chains Smart Contracts addresses and policies (to be later included in chain-spec file)";
 
-fn outro() -> String {
+fn outro(chain_config_file_path: String) -> String {
 	format!(
 		"Bootnode saved successfully. Keep in mind that you can manually modify {}, to edit bootnodes.",
-		BOOTNODES.config_file
+		chain_config_file_path
 	)
 }
 
@@ -270,12 +270,9 @@ impl<T: QueryNetwork> GetScriptsData for T {
 #[cfg(test)]
 pub mod tests {
 	use super::*;
-	use crate::config::config_fields::BOOTNODES;
-	use crate::config::{
-		CHAIN_CONFIG_FILE_PATH, ConfigFieldDefinition, RESOURCES_CONFIG_FILE_PATH, SelectOptions,
-	};
+	use crate::config::{ConfigFieldDefinition, SelectOptions};
 	use crate::prepare_configuration::Protocol::{Dns, Ipv4};
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, RESOURCES_CONFIG_FILE_PATH};
 	use crate::{CommonArguments, verify_json};
 
 	const KEY: &str = "962515971a22aa95706c2109ba6e9502c7f39b33bdf63024f46f77894424f1fe";
@@ -407,7 +404,7 @@ pub mod tests {
 			scenarios::read_config(),
 			scenarios::choose_to_configure_bootnode(true),
 			scenarios::pick_ip_protocol_with_defaults(),
-			MockIO::eprint(&outro()),
+			MockIO::eprint(&outro(CHAIN_CONFIG_FILE_PATH.to_owned())),
 		]);
 
 		let result = establish_bootnodes(&mock_context);
@@ -426,7 +423,7 @@ pub mod tests {
 			scenarios::read_config(),
 			scenarios::choose_to_configure_bootnode(true),
 			scenarios::pick_dns_protocol_with_defaults(),
-			MockIO::eprint(&outro()),
+			MockIO::eprint(&outro(CHAIN_CONFIG_FILE_PATH.to_owned())),
 		]);
 
 		let result = establish_bootnodes(&mock_context);
@@ -454,7 +451,7 @@ pub mod tests {
 	fn propose_saved_defaults_but_pick_different() {
 		let mock_context = context_with_config(KEY)
 			.with_json_file(
-				BOOTNODES.config_file,
+				CHAIN_CONFIG_FILE_PATH,
 				serde_json::json!({
 					"bootnodes": ["/ip4/ip_address/tcp/3034/p2p/12D3KooWWi9ys81fpG9ibuVWh6w6egfcTUM8L1iSJSpfFtMLMLG8"]
 				}),
@@ -467,7 +464,7 @@ pub mod tests {
 					3034,
 					Dns.default_address().to_string(),
 				),
-				MockIO::eprint(&outro()),
+				MockIO::eprint(&outro(CHAIN_CONFIG_FILE_PATH.to_owned())),
 			]);
 
 		let result = establish_bootnodes(&mock_context);
@@ -480,7 +477,7 @@ pub mod tests {
 	fn propose_saved_defaults_and_pick_it() {
 		let mock_context = context_with_config(KEY)
 			.with_json_file(
-				BOOTNODES.config_file,
+				CHAIN_CONFIG_FILE_PATH,
 				serde_json::json!({
 					"bootnodes": ["/ip4/ip_address/tcp/3034/p2p/12D3KooWWi9ys81fpG9ibuVWh6w6egfcTUM8L1iSJSpfFtMLMLG8"]
 				}),
@@ -493,7 +490,7 @@ pub mod tests {
 					3034,
 					"ip_address".to_string(),
 				),
-				MockIO::eprint(&outro()),
+				MockIO::eprint(&outro(CHAIN_CONFIG_FILE_PATH.to_owned())),
 			]);
 
 		let result = establish_bootnodes(&mock_context);
@@ -505,7 +502,7 @@ pub mod tests {
 	#[test]
 	fn continue_without_network_key_file_when_user_agrees() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(RESOURCES_CONFIG_FILE_PATH, serde_json::json!({}))
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, serde_json::json!({}))
 			.with_expected_io(vec![
 				scenarios::read_config(),
 				MockIO::print(&format!("Could not read network key from {}", network_key_file())),
@@ -528,7 +525,7 @@ pub mod tests {
 				scenarios::read_config(),
 				scenarios::choose_to_configure_bootnode(true),
 				scenarios::pick_ip_protocol_with_defaults(),
-				MockIO::eprint(&outro()),
+				MockIO::eprint(&outro(CHAIN_CONFIG_FILE_PATH.to_owned())),
 			]);
 
 		let result = establish_bootnodes(&mock_context);

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_cardano_params.rs
@@ -63,14 +63,14 @@ fn get_first_epoch_era(eras_summaries: Vec<EraSummary>) -> Result<EraSummary, an
 pub mod tests {
 
 	use super::*;
-	use crate::config::{CHAIN_CONFIG_FILE_PATH, NetworkProtocol};
+	use crate::config::NetworkProtocol;
 	use crate::ogmios::EraSummary;
 	use crate::ogmios::test_values::{
 		preprod_eras_summaries, preprod_shelley_config, preview_eras_summaries,
 		preview_shelley_config,
 	};
 	use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext};
 
 	pub(crate) const PREPROD_CARDANO_PARAMS: CardanoParameters = CardanoParameters {
 		security_parameter: 2160,

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -121,12 +121,14 @@ After setting up the permissioned candidates, execute the 'setup-main-chain-stat
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::config::config_fields::{GENESIS_UTXO, OGMIOS_PROTOCOL};
-	use crate::config::{CHAIN_CONFIG_FILE_PATH, NetworkProtocol};
+	use crate::config::NetworkProtocol;
 	use crate::ogmios::test_values::{preprod_eras_summaries, preprod_shelley_config};
 	use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 	use crate::prepare_configuration::prepare_cardano_params::tests::PREPROD_CARDANO_PARAMS;
-	use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
+	use crate::tests::{
+		CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, OffchainMock, OffchainMocks,
+		RESOURCES_CONFIG_FILE_PATH,
+	};
 	use crate::verify_json;
 	use partner_chains_cardano_offchain::scripts_data::{Addresses, PolicyIds, ScriptsData};
 	use serde_json::Value;
@@ -207,8 +209,8 @@ mod tests {
 	#[test]
 	fn happy_path() {
 		let mock_context = MockIOContext::new()
-			.with_json_file(GENESIS_UTXO.config_file, serde_json::json!({}))
-			.with_json_file(OGMIOS_PROTOCOL.config_file, serde_json::json!({}))
+			.with_json_file(CHAIN_CONFIG_FILE_PATH, serde_json::json!({}))
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, serde_json::json!({}))
 			.with_json_file("payment.skey", payment_key_content())
 			.with_offchain_mocks(preprod_offchain_mocks())
 			.with_expected_io(vec![
@@ -239,11 +241,11 @@ mod tests {
 	fn happy_path_with_initial_permissioned_candidates() {
 		let mock_context = MockIOContext::new()
 			.with_json_file(
-				INITIAL_PERMISSIONED_CANDIDATES.config_file,
+				CHAIN_CONFIG_FILE_PATH,
 				json!({"initial_permissioned_candidates": initial_permissioned_candidates_json()}),
 			)
 			.with_json_file("payment.skey", payment_key_content())
-			.with_json_file(OGMIOS_PROTOCOL.config_file, serde_json::json!({}))
+			.with_json_file(RESOURCES_CONFIG_FILE_PATH, serde_json::json!({}))
 			.with_offchain_mocks(preprod_offchain_mocks())
 			.with_expected_io(vec![
 				MockIO::ogmios_request(

--- a/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/select_genesis_utxo.rs
@@ -55,8 +55,6 @@ const INTRO: &str = "Now, let's set up the genesis UTXO. It identifies the partn
 
 #[cfg(test)]
 mod tests {
-	use crate::config::config_fields::GENESIS_UTXO;
-	use crate::config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
 	use crate::ogmios::config::tests::{
 		default_ogmios_config_json, default_ogmios_service_config, prompt_ogmios_configuration_io,
 	};
@@ -64,7 +62,7 @@ mod tests {
 	use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 	use crate::prepare_configuration::select_genesis_utxo::{INTRO, select_genesis_utxo};
 	use crate::select_utxo::tests::{mock_7_valid_utxos_rows, mock_result_7_valid, query_utxos_io};
-	use crate::tests::{MockIO, MockIOContext};
+	use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, RESOURCES_CONFIG_FILE_PATH};
 	use crate::verify_json;
 
 	fn payment_key_content() -> serde_json::Value {
@@ -102,7 +100,7 @@ mod tests {
 		result.expect("should succeed");
 		verify_json!(
 			mock_context,
-			GENESIS_UTXO.config_file,
+			CHAIN_CONFIG_FILE_PATH,
 			serde_json::json!({"chain_parameters": {"genesis_utxo": "4704a903b01514645067d851382efd4a6ed5d2ff07cf30a538acc78fed7c4c02#93"}})
 		);
 		verify_json!(

--- a/toolkit/partner-chains-cli/src/register/register1.rs
+++ b/toolkit/partner-chains-cli/src/register/register1.rs
@@ -160,8 +160,7 @@ fn derive_address<C: IOContext>(
 #[cfg(test)]
 mod tests {
 	use super::*;
-	use crate::tests::{MockIO, MockIOContext};
-	use config::{CHAIN_CONFIG_FILE_PATH, RESOURCES_CONFIG_FILE_PATH};
+	use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, RESOURCES_CONFIG_FILE_PATH};
 	use ogmios::{
 		OgmiosRequest,
 		config::tests::{

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -1,12 +1,13 @@
-use crate::config::CHAIN_CONFIG_FILE_PATH;
-use crate::config::RESOURCES_CONFIG_FILE_PATH;
 use crate::config::config_fields::CARDANO_PAYMENT_SIGNING_KEY_FILE;
 use crate::ogmios::config::tests::{
 	default_ogmios_config_json, default_ogmios_service_config, prompt_ogmios_configuration_io,
 };
 use crate::prepare_configuration::tests::{prompt, prompt_with_default};
 use crate::setup_main_chain_state::SetupMainChainStateCmd;
-use crate::tests::{MockIO, MockIOContext, OffchainMock, OffchainMocks};
+use crate::tests::{
+	CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, OffchainMock, OffchainMocks,
+	RESOURCES_CONFIG_FILE_PATH,
+};
 use crate::{CmdRun, CommonArguments, verify_json};
 use hex_literal::hex;
 use partner_chains_cardano_offchain::multisig::MultiSigSmartContractResult;
@@ -295,7 +296,7 @@ fn update_d_parameter_io() -> MockIO {
 fn print_main_chain_and_configuration_candidates_difference_io() -> MockIO {
 	MockIO::Group(vec![
 		MockIO::print(
-			"Permissioned candidates in the pc-chain-config.json file does not match the most recent on-chain initial permissioned candidates.",
+			"Permissioned candidates in the test-pc-chain-config.json file does not match the most recent on-chain initial permissioned candidates.",
 		),
 		MockIO::print("The most recent on-chain initial permissioned candidates are:"),
 		MockIO::print(
@@ -316,7 +317,7 @@ fn print_main_chain_and_configuration_candidates_difference_io() -> MockIO {
 
 fn print_main_chain_and_configuration_candidates_are_equal_io() -> MockIO {
 	MockIO::Group(vec![MockIO::print(
-		"Permissioned candidates in the pc-chain-config.json file match the most recent on-chain initial permissioned candidates.",
+		"Permissioned candidates in the test-pc-chain-config.json file match the most recent on-chain initial permissioned candidates.",
 	)])
 }
 

--- a/toolkit/partner-chains-cli/src/start_node/mod.rs
+++ b/toolkit/partner-chains-cli/src/start_node/mod.rs
@@ -1,5 +1,5 @@
 use crate::config::config_fields::{NODE_P2P_PORT, POSTGRES_CONNECTION_STRING};
-use crate::config::{CHAIN_CONFIG_FILE_PATH, CHAIN_SPEC_PATH, CardanoParameters};
+use crate::config::{CHAIN_SPEC_PATH, CardanoParameters};
 use crate::generate_keys::network_key_path;
 use crate::io::IOContext;
 use crate::keystore::*;
@@ -63,14 +63,15 @@ impl CmdRun for StartNodeCmd {
 }
 
 fn load_chain_config<C: IOContext>(context: &C) -> anyhow::Result<Option<StartNodeChainConfig>> {
-	let Some(chain_config_file) = context.read_file(CHAIN_CONFIG_FILE_PATH) else {
-		context.eprint(&format!("⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} does not exists. Run prepare-configuration wizard first."));
+	let chain_config_file_path = context.chain_config_file_path();
+	let Some(chain_config_file) = context.read_file(&chain_config_file_path) else {
+		context.eprint(&format!("⚠️ Chain config file {chain_config_file_path} does not exists. Run prepare-configuration wizard first."));
 		return Ok(None);
 	};
 	let chain_config = match serde_json::from_str::<StartNodeChainConfig>(&chain_config_file) {
 		Ok(chain_config) => chain_config,
 		Err(err) => {
-			context.eprint(&format!("⚠️ Chain config file {CHAIN_CONFIG_FILE_PATH} is invalid: {err}. Run prepare-configuration wizard or fix errors manually."));
+			context.eprint(&format!("⚠️ Chain config file {chain_config_file_path} is invalid: {err}. Run prepare-configuration wizard or fix errors manually."));
 			return Ok(None);
 		},
 	};

--- a/toolkit/partner-chains-cli/src/start_node/tests.rs
+++ b/toolkit/partner-chains-cli/src/start_node/tests.rs
@@ -1,8 +1,7 @@
-use crate::tests::{MockIO, MockIOContext};
+use crate::tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext, RESOURCES_CONFIG_FILE_PATH};
 
 use super::*;
 
-const RESOURCES_CONFIG_PATH: &str = "pc-resources-config.json";
 const DATA_PATH: &str = "/path/to/data";
 const CHAIN_SPEC_FILE: &str = "chain-spec.json";
 const DB_CONNECTION_STRING: &str =
@@ -113,16 +112,16 @@ fn happy_path() {
 	];
 
 	let context = MockIOContext::new()
-		.with_json_file(RESOURCES_CONFIG_PATH, default_resources_config_json())
+		.with_json_file(RESOURCES_CONFIG_FILE_PATH, default_resources_config_json())
         .with_json_file(CHAIN_CONFIG_FILE_PATH, default_chain_config())
 		.with_file(CHAIN_SPEC_FILE, "irrelevant")
 		.with_expected_io(vec![
 			MockIO::eprint(&format!(
-				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_PATH}): {DATA_PATH}"
+				"🛠️ Loaded node base path from config ({RESOURCES_CONFIG_FILE_PATH}): {DATA_PATH}"
 			)),
 			MockIO::list_dir(&keystore_path(), Some(keystore_files.clone())),
 			MockIO::eprint(&format!(
-				"🛠️ Loaded DB-Sync Postgres connection string from config ({RESOURCES_CONFIG_PATH}): {DB_CONNECTION_STRING}"
+				"🛠️ Loaded DB-Sync Postgres connection string from config ({RESOURCES_CONFIG_FILE_PATH}): {DB_CONNECTION_STRING}"
 			)),
 			value_check_prompt(),
 			MockIO::run_command(&default_chain_config_run_command(), "irrelevant")
@@ -131,7 +130,7 @@ fn happy_path() {
 	let result = StartNodeCmd { silent: false }.run(&context);
 
 	result.expect("should succeed");
-	verify_json!(context, RESOURCES_CONFIG_PATH, expected_final_resources_config_json());
+	verify_json!(context, RESOURCES_CONFIG_FILE_PATH, expected_final_resources_config_json());
 }
 
 mod check_chain_spec {
@@ -204,9 +203,8 @@ mod check_keystore {
 
 mod load_chain_config {
 	use crate::{
-		config::CHAIN_CONFIG_FILE_PATH,
 		start_node::load_chain_config,
-		tests::{MockIO, MockIOContext},
+		tests::{CHAIN_CONFIG_FILE_PATH, MockIO, MockIOContext},
 	};
 
 	use super::default_chain_config;

--- a/toolkit/partner-chains-cli/src/tests/config.rs
+++ b/toolkit/partner-chains-cli/src/tests/config.rs
@@ -2,17 +2,18 @@ use crate::config::*;
 
 mod config_field {
 
-	use crate::{tests::MockIOContext, verify_json};
+	use crate::{
+		tests::{CHAIN_CONFIG_FILE_PATH, MockIOContext, RESOURCES_CONFIG_FILE_PATH},
+		verify_json,
+	};
 
 	use super::*;
 
 	#[test]
 	fn saves_to_new_file() {
-		let config_file_path = "/path/to/test-config.json";
-
 		let config_field: ConfigFieldDefinition<String> = ConfigFieldDefinition::new(
 			"test config field",
-			config_file_path,
+			ConfigFile::Chain,
 			&["path", "to", "field"],
 			None,
 		);
@@ -28,13 +29,11 @@ mod config_field {
 		let mock_context = MockIOContext::new();
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
-		verify_json!(mock_context, config_file_path, expected_file_content);
+		verify_json!(mock_context, CHAIN_CONFIG_FILE_PATH, expected_file_content);
 	}
 
 	#[test]
 	fn saves_to_existing_file() {
-		let config_file_path = "/path/to/test-config.json";
-
 		let existing_content = serde_json::json!({
 			"some": {
 				"other": {
@@ -45,7 +44,7 @@ mod config_field {
 
 		let config_field: ConfigFieldDefinition<String> = ConfigFieldDefinition::new(
 			"test config field",
-			config_file_path,
+			ConfigFile::Resources,
 			&["path", "to", "field"],
 			None,
 		);
@@ -63,16 +62,15 @@ mod config_field {
 			}
 		});
 
-		let mock_context = MockIOContext::new().with_json_file(config_file_path, existing_content);
+		let mock_context =
+			MockIOContext::new().with_json_file(RESOURCES_CONFIG_FILE_PATH, existing_content);
 
 		config_field.save_to_file(&"this is a test string".into(), &mock_context);
-		verify_json!(mock_context, config_file_path, expected_file_content);
+		verify_json!(mock_context, RESOURCES_CONFIG_FILE_PATH, expected_file_content);
 	}
 
 	#[test]
 	fn loads_file() {
-		let config_file_path = "/path/to/test-config.json";
-
 		let json_content = serde_json::json!({
 			"path": {
 				"to": {
@@ -83,13 +81,13 @@ mod config_field {
 
 		let config_field: ConfigFieldDefinition<String> = ConfigFieldDefinition::new(
 			"test config field",
-			config_file_path,
+			ConfigFile::Resources,
 			&["path", "to", "field"],
 			None,
 		);
 
 		let mock_context =
-			MockIOContext::new().with_json_file(config_file_path, json_content.clone());
+			MockIOContext::new().with_json_file(RESOURCES_CONFIG_FILE_PATH, json_content.clone());
 
 		let read_content = config_field.load_file(&mock_context);
 
@@ -100,7 +98,7 @@ mod config_field {
 	fn extracts_from_json() {
 		let config_field: ConfigFieldDefinition<String> = ConfigFieldDefinition::new(
 			"test config field",
-			"not used",
+			ConfigFile::Chain,
 			&["path", "to", "field"],
 			None,
 		);

--- a/toolkit/partner-chains-cli/src/tests/mod.rs
+++ b/toolkit/partner-chains-cli/src/tests/mod.rs
@@ -1,5 +1,5 @@
 use crate::cmd_traits::*;
-use crate::config::ServiceConfig;
+use crate::config::{ConfigFile, ServiceConfig};
 use crate::io::IOContext;
 use crate::ogmios::{OgmiosRequest, OgmiosResponse};
 use anyhow::anyhow;
@@ -159,6 +159,10 @@ pub struct MockIOContext {
 	pub offchain_mocks: OffchainMocks,
 }
 
+pub(crate) const CHAIN_CONFIG_FILE_PATH: &str = "test-pc-chain-config.json";
+
+pub(crate) const RESOURCES_CONFIG_FILE_PATH: &str = "test-pc-resources-config.json";
+
 impl MockIOContext {
 	pub fn new() -> Self {
 		Self {
@@ -167,6 +171,7 @@ impl MockIOContext {
 			offchain_mocks: Default::default(),
 		}
 	}
+
 	pub fn with_file(self, path: &str, content: &str) -> Self {
 		self.files.lock().unwrap().insert(path.into(), content.into());
 		self
@@ -680,6 +685,13 @@ impl IOContext for MockIOContext {
 			anyhow::anyhow!("No mock for Offchain implementation for {:?}", ogmios_config)
 		})?;
 		Ok(mock.clone())
+	}
+
+	fn config_file_path(&self, file: ConfigFile) -> String {
+		match file {
+			ConfigFile::Chain => CHAIN_CONFIG_FILE_PATH.to_owned(),
+			ConfigFile::Resources => RESOURCES_CONFIG_FILE_PATH.to_owned(),
+		}
 	}
 }
 


### PR DESCRIPTION
# Description

By popular demand this PR adds option to configure wizards Chain Config File and Resources Config File paths by using `PC_CHAIN_CONFIG_PATH` and `PC_RESOURCES_CONFIG_PATH` environment variables.
In case of their absence, the default values are used.

REF: ETCM-12090
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
