### PR TITLE
ETCM-9247: avoid multiple ICS UTXOs

### DIFF
--- a/toolkit/block-producer-metadata/pallet/src/benchmarking.rs
+++ b/toolkit/block-producer-metadata/pallet/src/benchmarking.rs
@@ -5,7 +5,7 @@
 //! To benchmark this pallet, the PC Builder should define a `BenchmarkHelper` type implementing the
 //! [BenchmarkHelper] type to provide concrete mock values for all generic types used by the pallet:
 //!
-//! ```rust
+//! ```rust,ignore
 //! use sidechain_domain::byte_string::*;
 //! use sidechain_domain::{ CrossChainSignature, CrossChainPublicKey, UtxoId };
 //! use sp_core::{ ConstU32, Encode };
@@ -48,7 +48,7 @@
 //!
 //! Assuming that the runtime crate uses the feature flag `runtime-benchmarks` to enable benchmarking features,
 //! this helper should be then added to the pallet's config:
-//! ```rust
+//! ```rust, ignore
 //! # struct ExampleBenchmarkHelper;
 //! #[cfg(feature = "runtime-benchmarks")]
 //! type BenchmarkHelper = ExampleBenchmarkHelper;

--- a/toolkit/governed-map/pallet/src/benchmarking.rs
+++ b/toolkit/governed-map/pallet/src/benchmarking.rs
@@ -4,7 +4,7 @@
 //!
 //! To run your own benchmarks, you need to implement the [BenchmarkHelper] trait to supply
 //! realistic keys and values, eg:
-//! ```rust
+//! ```rust,ignore
 //! # use frame_support::testing_prelude::bounded_vec;
 //! # use sidechain_domain::bounded_str;
 //! # use sidechain_domain::byte_string::BoundedString;

--- a/toolkit/smart-contracts/offchain/src/csl.rs
+++ b/toolkit/smart-contracts/offchain/src/csl.rs
@@ -192,6 +192,8 @@ pub(crate) trait CostStore {
 	fn get_mint(&self, script: &PlutusScript) -> ExUnits;
 	/// Returns [ExUnits] cost of a validator script for a given spend index.
 	fn get_spend(&self, spend_ix: u32) -> ExUnits;
+	/// Returns [ExUnits] cost of a validator script for a given spend index.
+	fn get_spend_ix(&self, spend_ix: u32) -> ExUnits;
 	/// Returns spend cost of the single validator script in a transaction.
 	/// It panics if there is not exactly one validator script execution.
 	fn get_one_spend(&self) -> ExUnits;
@@ -217,6 +219,18 @@ impl CostStore for Costs {
 				.get(&spend_ix)
 				.expect("get_spend should not be called with an unknown spend index")
 				.clone(),
+		}
+	}
+	fn get_spend_ix(&self, spend_ix: u32) -> ExUnits {
+		match self {
+			Costs::ZeroCosts => zero_ex_units(),
+			Costs::Costs { spends, .. } => {
+				let spend_keys = spends.keys().cloned().collect::<Vec<_>>();
+				spends
+					.get(&spend_keys[spend_ix as usize])
+					.expect("get_spend should not be called with an unknown spend index")
+					.clone()
+			},
 		}
 	}
 	fn get_one_spend(&self) -> ExUnits {

--- a/toolkit/smart-contracts/offchain/src/csl.rs
+++ b/toolkit/smart-contracts/offchain/src/csl.rs
@@ -192,8 +192,8 @@ pub(crate) trait CostStore {
 	fn get_mint(&self, script: &PlutusScript) -> ExUnits;
 	/// Returns [ExUnits] cost of a validator script for a given spend index.
 	fn get_spend(&self, spend_ix: u32) -> ExUnits;
-	/// Returns [ExUnits] cost of a validator script for a given spend index.
-	fn get_spend_ix(&self, spend_ix: u32) -> ExUnits;
+	/// Returns [ExUnits] cost of a validator script of a given index.
+	fn get_spend_by_ix(&self, ix: u32) -> ExUnits;
 	/// Returns spend cost of the single validator script in a transaction.
 	/// It panics if there is not exactly one validator script execution.
 	fn get_one_spend(&self) -> ExUnits;
@@ -221,14 +221,14 @@ impl CostStore for Costs {
 				.clone(),
 		}
 	}
-	fn get_spend_ix(&self, spend_ix: u32) -> ExUnits {
+	fn get_spend_by_ix(&self, ix: u32) -> ExUnits {
 		match self {
 			Costs::ZeroCosts => zero_ex_units(),
 			Costs::Costs { spends, .. } => {
 				let spend_keys = spends.keys().cloned().collect::<Vec<_>>();
 				spends
-					.get(&spend_keys[spend_ix as usize])
-					.expect("get_spend should not be called with an unknown spend index")
+					.get(&spend_keys[ix as usize])
+					.expect("get_spend_by_ix should not be called with an out of range index")
 					.clone()
 			},
 		}

--- a/toolkit/smart-contracts/offchain/src/reserve/release.rs
+++ b/toolkit/smart-contracts/offchain/src/reserve/release.rs
@@ -146,7 +146,7 @@ fn reserve_release_tx(
 		&previous_reserve.utxo,
 		reserve_data,
 		ReserveRedeemer::ReleaseFromReserve,
-		&costs.get_spend_ix(0),
+		&costs.get_spend_by_ix(0),
 	)?;
 
 	// If there exists only one illiquid circulation supply UTXO we spend it
@@ -159,9 +159,9 @@ fn reserve_release_tx(
 		let amount = ics_utxo.value.to_csl()?;
 		current_ics_amount += Into::<u64>::into(
 			amount.multiasset().unwrap_or(MultiAsset::new()).get_asset(
-				&cardano_serialization_lib::ScriptHash::from_bytes(token.policy_id.0.to_vec())
+				&ScriptHash::from_bytes(token.policy_id.0.to_vec())
 					.unwrap(),
-				&cardano_serialization_lib::AssetName::new(token.asset_name.0.to_vec()).unwrap(),
+				&AssetName::new(token.asset_name.0.to_vec()).unwrap(),
 			),
 		);
 		let script = &reserve_data.scripts.illiquid_circulation_supply_validator;
@@ -174,12 +174,12 @@ fn reserve_release_tx(
 				&script.language,
 				script.bytes.len(),
 			),
-			&cardano_serialization_lib::DatumSource::new_ref_input(&ics_utxo.to_csl_tx_input()),
+			&DatumSource::new_ref_input(&ics_utxo.to_csl_tx_input()),
 			&Redeemer::new(
 				&RedeemerTag::new_spend(),
 				&1u32.into(),
 				&IlliquidCirculationSupplyRedeemer::DepositMoreToSupply.into(),
-				&costs.get_spend_ix(1),
+				&costs.get_spend_by_ix(1),
 			),
 		);
 		inputs.add_plutus_script_input(&witness, &input, &amount);
@@ -218,8 +218,7 @@ fn reserve_release_tx(
 	})?;
 
 	tx_builder.set_validity_start_interval_bignum(latest_slot.into());
-	let tx = tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses();
-	Ok(tx)
+	Ok(tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses())
 }
 
 fn v_function_from_utxo(utxo: &OgmiosUtxo) -> anyhow::Result<PlutusScript> {


### PR DESCRIPTION
# Description

This PR makes it so `reserve release` spends the existing ICS UTXO, if there is one.
This PR depends on the new and optimized smart-contracts.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
