### PR TITLE
change: Remove OpaqueKeys restriction from MaybeFromCandidateKeys

### DIFF
--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -98,7 +98,7 @@ pub type Hash = sp_core::H256;
 /// to even the core data structures.
 pub mod opaque {
 	use super::*;
-	use authority_selection_inherents::MaybeFromCandidateKeys;
+	use authority_selection_inherents::AutoMaybeFromCandidateKeys;
 	use parity_scale_codec::MaxEncodedLen;
 	use sp_core::{ed25519, sr25519};
 	pub use sp_runtime::OpaqueExtrinsic as UncheckedExtrinsic;
@@ -171,7 +171,7 @@ pub mod opaque {
 		}
 	}
 
-	impl MaybeFromCandidateKeys for SessionKeys {}
+	impl AutoMaybeFromCandidateKeys for SessionKeys {}
 
 	impl_opaque_keys! {
 		pub struct CrossChainKey {

--- a/demo/runtime/src/mock.rs
+++ b/demo/runtime/src/mock.rs
@@ -1,5 +1,5 @@
 use authority_selection_inherents::{
-	AriadneInherentDataProvider, AuthoritySelectionInputs, MaybeFromCandidateKeys,
+	AriadneInherentDataProvider, AuthoritySelectionInputs, AutoMaybeFromCandidateKeys,
 	RegisterValidatorSignedMessage, filter_trustless_candidates_registrations,
 };
 use frame_support::{
@@ -117,7 +117,7 @@ impl_opaque_keys! {
 	}
 }
 
-impl MaybeFromCandidateKeys for TestSessionKeys {}
+impl AutoMaybeFromCandidateKeys for TestSessionKeys {}
 
 impl From<(sr25519::Public, ed25519::Public)> for TestSessionKeys {
 	fn from((aura, grandpa): (sr25519::Public, ed25519::Public)) -> Self {

--- a/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
@@ -111,7 +111,21 @@ impl<AuthorityId: Clone, AuthorityKeys: Clone> CommitteeMemberT
 }
 
 /// Trait to try extract implementing type from [CandidateKeys].
+///
+/// Chains using keys created using [impl_opaque_keys] should mark them with the [AutoMaybeFromCandidateKeys]
+/// and have their [MaybeFromCandidateKeys] automatically derived instead of implementing it manually.
 pub trait MaybeFromCandidateKeys: OpaqueKeys + Decode + Sized {
+	/// Depends on `Decode` that is derived by `impl_opaque_keys!`
+	fn maybe_from(keys: &CandidateKeys) -> Option<Self>;
+}
+
+/// Marks candidate key types that should have their [MaybeFromCandidateKeys] instance automatically derived
+///
+/// Types for which auto-derivation is supported are:
+/// - types that implement [OpaqueKeys] trait, usually those created usig [impl_opaque_keys]
+pub trait AutoMaybeFromCandidateKeys {}
+
+impl<T: AutoMaybeFromCandidateKeys + OpaqueKeys + Decode + Sized> MaybeFromCandidateKeys for T {
 	/// Depends on `Decode` that is derived by `impl_opaque_keys!`
 	fn maybe_from(keys: &CandidateKeys) -> Option<Self> {
 		let required_keys = Self::key_ids();

--- a/toolkit/committee-selection/authority-selection-inherents/src/tests.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/tests.rs
@@ -1,7 +1,7 @@
-use crate::MaybeFromCandidateKeys;
 use crate::authority_selection_inputs::AuthoritySelectionInputs;
 use crate::filter_invalid_candidates::RegisterValidatorSignedMessage;
 use crate::select_authorities::select_authorities;
+use crate::{AutoMaybeFromCandidateKeys, MaybeFromCandidateKeys};
 use hex_literal::hex;
 use num_bigint::BigInt;
 use parity_scale_codec::Encode;
@@ -93,7 +93,7 @@ impl_opaque_keys! {
 	}
 }
 
-impl MaybeFromCandidateKeys for AccountKeys {}
+impl AutoMaybeFromCandidateKeys for AccountKeys {}
 
 impl AccountKeys {
 	pub fn from_seed(seed: &str) -> AccountKeys {

--- a/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
+++ b/toolkit/committee-selection/query/src/tests/runtime_api_mock.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::tests::query_mock::TestRuntimeApi;
 use authority_selection_inherents::{
-	MaybeFromCandidateKeys, PermissionedCandidateDataError, RegistrationDataError, StakeError,
+	AutoMaybeFromCandidateKeys, PermissionedCandidateDataError, RegistrationDataError, StakeError,
 	validate_permissioned_candidate_data, validate_registration_data,
 };
 use mock::*;
@@ -29,7 +29,7 @@ impl_opaque_keys! {
 	}
 }
 
-impl MaybeFromCandidateKeys for SessionKeys {}
+impl AutoMaybeFromCandidateKeys for SessionKeys {}
 
 #[derive(Encode, Decode, Clone)]
 pub struct CrossChainPublic([u8; 33]);

--- a/toolkit/partner-chains-cli/src/tests/runtime.rs
+++ b/toolkit/partner-chains-cli/src/tests/runtime.rs
@@ -1,4 +1,4 @@
-use authority_selection_inherents::{CommitteeMember, MaybeFromCandidateKeys};
+use authority_selection_inherents::{AutoMaybeFromCandidateKeys, CommitteeMember};
 use frame_support::{
 	sp_runtime::traits::{BlakeTwo256, IdentityLookup},
 	*,
@@ -53,7 +53,7 @@ impl_opaque_keys! {
 	}
 }
 
-impl MaybeFromCandidateKeys for TestSessionKeys {}
+impl AutoMaybeFromCandidateKeys for TestSessionKeys {}
 
 construct_runtime! {
 	pub enum MockRuntime {


### PR DESCRIPTION
# Description

Add your description here, if it fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
