### PR TITLE
feat: require --chain to be explicitly specified

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -11,6 +11,7 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 * `MainchainAddress` is now serialized as plain String instead of hexstring of its bytes
 * Wizards use optional env vars: PC_CHAIN_CONFIG_FILE and PC_RESOURCES_CONFIG_FILE env variables to
 locate the chain config and resources config files
+* partner-chains-demo-node will now reject commands that build chain spec when no `--chain` is specified
 * `pallet-block-producer-metadata` is updated with a configurable fee for inserting the metadata, to make attacks on unbounded storage economically infeasible
 * Added `valid_before` argument to the signed message and all extrinsics in `pallet_block_producer_metadata`. This is to
 prevent unauthorized re-submission of metadata updates. The `sign-block-producer-metadata` command was updated to

--- a/demo/node/src/command/mod.rs
+++ b/demo/node/src/command/mod.rs
@@ -39,7 +39,11 @@ impl SubstrateCli for Cli {
 			"dev" => testnet::development_config(),
 			"staging" => staging::staging_config(),
 			"local" => testnet::local_testnet_config(),
-			"" => template_chain_spec::chain_spec(),
+			"template" => template_chain_spec::chain_spec(),
+			"" => {
+				return Err("Please provide --chain dev|staging|local|template|<path> parameter"
+					.to_string());
+			},
 			path => match chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path)) {
 				Ok(parsed) => Ok(parsed),
 				Err(err) => return Err(format!("Parsing chain spec file failed: {}", err)),

--- a/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
+++ b/dev/local-environment/configurations/partner-chains-setup/entrypoint.sh
@@ -192,7 +192,7 @@ else
 fi
 
 echo "Generating chain-spec.json file for Partner chain Nodes..."
-./partner-chains-node build-spec --disable-default-bootnode > chain-spec.json
+./partner-chains-node build-spec --chain template --disable-default-bootnode > chain-spec.json
 
 echo "Configuring Initial Validators..."
 jq '.genesis.runtimeGenesis.config.session.initialValidators = [

--- a/docs/user-guides/manual-setup.md
+++ b/docs/user-guides/manual-setup.md
@@ -123,7 +123,7 @@ export NATIVE_TOKEN_ASSET_NAME=''
 Native token policy and asset name are out of partner chains control, they should be known by the chain builder.
 For chains that do not intend to use them, it is assumed that `pc-node build-spec` will not need them.
 
-Run `pc-node build-spec --disable-default-bootnode > chain-spec.json`.
+Run `pc-node build-spec --chain template --disable-default-bootnode > chain-spec.json`.
 As stated above, the content of the file depends mostly on `pc-node`.
 
 Please consult our [intro doc chain-spec](../intro.md#chain-spec.json) section and update all the required fields, most notably:

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -121,9 +121,11 @@ impl<T: PartnerChainRuntime> CreateChainSpecCmd<T> {
 			&config.illiquid_supply_address.to_string(),
 		);
 		context.run_command(
-			format!("{node_executable} build-spec --disable-default-bootnode > chain-spec.json")
-				.to_string()
-				.as_str(),
+			format!(
+				"{node_executable} build-spec --chain template --disable-default-bootnode > chain-spec.json"
+			)
+			.to_string()
+			.as_str(),
 		)
 	}
 

--- a/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/tests.rs
@@ -332,7 +332,7 @@ fn run_build_spec_io(output: Result<String, anyhow::Error>) -> MockIO {
 		set_env_vars_io(),
 		MockIO::RunCommand {
 			expected_cmd:
-				"<mock executable> build-spec --disable-default-bootnode > chain-spec.json"
+				"<mock executable> build-spec --chain template --disable-default-bootnode > chain-spec.json"
 					.to_string(),
 			output,
 		},


### PR DESCRIPTION
# Description

Removes using "template" chain spec when "--chain" is missing. Requires "--chain" for commands that create a chain-spec.

Ref: ETCM-9631

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [x] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
