### PR TITLE
feat: serialize MainchainAddress as String, deserialize String and hexstring

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 * Added extra constant burn fee in `pallet-address-association` to discourage attacks on pallet storage.
 * Wizards don't require `generate-keys` for `prepare-configuration`. Altered recommended order of `create-chain-spec` and `setup-main-chain-state`.
+* `MainchainAddress` is now serialized as plain String instead of hexstring of its bytes
 
 ## Changed
 

--- a/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
+++ b/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
@@ -235,8 +235,7 @@ jq '.genesis.runtimeGenesis.config.sessionCommitteeManagement.initialAuthorities
 ]' chain-spec.json > tmp.json && mv tmp.json chain-spec.json
 
 echo "Setting Governed Map scripts..."
-export GOVERNED_MAP_VALIDATOR_ADDRESS_HEX="0x$(echo -n $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
-jq --arg address $GOVERNED_MAP_VALIDATOR_ADDRESS_HEX --arg policy_id $GOVERNED_MAP_POLICY_ID '.genesis.runtimeGenesis.config.governedMap.mainChainScripts = {
+jq --arg address $GOVERNED_MAP_VALIDATOR_ADDRESS --arg policy_id $GOVERNED_MAP_POLICY_ID '.genesis.runtimeGenesis.config.governedMap.mainChainScripts = {
   "validator_address": $address,
   "asset_policy_id": $policy_id
 }' chain-spec.json > tmp.json && mv tmp.json chain-spec.json

--- a/dev/update-chain-spec.sh
+++ b/dev/update-chain-spec.sh
@@ -6,9 +6,7 @@ if [ -z "$GOVERNED_MAP_VALIDATOR_ADDRESS" ]
 then
     echo "GOVERNED_MAP_VALIDATOR_ADDRESS is not set. Not attempting to update chain-spec value for it."
 else
-    # -p for plain output, -c 128 to prevent wrapping lines
-    export ADDRESS_HEX="0x$(echo -n $GOVERNED_MAP_VALIDATOR_ADDRESS | xxd -p -c 128)"
-    jq --arg value $ADDRESS_HEX '.genesis.runtimeGenesis.config.governedMap.mainChainScripts.validator_address |= $value' $1 > chain-spec.json.tmp
+    jq --arg value $GOVERNED_MAP_VALIDATOR_ADDRESS '.genesis.runtimeGenesis.config.governedMap.mainChainScripts.validator_address |= $value' $1 > chain-spec.json.tmp
     mv chain-spec.json.tmp $1
 fi
 


### PR DESCRIPTION
# Description

Modifies serialization of `MainchainAddress` to be plain string instead of hexstring of wrapped bytes. Deserialization handles both formats.
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
