### PR TITLE
fix: metadata extrinsic front-run attack, rework benchmarks

### DIFF
--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -509,26 +509,35 @@ impl pallet_block_production_log::benchmarking::BenchmarkHelper<BlockAuthor>
 pub struct PalletBlockProducerMetadataBenchmarkHelper;
 
 #[cfg(feature = "runtime-benchmarks")]
-impl pallet_block_producer_metadata::benchmarking::BenchmarkHelper<BlockProducerMetadataType>
-	for PalletBlockProducerMetadataBenchmarkHelper
+impl
+	pallet_block_producer_metadata::benchmarking::BenchmarkHelper<
+		BlockProducerMetadataType,
+		AccountId,
+	> for PalletBlockProducerMetadataBenchmarkHelper
 {
+	fn genesis_utxo() -> UtxoId {
+		Sidechain::genesis_utxo()
+	}
+
 	fn metadata() -> BlockProducerMetadataType {
 		BlockProducerMetadataType {
 			url: "https://cool.stuff/spo.json".try_into().unwrap(),
 			hash: SizedByteString::from([0; 32]),
 		}
 	}
+
 	fn cross_chain_pub_key() -> sidechain_domain::CrossChainPublicKey {
 		sidechain_domain::CrossChainPublicKey(
 			hex_literal::hex!("020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1")
 				.to_vec(),
 		)
 	}
-	fn upsert_cross_chain_signature() -> sidechain_domain::CrossChainSignature {
-		sidechain_domain::CrossChainSignature(hex_literal::hex!("0892ab398baf72fb90c7e90147caea9b5aa642f082e8573877aba34aeb618c7e3c4a904ef5c12bdb6560d665a71584ea266279ba686ff7e4f886ca75e357fdff").to_vec())
-	}
-	fn delete_cross_chain_signature() -> sidechain_domain::CrossChainSignature {
-		sidechain_domain::CrossChainSignature(hex_literal::hex!("e891b42327fc5202f258b080d0a3f33d9a292693840dee5fa5e46033fe0b059b682597be65ac5678c182a65b46b621aaadcfb0811155f54e8d99c9e4394a1fe9").to_vec())
+
+	fn cross_chain_sign_key() -> pallet_block_producer_metadata::benchmarking::SecretKey {
+		pallet_block_producer_metadata::benchmarking::SecretKey::from_slice(&hex_literal::hex!(
+			"cb6df9de1efca7a3998a8ead4e02159d5fa99c3e0d4fd6432667390bb4726854"
+		))
+		.unwrap()
 	}
 
 	fn upsert_valid_before() -> u64 {

--- a/e2e-tests/src/partner_chains_node/node.py
+++ b/e2e-tests/src/partner_chains_node/node.py
@@ -41,13 +41,13 @@ class PartnerChainsNode:
             logging.error(f"Could not parse response of sign-address-association cmd: {result}")
             raise e
 
-    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
-        return self.sign_block_producer_metadata_operation(genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account)
+    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chain_account):
+        return self.sign_block_producer_metadata_operation(genesis_utxo, metadata_file, cross_chain_signing_key, partner_chain_account)
 
-    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chains_account):
-        return self.sign_block_producer_metadata_operation(genesis_utxo, None, cross_chain_signing_key, partner_chains_account)
+    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chain_account):
+        return self.sign_block_producer_metadata_operation(genesis_utxo, None, cross_chain_signing_key, partner_chain_account)
 
-    def sign_block_producer_metadata_operation(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
+    def sign_block_producer_metadata_operation(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chain_account):
         cross_chain_signing_key = cross_chain_signing_key.to_string().hex()
 
         sign_block_producer_metadata_cmd = " ".join([
@@ -57,7 +57,7 @@ class PartnerChainsNode:
                 f"--genesis-utxo {genesis_utxo}",
                 (f"--metadata-file {metadata_file}" if metadata_file is not None else ""),
                 f"--cross-chain-signing-key {cross_chain_signing_key}",
-                f"--partner-chain-account {partner_chains_account}"
+                f"--partner-chain-account {partner_chain_account}"
              ])
 
         result = self.run_command.exec(sign_block_producer_metadata_cmd)

--- a/e2e-tests/src/partner_chains_node/node.py
+++ b/e2e-tests/src/partner_chains_node/node.py
@@ -41,13 +41,13 @@ class PartnerChainsNode:
             logging.error(f"Could not parse response of sign-address-association cmd: {result}")
             raise e
 
-    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key):
-        return self.sign_block_producer_metadata_operation(genesis_utxo, metadata_file, cross_chain_signing_key)
+    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
+        return self.sign_block_producer_metadata_operation(genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account)
 
-    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key):
-        return self.sign_block_producer_metadata_operation(genesis_utxo, None, cross_chain_signing_key)
+    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chains_account):
+        return self.sign_block_producer_metadata_operation(genesis_utxo, None, cross_chain_signing_key, partner_chains_account)
 
-    def sign_block_producer_metadata_operation(self, genesis_utxo, metadata_file, cross_chain_signing_key):
+    def sign_block_producer_metadata_operation(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
         cross_chain_signing_key = cross_chain_signing_key.to_string().hex()
 
         sign_block_producer_metadata_cmd = " ".join([
@@ -56,7 +56,8 @@ class PartnerChainsNode:
                 (f"upsert" if metadata_file is not None else "delete"),
                 f"--genesis-utxo {genesis_utxo}",
                 (f"--metadata-file {metadata_file}" if metadata_file is not None else ""),
-                f"--cross-chain-signing-key {cross_chain_signing_key}"
+                f"--cross-chain-signing-key {cross_chain_signing_key}",
+                f"--partner-chain-account {partner_chains_account}"
              ])
 
         result = self.run_command.exec(sign_block_producer_metadata_cmd)

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -685,14 +685,14 @@ class SubstrateApi(BlockchainApi):
     def sign_address_association(self, genesis_utxo, address, stake_signing_key):
         return self.partner_chains_node.sign_address_association(genesis_utxo, address, stake_signing_key)
 
-    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
+    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chain_account):
         return self.partner_chains_node.sign_block_producer_metadata_upsert(
-            genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account
+            genesis_utxo, metadata_file, cross_chain_signing_key, partner_chain_account
         )
 
-    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chains_account):
+    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chain_account):
         return self.partner_chains_node.sign_block_producer_metadata_delete(
-            genesis_utxo, cross_chain_signing_key, partner_chains_account
+            genesis_utxo, cross_chain_signing_key, partner_chain_account
         )
 
     @long_running_function

--- a/e2e-tests/src/substrate_api.py
+++ b/e2e-tests/src/substrate_api.py
@@ -685,14 +685,14 @@ class SubstrateApi(BlockchainApi):
     def sign_address_association(self, genesis_utxo, address, stake_signing_key):
         return self.partner_chains_node.sign_address_association(genesis_utxo, address, stake_signing_key)
 
-    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key):
+    def sign_block_producer_metadata_upsert(self, genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account):
         return self.partner_chains_node.sign_block_producer_metadata_upsert(
-            genesis_utxo, metadata_file, cross_chain_signing_key
+            genesis_utxo, metadata_file, cross_chain_signing_key, partner_chains_account
         )
 
-    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key):
+    def sign_block_producer_metadata_delete(self, genesis_utxo, cross_chain_signing_key, partner_chains_account):
         return self.partner_chains_node.sign_block_producer_metadata_delete(
-            genesis_utxo, cross_chain_signing_key
+            genesis_utxo, cross_chain_signing_key, partner_chains_account
         )
 
     @long_running_function

--- a/e2e-tests/tests/committee/test_blocks.py
+++ b/e2e-tests/tests/committee/test_blocks.py
@@ -18,7 +18,7 @@ def test_block_producer_can_update_their_metadata(genesis_utxo, api: BlockchainA
     }
     metadata_filepath = write_file(api.partner_chains_node.run_command, metadata)
 
-    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey)
+    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey, get_wallet.address)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
 
@@ -41,7 +41,7 @@ def test_block_producer_can_update_their_metadata(genesis_utxo, api: BlockchainA
         "hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
     }
     metadata_filepath = write_file(api.partner_chains_node.run_command, metadata)
-    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey)
+    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey, get_wallet.address)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
 
@@ -72,7 +72,7 @@ def test_block_producer_can_delete_their_metadata(genesis_utxo, api: BlockchainA
     }
     metadata_filepath = write_file(api.partner_chains_node.run_command, metadata)
 
-    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey)
+    signature = api.sign_block_producer_metadata_upsert(genesis_utxo, metadata_filepath, skey, get_wallet.address)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
 
@@ -90,7 +90,7 @@ def test_block_producer_can_delete_their_metadata(genesis_utxo, api: BlockchainA
     assert rpc_metadata == metadata, "RPC did not return block producer metadata or it is incorrect"
 
     logger.info("Starting delete")
-    signature = api.sign_block_producer_metadata_delete(genesis_utxo, skey)
+    signature = api.sign_block_producer_metadata_delete(genesis_utxo, skey, get_wallet.address)
     assert signature.signature, "Signature is empty"
     assert signature.cross_chain_pub_key == f"0x{vkey_hex}"
 

--- a/toolkit/block-producer-metadata/pallet/Cargo.toml
+++ b/toolkit/block-producer-metadata/pallet/Cargo.toml
@@ -24,6 +24,7 @@ sp-core = { workspace = true, optional = true }
 sp-block-producer-metadata = { workspace = true }
 sp-runtime = { workspace = true, optional = true }
 sp-io = { workspace = true, optional = true }
+k256 = { workspace = true, optional = true }
 
 [dev-dependencies]
 sp-core = { workspace = true }
@@ -33,6 +34,7 @@ hex-literal = { workspace = true }
 k256 = { workspace = true }
 pallet-balances = { workspace = true }
 pretty_assertions = { workspace = true }
+sp-block-producer-metadata = { workspace = true, features = ["std"] }
 
 [features]
 default = ["std"]
@@ -57,4 +59,5 @@ runtime-benchmarks = [
     "hex-literal",
     "sp-core",
     "sp-io",
+    "k256",
 ]

--- a/toolkit/block-producer-metadata/pallet/src/lib.rs
+++ b/toolkit/block-producer-metadata/pallet/src/lib.rs
@@ -183,7 +183,7 @@ pub mod pallet {
 
 		/// Helper providing mock values for use in benchmarks
 		#[cfg(feature = "runtime-benchmarks")]
-		type BenchmarkHelper: benchmarking::BenchmarkHelper<Self::BlockProducerMetadata>;
+		type BenchmarkHelper: benchmarking::BenchmarkHelper<Self::BlockProducerMetadata, Self::AccountId>;
 	}
 
 	/// Storage mapping from block producers to their metadata, owner account and deposit amount
@@ -248,6 +248,7 @@ pub mod pallet {
 				metadata: Some(metadata.clone()),
 				genesis_utxo,
 				valid_before,
+				owner: origin_account.clone(),
 			};
 
 			let is_valid_signature =
@@ -297,11 +298,12 @@ pub mod pallet {
 			let origin_account = ensure_signed(origin)?;
 
 			let genesis_utxo = T::genesis_utxo();
-			let metadata_message = MetadataSignedMessage::<T::BlockProducerMetadata> {
+			let metadata_message = MetadataSignedMessage::<T::BlockProducerMetadata, T::AccountId> {
 				cross_chain_pub_key: cross_chain_pub_key.clone(),
 				metadata: None,
 				genesis_utxo,
 				valid_before,
+				owner: origin_account.clone(),
 			};
 			let cross_chain_key_hash = cross_chain_pub_key.hash();
 			let is_valid_signature =

--- a/toolkit/block-producer-metadata/primitives/src/lib.rs
+++ b/toolkit/block-producer-metadata/primitives/src/lib.rs
@@ -20,7 +20,7 @@ extern crate alloc;
 
 /// Message signed to authorize modification of a block producer's on-chain metadata
 #[derive(Debug, Clone, Encode)]
-pub struct MetadataSignedMessage<Metadata> {
+pub struct MetadataSignedMessage<Metadata, AccountId> {
 	/// Cross-chain public key
 	pub cross_chain_pub_key: CrossChainPublicKey,
 	/// Block producer's metadata. [None] signifies a deletion of metadata from the chain.
@@ -31,11 +31,12 @@ pub struct MetadataSignedMessage<Metadata> {
 	/// to be valid. This value is mapped to a Partner Chain slot which loses precision for
 	/// chains with block times above 1 second.
 	pub valid_before: u64,
+	/// Account ID that will be used to set the metadata and own it on-chain
+	pub owner: AccountId,
 }
 
-impl<M: Encode> MetadataSignedMessage<M> {
+impl<M: Encode, AccountId: Encode> MetadataSignedMessage<M, AccountId> {
 	/// Encodes this message using SCALE codec and signs it
-	#[cfg(feature = "std")]
 	pub fn sign_with_key(&self, skey: &k256::SecretKey) -> CrossChainSignature {
 		use k256::Secp256k1;
 		use k256::ecdsa::hazmat::DigestPrimitive;
@@ -70,6 +71,7 @@ mod tests {
 			metadata: Some("metadata".to_string()),
 			genesis_utxo: UtxoId::new([2; 32], 0),
 			valid_before: 100_000_000_000,
+			owner: 1000,
 		};
 
 		// Alice cross-chain key

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -19,6 +19,7 @@ use sc_service::TaskManager;
 use sidechain_domain::{McEpochNumber, ScEpochNumber, StakePoolPublicKey};
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
+use sp_runtime::AccountId32;
 use sp_runtime::DeserializeOwned;
 use sp_runtime::Serialize;
 use sp_runtime::traits::Block as BlockT;
@@ -132,7 +133,7 @@ pub enum PartnerChainsSubcommand<
 
 	/// Signs block producer metadata for submitting to the runtime
 	#[command(subcommand)]
-	SignBlockProducerMetadata(BlockProducerMetadataSignatureCmd),
+	SignBlockProducerMetadata(BlockProducerMetadataSignatureCmd<AccountId32>),
 
 	/// Commands for interacting with Partner Chain smart contracts on Cardano
 	#[command(subcommand)]


### PR DESCRIPTION
# Description

* Adds `AccountId` of the extrinsic submitter to the signed message for updating block producer metadata to prevent front-run attacks
* Reworks the tests and benchmarks for the metadata pallet, so that signatures are now automatically signed instead of requiring manual updating using the CLI

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
