### PR TITLE
refactor: use types in CreateChainSpecConfig

### DIFF
--- a/toolkit/partner-chains-cli/Cargo.toml
+++ b/toolkit/partner-chains-cli/Cargo.toml
@@ -44,3 +44,7 @@ pallet-session-validator-management = { workspace = true, features = ["std"] }
 [dev-dependencies]
 pretty_assertions = { workspace = true }
 hex-literal = { workspace = true }
+
+[features]
+default = ["std"]
+std = []

--- a/toolkit/partner-chains-cli/src/config.rs
+++ b/toolkit/partner-chains-cli/src/config.rs
@@ -398,9 +398,9 @@ pub(crate) fn load_chain_config(context: &impl IOContext) -> anyhow::Result<Chai
 
 pub(crate) mod config_fields {
 	use super::*;
-	use sidechain_domain::UtxoId;
+	use sidechain_domain::{AssetName, MainchainAddress, PolicyId, UtxoId};
 
-	pub(crate) const NATIVE_TOKEN_POLICY: ConfigFieldDefinition<'static, String> =
+	pub(crate) const NATIVE_TOKEN_POLICY: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "native_token", "asset", "policy_id"],
@@ -409,7 +409,7 @@ pub(crate) mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub(crate) const NATIVE_TOKEN_ASSET_NAME: ConfigFieldDefinition<'static, String> =
+	pub(crate) const NATIVE_TOKEN_ASSET_NAME: ConfigFieldDefinition<'static, AssetName> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "native_token", "asset", "asset_name"],
@@ -418,7 +418,7 @@ pub(crate) mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub(crate) const ILLIQUID_SUPPLY_ADDRESS: ConfigFieldDefinition<'static, String> =
+	pub(crate) const ILLIQUID_SUPPLY_ADDRESS: ConfigFieldDefinition<'static, MainchainAddress> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "native_token", "illiquid_supply_address"],
@@ -535,16 +535,18 @@ pub(crate) mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub(crate) const COMMITTEE_CANDIDATES_ADDRESS: ConfigFieldDefinition<'static, String> =
-		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
-			path: &["cardano_addresses", "committee_candidates_address"],
-			name: "Committee candidates address",
-			default: None,
-			_marker: PhantomData,
-		};
+	pub(crate) const COMMITTEE_CANDIDATES_ADDRESS: ConfigFieldDefinition<
+		'static,
+		MainchainAddress,
+	> = ConfigFieldDefinition {
+		config_file: CHAIN_CONFIG_FILE_PATH,
+		path: &["cardano_addresses", "committee_candidates_address"],
+		name: "Committee candidates address",
+		default: None,
+		_marker: PhantomData,
+	};
 
-	pub(crate) const D_PARAMETER_POLICY_ID: ConfigFieldDefinition<'static, String> =
+	pub(crate) const D_PARAMETER_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "d_parameter_policy_id"],
@@ -553,7 +555,7 @@ pub(crate) mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub(crate) const PERMISSIONED_CANDIDATES_POLICY_ID: ConfigFieldDefinition<'static, String> =
+	pub(crate) const PERMISSIONED_CANDIDATES_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "permissioned_candidates_policy_id"],
@@ -562,16 +564,18 @@ pub(crate) mod config_fields {
 			_marker: PhantomData,
 		};
 
-	pub(crate) const GOVERNED_MAP_VALIDATOR_ADDRESS: ConfigFieldDefinition<'static, String> =
-		ConfigFieldDefinition {
-			config_file: CHAIN_CONFIG_FILE_PATH,
-			path: &["cardano_addresses", "governed_map", "validator_address"],
-			name: "Governed Map Validator Address",
-			default: None,
-			_marker: PhantomData,
-		};
+	pub(crate) const GOVERNED_MAP_VALIDATOR_ADDRESS: ConfigFieldDefinition<
+		'static,
+		MainchainAddress,
+	> = ConfigFieldDefinition {
+		config_file: CHAIN_CONFIG_FILE_PATH,
+		path: &["cardano_addresses", "governed_map", "validator_address"],
+		name: "Governed Map Validator Address",
+		default: None,
+		_marker: PhantomData,
+	};
 
-	pub(crate) const GOVERNED_MAP_POLICY_ID: ConfigFieldDefinition<'static, String> =
+	pub(crate) const GOVERNED_MAP_POLICY_ID: ConfigFieldDefinition<'static, PolicyId> =
 		ConfigFieldDefinition {
 			config_file: CHAIN_CONFIG_FILE_PATH,
 			path: &["cardano_addresses", "governed_map", "policy_id"],

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -232,18 +232,18 @@ fn chain_parameters_json() -> serde_json::Value {
 fn cardano_addresses_json() -> serde_json::Value {
 	serde_json::json!({
 		"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
-		"d_parameter_policy_id": "d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
-		"permissioned_candidates_policy_id": "58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+		"d_parameter_policy_id": "0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+		"permissioned_candidates_policy_id": "0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 		"native_token": {
 			"asset": {
-				"policy_id": "ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-				"asset_name": "5043546f6b656e44656d6f",
+				"policy_id": "0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+				"asset_name": "0x5043546f6b656e44656d6f",
 			},
 			"illiquid_supply_address": "addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz"
 		},
 		"governed_map": {
 			"validator_address": "addr_test1wqpjpjq08treyvmqjca0qy5kw8xgq4awgt945v46jsxgyhsafz4ws",
-			"policy_id": "c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000"
+			"policy_id": "0xc814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000"
 		}
 	})
 }
@@ -263,15 +263,15 @@ fn show_chain_parameters() -> MockIO {
 			"- committee_candidate_address: addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
 		),
 		MockIO::print(
-			"- d_parameter_policy_id: d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+			"- d_parameter_policy_id: 0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
 		),
 		MockIO::print(
-			"- permissioned_candidates_policy_id: 58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+			"- permissioned_candidates_policy_id: 0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 		),
 		MockIO::print("Native Token Management Configuration (unused if empty):"),
-		MockIO::print("- asset name: 5043546f6b656e44656d6f"),
+		MockIO::print("- asset name: 0x5043546f6b656e44656d6f"),
 		MockIO::print(
-			"- asset policy ID: ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+			"- asset policy ID: 0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 		),
 		MockIO::print(
 			"- illiquid supply address: addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz",
@@ -281,7 +281,7 @@ fn show_chain_parameters() -> MockIO {
 			"- validator address: addr_test1wqpjpjq08treyvmqjca0qy5kw8xgq4awgt945v46jsxgyhsafz4ws",
 		),
 		MockIO::print(
-			"- asset policy ID: c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000",
+			"- asset policy ID: 0xc814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000",
 		),
 	])
 }
@@ -310,17 +310,17 @@ fn set_env_vars_io() -> MockIO {
 		),
 		MockIO::set_env_var(
 			"D_PARAMETER_POLICY_ID",
-			"d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+			"0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
 		),
 		MockIO::set_env_var(
 			"PERMISSIONED_CANDIDATES_POLICY_ID",
-			"58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+			"0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 		),
 		MockIO::set_env_var(
 			"NATIVE_TOKEN_POLICY_ID",
-			"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+			"0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
 		),
-		MockIO::set_env_var("NATIVE_TOKEN_ASSET_NAME", "5043546f6b656e44656d6f"),
+		MockIO::set_env_var("NATIVE_TOKEN_ASSET_NAME", "0x5043546f6b656e44656d6f"),
 		MockIO::set_env_var(
 			"ILLIQUID_SUPPLY_VALIDATOR_ADDRESS",
 			"addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz",
@@ -394,7 +394,7 @@ fn updated_chain_spec() -> serde_json::Value {
 						"governedMap": {
 							"mainChainScripts": {
 								"asset_policy_id": "0xc814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000",
-								"validator_address": "0x616464725f74657374317771706a706a71303874726579766d716a6361307179356b773878677134617767743934357634366a73786779687361667a347773"
+								"validator_address": "addr_test1wqpjpjq08treyvmqjca0qy5kw8xgq4awgt945v46jsxgyhsafz4ws"
 							}
 						}
 					}

--- a/toolkit/partner-chains-cli/src/deregister/tests.rs
+++ b/toolkit/partner-chains-cli/src/deregister/tests.rs
@@ -170,12 +170,12 @@ fn test_chain_config_content() -> serde_json::Value {
 		},
 		"cardano_addresses": {
 			"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
-			"d_parameter_policy_id": "d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
-			"permissioned_candidates_policy_id": "58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+			"d_parameter_policy_id": "0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+			"permissioned_candidates_policy_id": "0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 			"native_token": {
 				"asset": {
-					"policy_id": "ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-					"asset_name": "5043546f6b656e44656d6f",
+					"policy_id": "0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+					"asset_name": "0x5043546f6b656e44656d6f",
 				},
 				"illiquid_supply_address": "addr_test1wrhvtvx3f0g9wv9rx8kfqc60jva3e07nqujk2cspekv4mqs9rjdvz"
 			},

--- a/toolkit/partner-chains-cli/src/permissioned_candidates.rs
+++ b/toolkit/partner-chains-cli/src/permissioned_candidates.rs
@@ -1,3 +1,4 @@
+use crate::cmd_traits::{GetPermissionedCandidates, UpsertPermissionedCandidates};
 use ogmios_client::query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId};
 use ogmios_client::query_network::QueryNetwork;
 use ogmios_client::transactions::Transactions;
@@ -14,8 +15,6 @@ use sp_core::crypto::AccountId32;
 use sp_core::{ecdsa, ed25519, sr25519};
 use sp_runtime::traits::IdentifyAccount;
 use std::fmt::{Display, Formatter};
-
-use crate::cmd_traits::{GetPermissionedCandidates, UpsertPermissionedCandidates};
 
 #[derive(Debug, Deserialize, Eq, PartialEq, PartialOrd, Ord, Serialize)]
 pub(crate) struct PermissionedCandidateKeys {
@@ -47,10 +46,14 @@ impl From<&sidechain_domain::PermissionedCandidateData> for PermissionedCandidat
 	}
 }
 
+/// Groups together keys of permissioned candidates. Expected to turn into a more generic type.
 #[derive(Debug, Deserialize, Eq, PartialEq, Ord, PartialOrd, Serialize)]
 pub(crate) struct ParsedPermissionedCandidatesKeys {
+	/// Polkadot identity of the permissioned candidate (aka. partner-chain key)
 	pub sidechain: ecdsa::Public,
+	/// AURA key of the permissioned candidate
 	pub aura: sr25519::Public,
+	/// Grandpa key of the permissioned candidate
 	pub grandpa: ed25519::Public,
 }
 

--- a/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
+++ b/toolkit/partner-chains-cli/src/prepare_configuration/prepare_main_chain_config.rs
@@ -7,7 +7,9 @@ use crate::config::config_fields::{
 };
 use crate::io::IOContext;
 use crate::prepare_configuration::prepare_cardano_params::prepare_cardano_params;
-use sidechain_domain::{PolicyId, UtxoId};
+use anyhow::anyhow;
+use sidechain_domain::{AssetName, MainchainAddress, PolicyId, UtxoId};
+use std::str::FromStr;
 
 pub fn prepare_main_chain_config<C: IOContext>(
 	context: &C,
@@ -37,13 +39,18 @@ fn set_up_cardano_addresses<C: IOContext>(
 		.block_on(offchain_impl.get_scripts_data(genesis_utxo))
 		.map_err(|e| anyhow::anyhow!("Offchain call failed: {e:?}!"))?;
 
-	let committee_candidate_validator_addr = scripts_data.addresses.committee_candidate_validator;
-	let d_parameter_policy_id = hex::encode(scripts_data.policy_ids.d_parameter.0);
-	let permissioned_candidates_policy_id =
-		hex::encode(scripts_data.policy_ids.permissioned_candidates.0);
-	let illiquid_supply_addr = scripts_data.addresses.illiquid_circulation_supply_validator;
-	let governed_map_validator_addr = scripts_data.addresses.governed_map_validator;
-	let governed_map_policy_id = hex::encode(scripts_data.policy_ids.governed_map.0);
+	let committee_candidate_validator_addr =
+		MainchainAddress::from_str(&scripts_data.addresses.committee_candidate_validator)
+			.map_err(|e| anyhow!("Internal error: invalid address '{e}' in scripts data"))?;
+	let d_parameter_policy_id = scripts_data.policy_ids.d_parameter;
+	let permissioned_candidates_policy_id = scripts_data.policy_ids.permissioned_candidates;
+	let illiquid_supply_addr =
+		MainchainAddress::from_str(&scripts_data.addresses.illiquid_circulation_supply_validator)
+			.map_err(|e| anyhow!("Internal error: invalid address '{e}' in scripts data"))?;
+	let governed_map_validator_addr =
+		MainchainAddress::from_str(&scripts_data.addresses.governed_map_validator)
+			.map_err(|e| anyhow!("Internal error: invalid address '{e}' in scripts data"))?;
+	let governed_map_policy_id = scripts_data.policy_ids.governed_map;
 	COMMITTEE_CANDIDATES_ADDRESS.save_to_file(&committee_candidate_validator_addr, context);
 	D_PARAMETER_POLICY_ID.save_to_file(&d_parameter_policy_id, context);
 	PERMISSIONED_CANDIDATES_POLICY_ID.save_to_file(&permissioned_candidates_policy_id, context);
@@ -69,11 +76,21 @@ fn prepare_native_token<C: IOContext>(context: &C) -> anyhow::Result<()> {
 	context.print("Creation of the native token is not supported by this wizard and must be performed manually before this step.");
 	if context.prompt_yes_no("Do you want to configure a native token for you Partner Chain?", true)
 	{
-		NATIVE_TOKEN_POLICY.prompt_with_default_from_file_and_save(context);
-		NATIVE_TOKEN_ASSET_NAME.prompt_with_default_from_file_and_save(context);
+		NATIVE_TOKEN_POLICY
+			.prompt_with_default_from_file_parse_and_save(context)
+			.map_err(|e| {
+				anyhow!(
+					"Could not parse PolicyId, expected hex string representing 28 bytes. Error: '{e}'."
+				)
+			})?;
+		NATIVE_TOKEN_ASSET_NAME
+			.prompt_with_default_from_file_parse_and_save(context)
+			.map_err(|e| {
+				anyhow!("Could not parse AssetName, expected valid hex string. Error: '{e}'")
+			})?;
 	} else {
-		NATIVE_TOKEN_POLICY.save_to_file(&PolicyId::default().to_hex_string(), context);
-		NATIVE_TOKEN_ASSET_NAME.save_to_file(&"0x".into(), context);
+		NATIVE_TOKEN_POLICY.save_to_file(&PolicyId::default(), context);
+		NATIVE_TOKEN_ASSET_NAME.save_to_file(&AssetName::empty(), context);
 	}
 
 	Ok(())
@@ -120,17 +137,17 @@ mod tests {
 	const TEST_GENESIS_UTXO: &str =
 		"0000000000000000000000000000000000000000000000000000000000000000#0";
 	const TEST_D_PARAMETER_POLICY_ID: &str =
-		"623cc9d41321674962b8599bf2baf0f34b8df8ad9d549f7ba3b1fdbb";
+		"0x623cc9d41321674962b8599bf2baf0f34b8df8ad9d549f7ba3b1fdbb";
 	const TEST_COMMITTEE_CANDIDATES_ADDRESS: &str =
 		"addr_test1wz5fe8fmxx4v83gzfsdlnhgxm8x7zpldegrqh2wakl3wteqe834r4";
 	const TEST_PERMISSIONED_CANDIDATES_POLICY_ID: &str =
-		"13db1ba564b3b264f45974fece44b2beb0a2326b10e65a0f7f300dfb";
+		"0x13db1ba564b3b264f45974fece44b2beb0a2326b10e65a0f7f300dfb";
 	const TEST_ILLIQUID_SUPPLY_ADDRESS: &str =
 		"addr_test1wqn2pkvvmesmxtfa4tz7w8gh8vumr52lpkrhcs4dkg30uqq77h5z4";
 	const TEST_GOVERNED_MAP_VALIDATOR_ADDRESS: &str =
 		"addr_test1wqcyptcm4ueft86vjnqng0k70gdazzukmyknuhmsjhmvfts7c0000";
 	const TEST_GOVERNED_MAP_POLICY_ID: &str =
-		"c814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000";
+		"0xc814db91bfaf7f0078e2c69d13443ffc46c9957393174f7baa8d0000";
 
 	fn ogmios_config() -> ServiceConfig {
 		ServiceConfig {
@@ -165,7 +182,7 @@ mod tests {
 				MockIO::prompt(
 					&format!("Enter the {}", NATIVE_TOKEN_ASSET_NAME.name),
 					None,
-					"5043546f6b656e44656d6f",
+					"0x5043546f6b656e44656d6f",
 				),
 			])
 		}
@@ -313,8 +330,8 @@ mod tests {
 				"native_token": {
 					"illiquid_supply_address": TEST_ILLIQUID_SUPPLY_ADDRESS,
 					"asset": {
-						"policy_id":"ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-						"asset_name":"5043546f6b656e44656d6f"
+						"policy_id":"0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+						"asset_name":"0x5043546f6b656e44656d6f"
 					}
 				}
 			},

--- a/toolkit/partner-chains-cli/src/register/register3.rs
+++ b/toolkit/partner-chains-cli/src/register/register3.rs
@@ -376,12 +376,12 @@ mod tests {
 			},
 			"cardano_addresses": {
 				"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
-				"d_parameter_policy_id": "d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
-				"permissioned_candidates_policy_id": "58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+				"d_parameter_policy_id": "0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+				"permissioned_candidates_policy_id": "0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 				"native_token": {
 					"asset": {
-						"policy_id": "ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-						"asset_name": "5043546f6b656e44656d6f",
+						"policy_id": "0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+						"asset_name": "0x5043546f6b656e44656d6f",
 					},
 					"illiquid_supply_address": "addr_test1wqn2pkvvmesmxtfa4tz7w8gh8vumr52lpkrhcs4dkg30uqq77h5z4"
 				},

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -343,12 +343,12 @@ fn test_chain_config_content() -> serde_json::Value {
 		},
 		"cardano_addresses": {
 			"committee_candidates_address": "addr_test1wz5qc7fk2pat0058w4zwvkw35ytptej3nuc3je2kgtan5dq3rt4sc",
-			"d_parameter_policy_id": "d0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
-			"permissioned_candidates_policy_id": "58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
+			"d_parameter_policy_id": "0xd0ebb61e2ba362255a7c4a253c6578884603b56fb0a68642657602d6",
+			"permissioned_candidates_policy_id": "0x58b4ba68f641d58f7f1bba07182eca9386da1e88a34d47a14638c3fe",
 			"native_token": {
 				"asset": {
-					"policy_id": "ada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
-					"asset_name": "5043546f6b656e44656d6f",
+					"policy_id": "0xada83ddd029614381f00e28de0922ab0dec6983ea9dd29ae20eef9b4",
+					"asset_name": "0x5043546f6b656e44656d6f",
 				},
 				"illiquid_supply_address": "addr_test1wqn2pkvvmesmxtfa4tz7w8gh8vumr52lpkrhcs4dkg30uqq77h5z4"
 			},

--- a/toolkit/sidechain/domain/src/lib.rs
+++ b/toolkit/sidechain/domain/src/lib.rs
@@ -320,6 +320,13 @@ const POLICY_ID_LEN: usize = 28;
 /// Cardano Policy Id
 pub struct PolicyId(pub [u8; POLICY_ID_LEN]);
 
+#[cfg(feature = "std")]
+impl Display for PolicyId {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.to_hex_string())
+	}
+}
+
 /// Cardano script hash
 pub type ScriptHash = PolicyId;
 
@@ -331,12 +338,20 @@ pub const MAX_ASSET_NAME_LEN: u32 = 32;
 	Clone, Default, PartialEq, Eq, Encode, Decode, DecodeWithMemTracking, TypeInfo, MaxEncodedLen,
 )]
 #[byte_string(debug, hex_serialize, hex_deserialize, decode_hex)]
+#[cfg_attr(feature = "std", byte_string(to_hex_string))]
 pub struct AssetName(pub BoundedVec<u8, ConstU32<MAX_ASSET_NAME_LEN>>);
 
 impl AssetName {
 	/// Constructs an empty [AssetName]
 	pub fn empty() -> Self {
 		Self(BoundedVec::new())
+	}
+}
+
+#[cfg(feature = "std")]
+impl Display for AssetName {
+	fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
+		write!(f, "{}", self.to_hex_string())
 	}
 }
 


### PR DESCRIPTION
# Description

Adds types to the chain config.
Preliminary work for creating chain spec from wizards, without calling `node-executable build-spec`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
