### PR TITLE
chore: update Rust to 1.88 and use wasm32v1-none

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ match this change.
 * `authority-selection-inherents` crate now exports all its public members from the crate root
 * `select_authorities` in `authority-selection-inherents` crate now returns a `BoundedVec` of `CommitteeMembers`. Projects that used the old version no longer
 need to transform the data in their own runtime code
+* Updates Rust dependency to v1.88, changes WASM target to 'wasm32v1-none'
 
 ## Added
 

--- a/flake.nix
+++ b/flake.nix
@@ -38,7 +38,7 @@
         };
         rustToolchain = fenix.packages.${system}.fromToolchainFile {
           file = ./rust-toolchain.toml;
-          sha256 = "X/4ZBHO3iW0fOenQ3foEvscgAPJYl2abspaBThDOukI=";
+          sha256 = "Qxt8XAuaUR2OMdKbN4u8dBJOhSHxS+uS06Wl9+flVEk=";
         };
 
         isLinux = pkgs.stdenv.isLinux;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.86.0"
+channel = "1.88.0"
 components = [
 	"cargo",
 	"clippy",
@@ -10,5 +10,5 @@ components = [
 	"rustc",
 	"rustfmt",
 ]
-targets = ["wasm32-unknown-unknown"]
+targets = ["wasm32v1-none"]
 profile = "minimal"


### PR DESCRIPTION
# Description

Updates Rust to v1.88. Changes wasm target to wasm32v1-none.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
