### PR TITLE
change: Usability improvements

### DIFF
--- a/demo/node/src/data_sources.rs
+++ b/demo/node/src/data_sources.rs
@@ -1,4 +1,4 @@
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
+use authority_selection_inherents::AuthoritySelectionDataSource;
 use pallet_sidechain_rpc::SidechainRpcDataSource;
 use partner_chains_db_sync_data_sources::{
 	BlockDataSourceImpl, CandidatesDataSourceImpl, GovernedMapDataSourceCachedImpl,

--- a/demo/node/src/inherent_data.rs
+++ b/demo/node/src/inherent_data.rs
@@ -1,7 +1,6 @@
-use authority_selection_inherents::CommitteeMember;
-use authority_selection_inherents::ariadne_inherent_data_provider::AriadneInherentDataProvider as AriadneIDP;
-use authority_selection_inherents::authority_selection_inputs::{
-	AuthoritySelectionDataSource, AuthoritySelectionInputs,
+use authority_selection_inherents::{
+	AriadneInherentDataProvider as AriadneIDP, AuthoritySelectionDataSource,
+	AuthoritySelectionInputs, CommitteeMember,
 };
 use derive_new::new;
 use jsonrpsee::core::async_trait;

--- a/demo/node/src/rpc.rs
+++ b/demo/node/src/rpc.rs
@@ -6,9 +6,8 @@
 #![warn(missing_docs)]
 
 use crate::data_sources::DataSources;
-use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
 use authority_selection_inherents::{
-	CommitteeMember, authority_selection_inputs::AuthoritySelectionInputs,
+	AuthoritySelectionInputs, CandidateValidationApi, CommitteeMember,
 };
 use jsonrpsee::RpcModule;
 use pallet_block_producer_fees_rpc::*;

--- a/demo/node/src/service.rs
+++ b/demo/node/src/service.rs
@@ -3,7 +3,7 @@
 use crate::data_sources::DataSources;
 use crate::inherent_data::{CreateInherentDataConfig, ProposalCIDP, VerifierCIDP};
 use crate::rpc::GrandpaDeps;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
+use authority_selection_inherents::AuthoritySelectionDataSource;
 use partner_chains_db_sync_data_sources::McFollowerMetrics;
 use partner_chains_db_sync_data_sources::register_metrics_warn_errors;
 use partner_chains_demo_runtime::{self, RuntimeApi, opaque::Block};

--- a/demo/node/src/tests/inherent_data_tests.rs
+++ b/demo/node/src/tests/inherent_data_tests.rs
@@ -3,7 +3,7 @@ use crate::tests::mock::{test_client, test_create_inherent_data_config};
 use crate::tests::runtime_api_mock;
 use crate::tests::runtime_api_mock::{TestApi, mock_header};
 use authority_selection_inherents::{
-	authority_selection_inputs::AuthoritySelectionInputs, mock::MockAuthoritySelectionDataSource,
+	AuthoritySelectionInputs, mock::MockAuthoritySelectionDataSource,
 };
 use hex_literal::hex;
 use partner_chains_demo_runtime::BlockAuthor;

--- a/demo/node/src/tests/runtime_api_mock.rs
+++ b/demo/node/src/tests/runtime_api_mock.rs
@@ -1,6 +1,5 @@
 use super::mock::mock_genesis_utxo;
-use authority_selection_inherents::CommitteeMember;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
+use authority_selection_inherents::{AuthoritySelectionInputs, CommitteeMember};
 use hex_literal::hex;
 use partner_chains_demo_runtime::opaque::SessionKeys;
 use partner_chains_demo_runtime::{BlockAuthor, CrossChainPublic};

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -403,12 +403,7 @@ impl pallet_session_validator_management::Config for Runtime {
 		input: AuthoritySelectionInputs,
 		sidechain_epoch: ScEpochNumber,
 	) -> Option<BoundedVec<Self::CommitteeMember, Self::MaxValidators>> {
-		Some(BoundedVec::truncate_from(
-			select_authorities(Sidechain::genesis_utxo(), input, sidechain_epoch)?
-				.into_iter()
-				.map(|member| member.into())
-				.collect(),
-		))
+		select_authorities(Sidechain::genesis_utxo(), input, sidechain_epoch)
 	}
 
 	fn current_epoch_number() -> ScEpochNumber {

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -11,13 +11,15 @@ extern crate alloc;
 
 use alloc::collections::BTreeMap;
 use alloc::string::String;
-use authority_selection_inherents::CommitteeMember;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
-use authority_selection_inherents::filter_invalid_candidates::{
-	PermissionedCandidateDataError, RegistrationDataError, StakeError,
-	validate_permissioned_candidate_data,
+use authority_selection_inherents::{
+	CommitteeMember,
+	authority_selection_inputs::AuthoritySelectionInputs,
+	filter_invalid_candidates::{
+		PermissionedCandidateDataError, RegistrationDataError, StakeError,
+		validate_permissioned_candidate_data,
+	},
+	select_authorities,
 };
-use authority_selection_inherents::select_authorities::select_authorities;
 use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
 use frame_support::weights::constants::RocksDbWeight as RuntimeDbWeight;

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -12,13 +12,8 @@ extern crate alloc;
 use alloc::collections::BTreeMap;
 use alloc::string::String;
 use authority_selection_inherents::{
-	CommitteeMember,
-	authority_selection_inputs::AuthoritySelectionInputs,
-	filter_invalid_candidates::{
-		PermissionedCandidateDataError, RegistrationDataError, StakeError,
-		validate_permissioned_candidate_data,
-	},
-	select_authorities,
+	AuthoritySelectionInputs, CommitteeMember, PermissionedCandidateDataError,
+	RegistrationDataError, StakeError, select_authorities, validate_permissioned_candidate_data,
 };
 use frame_support::genesis_builder_helper::{build_state, get_preset};
 use frame_support::inherent::ProvideInherent;
@@ -1068,12 +1063,12 @@ impl_runtime_apis! {
 		}
 	}
 
-	impl authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi<Block> for Runtime {
+	impl authority_selection_inherents::CandidateValidationApi<Block> for Runtime {
 		fn validate_registered_candidate_data(stake_pool_public_key: &StakePoolPublicKey, registration_data: &RegistrationData) -> Option<RegistrationDataError> {
-			authority_selection_inherents::filter_invalid_candidates::validate_registration_data(stake_pool_public_key, registration_data, Sidechain::genesis_utxo()).err()
+			authority_selection_inherents::validate_registration_data(stake_pool_public_key, registration_data, Sidechain::genesis_utxo()).err()
 		}
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError> {
-			authority_selection_inherents::filter_invalid_candidates::validate_stake(stake).err()
+			authority_selection_inherents::validate_stake(stake).err()
 		}
 		fn validate_permissioned_candidate_data(candidate: PermissionedCandidateData) -> Option<PermissionedCandidateDataError> {
 			validate_permissioned_candidate_data(candidate).err()

--- a/demo/runtime/src/mock.rs
+++ b/demo/runtime/src/mock.rs
@@ -1,7 +1,6 @@
-use authority_selection_inherents::ariadne_inherent_data_provider::AriadneInherentDataProvider;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
-use authority_selection_inherents::filter_invalid_candidates::{
-	RegisterValidatorSignedMessage, filter_trustless_candidates_registrations,
+use authority_selection_inherents::{
+	AriadneInherentDataProvider, AuthoritySelectionInputs, RegisterValidatorSignedMessage,
+	filter_trustless_candidates_registrations,
 };
 use frame_support::{
 	Hashable,

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -2,9 +2,8 @@
 //! and a [run] function for running these commands.
 //! [PartnerChainsSubcommand] is meant to be used by a command line argument parser library.
 #![deny(missing_docs)]
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionInputs;
 use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
+use authority_selection_inherents::{AuthoritySelectionDataSource, AuthoritySelectionInputs};
 use clap::Parser;
 use cli_commands::address_association_signatures::AddressAssociationSignaturesCmd;
 use cli_commands::block_producer_metadata_signatures::BlockProducerMetadataSignatureCmd;

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -2,8 +2,9 @@
 //! and a [run] function for running these commands.
 //! [PartnerChainsSubcommand] is meant to be used by a command line argument parser library.
 #![deny(missing_docs)]
-use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
-use authority_selection_inherents::{AuthoritySelectionDataSource, AuthoritySelectionInputs};
+use authority_selection_inherents::{
+	AuthoritySelectionDataSource, AuthoritySelectionInputs, CandidateValidationApi,
+};
 use clap::Parser;
 use cli_commands::address_association_signatures::AddressAssociationSignaturesCmd;
 use cli_commands::block_producer_metadata_signatures::BlockProducerMetadataSignatureCmd;

--- a/toolkit/committee-selection/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
@@ -6,9 +6,8 @@ use parity_scale_codec::{Decode, Encode};
 #[cfg(feature = "std")]
 use {
 	crate::authority_selection_inputs::AuthoritySelectionInputsCreationError,
-	sidechain_domain::mainchain_epoch::{MainchainEpochConfig, MainchainEpochDerivation},
+	sidechain_domain::mainchain_epoch::MainchainEpochDerivation,
 	sidechain_domain::*,
-	sidechain_slots::ScSlotConfig,
 	sp_api::ProvideRuntimeApi,
 	sp_consensus_slots::Slot,
 	sp_inherents::{InherentData, InherentIdentifier},
@@ -18,6 +17,9 @@ use {
 		INHERENT_IDENTIFIER, InherentError, MainChainScripts, SessionValidatorManagementApi,
 	},
 };
+
+#[cfg(feature = "std")]
+pub use {sidechain_domain::mainchain_epoch::MainchainEpochConfig, sidechain_slots::ScSlotConfig};
 
 /// Inherent data type provided by [AriadneInherentDataProvider].
 pub type InherentType = AuthoritySelectionInputs;

--- a/toolkit/committee-selection/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/ariadne_inherent_data_provider.rs
@@ -21,9 +21,6 @@ use {
 #[cfg(feature = "std")]
 pub use {sidechain_domain::mainchain_epoch::MainchainEpochConfig, sidechain_slots::ScSlotConfig};
 
-/// Inherent data type provided by [AriadneInherentDataProvider].
-pub type InherentType = AuthoritySelectionInputs;
-
 #[derive(Clone, Debug, Encode, Decode)]
 /// Inherent data provider providing inputs for authority selection.
 pub struct AriadneInherentDataProvider {

--- a/toolkit/committee-selection/authority-selection-inherents/src/authority_selection_inputs.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/authority_selection_inputs.rs
@@ -4,6 +4,7 @@ use plutus::*;
 use scale_info::TypeInfo;
 use sidechain_domain::*;
 
+/// Inherent data type provided by [AriadneInherentDataProvider].
 /// The part of data for selection of authorities that comes from the main chain.
 /// It is unfiltered, so the selection algorithm should filter out invalid candidates.
 #[derive(Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq)]

--- a/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
@@ -13,7 +13,14 @@ use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
 pub mod ariadne_inherent_data_provider;
 pub mod authority_selection_inputs;
 pub mod filter_invalid_candidates;
-pub mod select_authorities;
+mod select_authorities;
+
+#[cfg(feature = "std")]
+pub use authority_selection_inputs::AuthoritySelectionDataSource;
+pub use {
+	ariadne_inherent_data_provider::AriadneInherentDataProvider,
+	authority_selection_inputs::AuthoritySelectionInputs, select_authorities::select_authorities,
+};
 
 #[cfg(test)]
 mod runtime_api_mock;

--- a/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
@@ -10,16 +10,26 @@ use sidechain_domain::StakePoolPublicKey;
 use sp_core::{Decode, DecodeWithMemTracking, Encode, MaxEncodedLen};
 use sp_session_validator_management::CommitteeMember as CommitteeMemberT;
 
-pub mod ariadne_inherent_data_provider;
-pub mod authority_selection_inputs;
-pub mod filter_invalid_candidates;
+mod ariadne_inherent_data_provider;
+mod authority_selection_inputs;
+mod filter_invalid_candidates;
 mod select_authorities;
 
-#[cfg(feature = "std")]
-pub use authority_selection_inputs::AuthoritySelectionDataSource;
 pub use {
 	ariadne_inherent_data_provider::AriadneInherentDataProvider,
-	authority_selection_inputs::AuthoritySelectionInputs, select_authorities::select_authorities,
+	authority_selection_inputs::{AriadneParameters, AuthoritySelectionInputs},
+	filter_invalid_candidates::{
+		PermissionedCandidateDataError, RegisterValidatorSignedMessage, RegistrationDataError,
+		StakeError, filter_trustless_candidates_registrations,
+		runtime_decl_for_candidate_validation_api, validate_permissioned_candidate_data,
+		validate_registration_data, validate_stake,
+	},
+	select_authorities::select_authorities,
+};
+#[cfg(feature = "std")]
+pub use {
+	authority_selection_inputs::AuthoritySelectionDataSource,
+	filter_invalid_candidates::CandidateValidationApi,
 };
 
 #[cfg(test)]

--- a/toolkit/committee-selection/pallet/Cargo.toml
+++ b/toolkit/committee-selection/pallet/Cargo.toml
@@ -24,7 +24,7 @@ frame-system = { workspace = true }
 sp-std = { workspace = true }
 sp-runtime = { workspace = true }
 sp-core = { workspace = true }
-sp-session-validator-management = { workspace = true }
+sp-session-validator-management = { workspace = true, features = ["serde"] }
 sp-io = { workspace = true, optional = true }
 sidechain-domain = { workspace = true }
 derive-new = { workspace = true, optional = true }

--- a/toolkit/committee-selection/pallet/src/session_manager.rs
+++ b/toolkit/committee-selection/pallet/src/session_manager.rs
@@ -40,8 +40,6 @@
 //! );
 //! ```
 
-#![cfg_attr(not(feature = "std"), no_std)]
-
 use crate::CommitteeMember;
 use core::marker::PhantomData;
 use derive_new::new;

--- a/toolkit/committee-selection/primitives/Cargo.toml
+++ b/toolkit/committee-selection/primitives/Cargo.toml
@@ -35,9 +35,8 @@ std = [
     "sp-std/std",
     "sp-runtime/std",
     "sidechain-domain/std",
-    "sidechain-domain/serde",
-    "thiserror",
-    "envy",
+    "dep:thiserror",
+    "dep:envy",
     "serde"
 ]
 serde = [

--- a/toolkit/committee-selection/query/src/get_registrations.rs
+++ b/toolkit/committee-selection/query/src/get_registrations.rs
@@ -1,9 +1,6 @@
 //! Module implementing getting candidate registrations for epoch
 use crate::*;
-use authority_selection_inherents::filter_invalid_candidates::RegistrationDataError;
-use authority_selection_inherents::filter_invalid_candidates::{
-	CandidateValidationApi, StakeError,
-};
+use authority_selection_inherents::{CandidateValidationApi, RegistrationDataError, StakeError};
 use sidechain_domain::{
 	CandidateRegistrations, MainchainAddress, McEpochNumber, RegistrationData, StakeDelegation,
 };

--- a/toolkit/committee-selection/query/src/lib.rs
+++ b/toolkit/committee-selection/query/src/lib.rs
@@ -5,10 +5,9 @@ pub mod get_registrations;
 pub mod types;
 
 use async_trait::async_trait;
-use authority_selection_inherents::authority_selection_inputs::{
-	AuthoritySelectionDataSource, AuthoritySelectionInputs,
+use authority_selection_inherents::{
+	AuthoritySelectionDataSource, AuthoritySelectionInputs, CandidateValidationApi,
 };
-use authority_selection_inherents::filter_invalid_candidates::CandidateValidationApi;
 use derive_new::new;
 use parity_scale_codec::{Decode, Encode};
 use sidechain_block_search::{FindSidechainBlock, SidechainInfo, predicates::AnyBlockInEpoch};

--- a/toolkit/committee-selection/query/src/tests/mock.rs
+++ b/toolkit/committee-selection/query/src/tests/mock.rs
@@ -1,4 +1,4 @@
-use authority_selection_inherents::filter_invalid_candidates::RegisterValidatorSignedMessage;
+use authority_selection_inherents::RegisterValidatorSignedMessage;
 use plutus::ToDatum;
 use sidechain_domain::*;
 use sp_core::{Pair, ecdsa, ed25519};

--- a/toolkit/committee-selection/query/src/tests/mod.rs
+++ b/toolkit/committee-selection/query/src/tests/mod.rs
@@ -108,7 +108,7 @@ async fn get_epoch_committee_should_work_correctly_for_next_epoch() {
 mod get_registration_tests {
 	use super::*;
 	use crate::types::PermissionedCandidateData;
-	use authority_selection_inherents::filter_invalid_candidates::{
+	use authority_selection_inherents::{
 		PermissionedCandidateDataError, RegistrationDataError, StakeError,
 	};
 	use sidechain_domain::byte_string::ByteString;

--- a/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
+++ b/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::tests::query_mock::TestRuntimeApi;
-use authority_selection_inherents::filter_invalid_candidates::{
+use authority_selection_inherents::{
 	PermissionedCandidateDataError, RegistrationDataError, StakeError,
 	validate_permissioned_candidate_data, validate_registration_data,
 };
@@ -86,7 +86,7 @@ sp_api::mock_impl_runtime_apis! {
 			validate_registration_data(mainchain_pub_key, registration_data, TEST_UTXO_ID).err()
 		}
 		fn validate_stake(stake: Option<StakeDelegation>) -> Option<StakeError> {
-			authority_selection_inherents::filter_invalid_candidates::validate_stake(stake).err()
+			authority_selection_inherents::validate_stake(stake).err()
 		}
 		fn validate_permissioned_candidate_data(candidate: sidechain_domain::PermissionedCandidateData) -> Option<PermissionedCandidateDataError> {
 			validate_permissioned_candidate_data(candidate).err()

--- a/toolkit/committee-selection/query/src/types/ariadne.rs
+++ b/toolkit/committee-selection/query/src/types/ariadne.rs
@@ -1,5 +1,5 @@
 use crate::types::{GetRegistrationsResponseMap, keys_to_map};
-use authority_selection_inherents::filter_invalid_candidates::PermissionedCandidateDataError;
+use authority_selection_inherents::PermissionedCandidateDataError;
 use serde::{Deserialize, Serialize};
 use sidechain_domain::{SidechainPublicKey, byte_string::ByteString};
 use std::collections::HashMap;

--- a/toolkit/committee-selection/query/src/types/registrations.rs
+++ b/toolkit/committee-selection/query/src/types/registrations.rs
@@ -1,7 +1,7 @@
 //! Types for Candidates Registrations returned by RPC endpoints
 
 use crate::types::keys_to_map;
-use authority_selection_inherents::filter_invalid_candidates::{RegistrationDataError, StakeError};
+use authority_selection_inherents::{RegistrationDataError, StakeError};
 use parity_scale_codec::Decode;
 use serde::{Deserialize, Serialize};
 use sidechain_domain::{

--- a/toolkit/data-sources/cli/src/main.rs
+++ b/toolkit/data-sources/cli/src/main.rs
@@ -5,7 +5,7 @@
 //! `follower_commands` macro is used to generate [clap] commands.
 //! Command level doc comments are supported, but parameter level doc comments are not supported.
 
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
+use authority_selection_inherents::AuthoritySelectionDataSource;
 use clap::Parser;
 use partner_chains_db_sync_data_sources::{BlockDataSourceImpl, CandidatesDataSourceImpl, PgPool};
 use sidechain_domain::*;

--- a/toolkit/data-sources/db-sync/src/candidates/cached.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/cached.rs
@@ -5,7 +5,7 @@
 
 use crate::candidates::CandidatesDataSourceImpl;
 use async_trait::async_trait;
-use authority_selection_inherents::authority_selection_inputs::*;
+use authority_selection_inherents::*;
 use figment::{Figment, providers::Env};
 use log::info;
 use lru::LruCache;

--- a/toolkit/data-sources/db-sync/src/candidates/mod.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/mod.rs
@@ -5,7 +5,7 @@ use crate::db_model::{
 };
 use crate::metrics::McFollowerMetrics;
 use crate::observed_async_trait;
-use authority_selection_inherents::authority_selection_inputs::*;
+use authority_selection_inherents::*;
 use itertools::Itertools;
 use log::error;
 use partner_chains_plutus_data::{

--- a/toolkit/data-sources/db-sync/src/candidates/tests.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/tests.rs
@@ -1,7 +1,7 @@
 use crate::candidates::CandidatesDataSourceImpl;
 use crate::db_model::index_exists_unsafe;
 use crate::metrics::mock::test_metrics;
-use authority_selection_inherents::authority_selection_inputs::AuthoritySelectionDataSource;
+use authority_selection_inherents::AuthoritySelectionDataSource;
 use hex_literal::hex;
 use sidechain_domain::*;
 use sqlx::PgPool;

--- a/toolkit/data-sources/mock/src/candidate.rs
+++ b/toolkit/data-sources/mock/src/candidate.rs
@@ -1,6 +1,6 @@
 use crate::Result;
 use async_trait::async_trait;
-use authority_selection_inherents::authority_selection_inputs::*;
+use authority_selection_inherents::*;
 use hex_literal::hex;
 use log::{debug, info};
 use serde::*;


### PR DESCRIPTION
# Description

Minor usability improvements after adding Partner Chain features to a fresh Substrate solochain template:
- fixed passing of some feature flags
- made `select_authorities` cast `Candidate`s to `CommitteeMember` and collect to `BoundedVec`, so there's no logic to implement in node
- re-export some external types from crates that use them
- export all public objects in `authority-selection-inherents` from the root of the crate for simplicity. this also reveals that we're exporting some stuff that probably should be internal (all `validate_*` and `filter_*` functions which we're using in mocks in other crates or to define runtime APIs which should be possible to implement in other ways instead)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
