### PR TITLE
[DO NOT MERGE] ETCM-9835 tx out consumed query

### DIFF
--- a/dev/local-environment/configurations/db-sync/config.json
+++ b/dev/local-environment/configurations/db-sync/config.json
@@ -1,4 +1,9 @@
 {
+  "insert_options": {
+    "tx_output": {
+      "value": "consumed"
+    }
+  },
   "EnableLogMetrics": false,
   "EnableLogging": true,
   "NetworkName": "Testnet",

--- a/toolkit/data-sources/db-sync/testdata/governed-map/migrations/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/governed-map/migrations/1_create_schema.sql
@@ -140,15 +140,6 @@ CREATE INDEX redeemer_data_tx_id_idx ON public.redeemer_data USING btree (tx_id)
 
 ALTER TABLE public.redeemer_data ADD CONSTRAINT redeemer_data_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
-CREATE TABLE tx_in (
-    id bigint NOT NULL,
-    tx_in_id bigint NOT NULL,
-    tx_out_id bigint NOT NULL,
-    tx_out_index txindex NOT NULL,
-    redeemer_id bigint,
-    CONSTRAINT tx_in_pkey PRIMARY KEY (id)
-);
-
 CREATE TABLE tx_out (
     id bigint NOT NULL,
     tx_id bigint NOT NULL,
@@ -160,8 +151,10 @@ CREATE TABLE tx_out (
     stake_address_id bigint,
     value lovelace NOT NULL,
     data_hash hash32type,
+    consumed_by_tx_id bigint,
     comment varchar
 );
+ALTER TABLE tx_out ADD CONSTRAINT consumed_by_tx_id_fkey FOREIGN KEY (consumed_by_tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 CREATE TABLE redeemer (
     id bigint PRIMARY KEY,

--- a/toolkit/data-sources/db-sync/testdata/governed-map/migrations/2_data.sql
+++ b/toolkit/data-sources/db-sync/testdata/governed-map/migrations/2_data.sql
@@ -92,17 +92,17 @@ INSERT INTO tx ( id         , hash   , block_id, block_index, out_sum, fee, depo
               ,( ups_tx_id  , thash_6, 7       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
 ;
 
-INSERT INTO tx_out ( id   , tx_id      , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash, comment          )
-            VALUES ( 0    , cons_tx_id , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
-                  ,( 1    , cons_tx_id , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
-                  ,( 2    , cons_tx_id , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             )
-                  ,( 3    , ins_tx_ida , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_1  , 'add key2'       )
-                  ,( 4    , ins_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_2  , 'add key1'       )
-                  ,( 5    , ins_tx_id  , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_3  , 'add invalid'    )
-                  ,( 7    , ins_tx_id  , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_4  , 'duplicate key2' )
-                  ,( 8    , del_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , 'delete key1'    )
-                  ,( 9    , ins_tx_id2 , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_5  , 'add key3'       )
-                  ,( 10   , ups_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_6  , 'upsert key3'    )
+INSERT INTO tx_out ( id   , tx_id      , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash, consumed_by_tx_id, comment          )
+            VALUES ( 0    , cons_tx_id , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , ins_tx_id        , NULL             )
+                  ,( 1    , cons_tx_id , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , ins_tx_id        , NULL             )
+                  ,( 2    , cons_tx_id , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             , NULL             )
+                  ,( 3    , ins_tx_ida , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_1  , NULL             , 'add key2'       )
+                  ,( 4    , ins_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_2  , del_tx_id        , 'add key1'       )
+                  ,( 5    , ins_tx_id  , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_3  , del_tx_id        , 'add invalid'    )
+                  ,( 7    , ins_tx_id  , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_4  , NULL             , 'duplicate key2' )
+                  ,( 8    , del_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , NULL             , 'delete key1'    )
+                  ,( 9    , ins_tx_id2 , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_5  , ups_tx_id        , 'add key3'       )
+                  ,( 10   , ups_tx_id  , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , dhash_6  , NULL             , 'upsert key3'    )
 ;
 
 INSERT INTO ma_tx_out ( id   , quantity , tx_out_id , ident)
@@ -113,15 +113,6 @@ VALUES                ( 0    , 1        , 3         , 999  )
                      ,( 4    , 1        , 8         , 999  )
                      ,( 5    , 1        , 9         , 999  )
                      ,( 6    , 1        , 10        , 999  )
-;
-
-INSERT INTO tx_in ( id, tx_in_id   , tx_out_id  , tx_out_index, redeemer_id )
-           VALUES ( 0 , ins_tx_id  , cons_tx_id , 0           , NULL        )
-                 ,( 1 , ins_tx_id  , cons_tx_id , 1           , NULL        )
-                 ,( 2 , ins_tx_id2 , cons_tx_id , 0           , NULL        )
-                 ,( 4 , del_tx_id  , ins_tx_id  , 0           , NULL        )
-                 ,( 5 , del_tx_id  , ins_tx_id  , 1           , NULL        )
-                 ,( 6 , ups_tx_id  , ins_tx_id2 , 0           , NULL        )
 ;
 
 INSERT INTO datum ( id   , hash    , tx_id     , value                )

--- a/toolkit/data-sources/db-sync/testdata/migrations/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/migrations/1_create_schema.sql
@@ -140,15 +140,6 @@ CREATE INDEX redeemer_data_tx_id_idx ON public.redeemer_data USING btree (tx_id)
 
 ALTER TABLE public.redeemer_data ADD CONSTRAINT redeemer_data_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
-CREATE TABLE tx_in (
-    id bigint NOT NULL,
-    tx_in_id bigint NOT NULL,
-    tx_out_id bigint NOT NULL,
-    tx_out_index txindex NOT NULL,
-    redeemer_id bigint,
-    CONSTRAINT tx_in_pkey PRIMARY KEY (id)
-);
-
 CREATE TABLE tx_out (
     id bigint NOT NULL,
     tx_id bigint NOT NULL,
@@ -159,8 +150,10 @@ CREATE TABLE tx_out (
     payment_cred hash28type,
     stake_address_id bigint,
     value lovelace NOT NULL,
-    data_hash hash32type
+    data_hash hash32type,
+    consumed_by_tx_id bigint
 );
+ALTER TABLE tx_out ADD CONSTRAINT consumed_by_tx_id_fkey FOREIGN KEY (consumed_by_tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 CREATE TABLE redeemer (
     id bigint PRIMARY KEY,

--- a/toolkit/data-sources/db-sync/testdata/migrations/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/migrations/6_insert_transactions.sql
@@ -161,16 +161,16 @@ INSERT INTO tx ( id            , hash            , block_id, block_index, out_su
 
 -- the transaction reg_tx_id has 2 outputs
 -- the second output (index 1) is consumed by dereg_tx_id
-INSERT INTO tx_out ( id, tx_id           , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash )
-            VALUES ( 0 , consumed_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 1 , consumed_tx_id  , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 2 , consumed_tx_id  , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL      )
-                  ,( 4 , reg_tx_id       , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash1     ) -- good registration
-                  ,( 5 , reg_tx_id       , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash2     ) -- wrong format
-                  ,( 6 , reg_tx_id       , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash3     ) -- formatted properly but not an spo
-                  ,( 7 , dereg_tx_id     , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , hash1     )
-                  ,( 8 , reg_tx_id2      , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash5     )
-                  ,( 9 , reg_tx_id2      , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash6     ) -- formatted properly but did not consumed advertisedhash
+INSERT INTO tx_out ( id, tx_id           , index, address     , address_raw, address_has_script, payment_cred, stake_address_id, value, data_hash, consumed_by_tx_id )
+            VALUES ( 0 , consumed_tx_id  , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , reg_tx_id         )
+                  ,( 1 , consumed_tx_id  , 1    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , reg_tx_id         )
+                  ,( 2 , consumed_tx_id  , 2    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , NULL     , reg_tx_id2        )
+                  ,( 4 , reg_tx_id       , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash1    , dereg_tx_id       ) -- good registration
+                  ,( 5 , reg_tx_id       , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash2    , dereg_tx_id       ) -- wrong format
+                  ,( 6 , reg_tx_id       , 2    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash3    , NULL              ) -- formatted properly but not an spo
+                  ,( 7 , dereg_tx_id     , 0    , 'other_addr', ''         , TRUE              , NULL        , NULL            , 0    , hash1    , NULL              )
+                  ,( 8 , reg_tx_id2      , 0    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash5    , NULL              )
+                  ,( 9 , reg_tx_id2      , 1    , script_addr , ''         , TRUE              , NULL        , NULL            , 0    , hash6    , NULL              ) -- formatted properly but did not consumed advertisedhash
 ;
 
 INSERT INTO datum ( id, hash , tx_id     , value                                            )
@@ -181,13 +181,6 @@ INSERT INTO datum ( id, hash , tx_id     , value                                
                  ,( 5 , hash6, reg_tx_id2, registration3                                    )
 ;
 
-INSERT INTO tx_in ( id, tx_in_id   , tx_out_id, tx_out_index, redeemer_id )
-           VALUES ( 0 , reg_tx_id  , consumed_tx_id, 0      , NULL   )
-                 ,( 1 , reg_tx_id  , consumed_tx_id, 1      , NULL   )
-                 ,( 2 , reg_tx_id2 , consumed_tx_id, 2      , NULL   )
-                 ,( 4 , dereg_tx_id, reg_tx_id     , 0      , NULL   )
-                 ,( 5 , dereg_tx_id, reg_tx_id     , 1      , NULL   )
-;
 END $$;
 
 -- Insert D-parameter

--- a/toolkit/data-sources/db-sync/testdata/native-token/migrations/1_create_schema.sql
+++ b/toolkit/data-sources/db-sync/testdata/native-token/migrations/1_create_schema.sql
@@ -139,15 +139,6 @@ CREATE INDEX redeemer_data_tx_id_idx ON public.redeemer_data USING btree (tx_id)
 
 ALTER TABLE public.redeemer_data ADD CONSTRAINT redeemer_data_tx_id_fkey FOREIGN KEY (tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
-CREATE TABLE tx_in (
-    id bigint NOT NULL,
-    tx_in_id bigint NOT NULL,
-    tx_out_id bigint NOT NULL,
-    tx_out_index txindex NOT NULL,
-    redeemer_id bigint,
-    CONSTRAINT tx_in_pkey PRIMARY KEY (id)
-);
-
 CREATE TABLE tx_out (
     id bigint NOT NULL,
     tx_id bigint NOT NULL,
@@ -158,8 +149,10 @@ CREATE TABLE tx_out (
     payment_cred hash28type,
     stake_address_id bigint,
     value lovelace NOT NULL,
-    data_hash hash32type
+    data_hash hash32type,
+    consumed_by_tx_id bigint
 );
+ALTER TABLE tx_out ADD CONSTRAINT consumed_by_tx_id_fkey FOREIGN KEY (consumed_by_tx_id) REFERENCES tx(id) ON DELETE CASCADE ON UPDATE RESTRICT;
 
 CREATE TABLE redeemer (
     id bigint PRIMARY KEY,


### PR DESCRIPTION
# Description

Showcase of changes to the queries required to make use of the `tx_out.value = "consumed"` option in db-sync configuration. When this option is set:
1. the `tx_out` table has an additional column `consumed_by_tx_id` which references the transaction in `tx` table that consumed given output
2. the `tx_in` does not exist
In practice this means we can use a single join between `tx` and `tx_out` when we need to determine inputs to a transaction instead of two joins going through `tx_in`, which also makes the queries easier to understand.

### Next steps

If we decide to support this option, I see three ways to go about it:
1. update the queries and strictly require db-sync to be configured with `tx_out.value = "consumed"`
2. preserve the old queries, supporting both old and new configurations, and either:
    a. let the user control which queries are run by some `TX_OUT_STYLE` environment variable
    b. automatically detect the setting by checking for existence of `tx_in`

I lean towards option 1

### Testing

I run two nodes compiled from this branch and `master` and they synced each other's blocks without issues.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
