### PR TITLE
docs: fix warnings

### DIFF
--- a/demo/node/src/chain_spec.rs
+++ b/demo/node/src/chain_spec.rs
@@ -36,7 +36,7 @@ pub fn runtime_wasm() -> &'static [u8] {
 }
 
 /// Creates chain-spec according to the config obtained by wizards.
-/// [JValue] is returned instead of [sc_service::GenericChainSpec] in order to avoid
+/// [serde_json::Value] is returned instead of [sc_service::GenericChainSpec] in order to avoid
 /// GPL code in the toolkit.
 pub fn pc_create_chain_spec(config: &CreateChainSpecConfig<SessionKeys>) -> serde_json::Value {
 	let runtime_genesis_config = partner_chains_demo_runtime::RuntimeGenesisConfig {

--- a/demo/node/src/service.rs
+++ b/demo/node/src/service.rs
@@ -35,8 +35,8 @@ type FullSelectChain = sc_consensus::LongestChain<FullBackend, Block>;
 /// imported and generated.
 const GRANDPA_JUSTIFICATION_PERIOD: u32 = 512;
 
-/// This function provides dependencies of [partner_chains_nodes_command::PartnerChainsSubcommand].
-/// It is not mandatory to have such a dedicated function, [partial_service] could be enough,
+/// This function provides dependencies of [partner_chains_node_commands::PartnerChainsSubcommand].
+/// It is not mandatory to have such a dedicated function, [new_partial] could be enough,
 /// however using such a specialized function decreases number of possible failures and wiring time.
 pub fn new_pc_command_deps(
 	config: &Configuration,

--- a/toolkit/block-producer-fees/rpc/src/lib.rs
+++ b/toolkit/block-producer-fees/rpc/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! ## Contents
 //!
-//! This crate provides the [BlockProducerFeesRpcApiServer] trait defining the JsonRPC method to display
+//! This crate provides the [BlockProducerFeesRpcServer] trait defining the JsonRPC method to display
 //! block producer fees and its concrete implementation [BlockProducerFeesRpc].
 //! ## Usage - PC Builders
 //!
@@ -65,7 +65,7 @@ pub trait BlockProducerFeesRpc<AccountId: Decode> {
 	fn get_block_producer_fees(&self) -> RpcResult<Vec<FeesSettings<AccountId>>>;
 }
 
-/// Concrete implementation of [BlockProducerFeesRpcApiServer] that uses [BlockProducerFeesRpcApi] for querying runtime storage.
+/// Concrete implementation of [BlockProducerFeesRpcServer] that uses [BlockProducerFeesApi] for querying runtime storage.
 #[derive(new)]
 pub struct BlockProducerFeesRpc<C, Block, AccountId> {
 	client: Arc<C>,

--- a/toolkit/block-producer-metadata/pallet/src/benchmarking.rs
+++ b/toolkit/block-producer-metadata/pallet/src/benchmarking.rs
@@ -61,7 +61,7 @@
 //!
 //! Afterwards, the pallet can be benchmarked using Polkadot SDK's [omini-bencher](https://github.com/paritytech/polkadot-sdk/tree/master/substrate/utils/frame/omni-bencher).
 
-#![cfg(feature = "runtime-benchmarks")]
+#![cfg(any(feature = "runtime-benchmarks", doc))]
 use super::*;
 use frame_benchmarking::v2::*;
 use frame_system::RawOrigin;

--- a/toolkit/committee-selection/authority-selection-inherents/src/authority_selection_inputs.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/authority_selection_inputs.rs
@@ -4,7 +4,7 @@ use plutus::*;
 use scale_info::TypeInfo;
 use sidechain_domain::*;
 
-/// Inherent data type provided by [AriadneInherentDataProvider].
+/// Inherent data type provided by [crate::AriadneInherentDataProvider].
 /// The part of data for selection of authorities that comes from the main chain.
 /// It is unfiltered, so the selection algorithm should filter out invalid candidates.
 #[derive(Clone, Debug, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq)]

--- a/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/lib.rs
@@ -110,7 +110,7 @@ impl<AuthorityId: Clone, AuthorityKeys: Clone> CommitteeMemberT
 	}
 }
 
-/// Trait to try extract [T] from [CandidateKeys].
+/// Trait to try extract implementing type from [CandidateKeys].
 pub trait MaybeFromCandidateKeys: OpaqueKeys + Decode + Sized {
 	/// Depends on `Decode` that is derived by `impl_opaque_keys!`
 	fn maybe_from(keys: &CandidateKeys) -> Option<Self> {

--- a/toolkit/committee-selection/pallet/src/lib.rs
+++ b/toolkit/committee-selection/pallet/src/lib.rs
@@ -206,7 +206,7 @@ pub mod pallet {
 		type Error = InherentError;
 		const INHERENT_IDENTIFIER: InherentIdentifier = INHERENT_IDENTIFIER;
 
-		/// Responsible for calling [Call:set] on each block by the block author, if the validator list changed
+		/// Responsible for calling [Call::set] on each block by the block author, if the validator list changed
 		fn create_inherent(data: &InherentData) -> Option<Self::Call> {
 			if NextCommittee::<T>::exists() {
 				None

--- a/toolkit/committee-selection/pallet/src/migrations/v1.rs
+++ b/toolkit/committee-selection/pallet/src/migrations/v1.rs
@@ -9,7 +9,7 @@ use {
 
 use super::v0;
 
-/// [VersionedMigration] parametrized for v0 to v1 migration.
+/// [frame_support::migrations::VersionedMigration] parametrized for v0 to v1 migration.
 pub type LegacyToV1Migration<T> = frame_support::migrations::VersionedMigration<
 	0, // The migration will only execute when the on-chain storage version is 0
 	1, // The on-chain storage version will be set to 1 after the migration is complete

--- a/toolkit/committee-selection/primitives/src/lib.rs
+++ b/toolkit/committee-selection/primitives/src/lib.rs
@@ -140,7 +140,7 @@ sp_api::decl_runtime_apis! {
 	{
 		/// Returns main chain scripts
 		fn get_main_chain_scripts() -> MainChainScripts;
-		/// Returns next unset [ScEpochNumber]
+		/// Returns next unset [sidechain_domain::ScEpochNumber]
 		fn get_next_unset_epoch_number() -> ScEpochNumber;
 
 		#[changed_in(2)]

--- a/toolkit/data-sources/mock/src/lib.rs
+++ b/toolkit/data-sources/mock/src/lib.rs
@@ -53,7 +53,9 @@ pub use block::BlockDataSourceMock;
 #[cfg(feature = "candidate-source")]
 mod candidate;
 #[cfg(feature = "candidate-source")]
-pub use candidate::{AuthoritySelectionDataSourceMock, MockRegistrationsConfig};
+pub use candidate::{
+	AuthoritySelectionDataSourceMock, MockEpochCandidates, MockRegistrationsConfig,
+};
 
 #[cfg(feature = "governed-map")]
 mod governed_map;

--- a/toolkit/governed-map/pallet/src/lib.rs
+++ b/toolkit/governed-map/pallet/src/lib.rs
@@ -86,7 +86,7 @@
 //! through the [SubstrateWeight][crate::weights::SubstrateWeight] type.
 //!
 //! However, since data size limits and the on-change logic both can affect the weights, it is advisable to run
-//! your own benchmark to account for their impact. See the documentation on [crate::benchmarking] for details.
+//! your own benchmark to account for their impact. See the documentation on [benchmarking] for details.
 //!
 //! ### Configuring the pallet
 //!
@@ -170,7 +170,7 @@ mod tests;
 #[cfg(test)]
 mod mock;
 
-#[cfg(feature = "runtime-benchmarks")]
+#[cfg(any(feature = "runtime-benchmarks", doc))]
 pub mod benchmarking;
 
 #[frame_support::pallet]

--- a/toolkit/native-token-management/pallet/src/lib.rs
+++ b/toolkit/native-token-management/pallet/src/lib.rs
@@ -54,14 +54,14 @@
 //! ```
 //!
 //! Keep in mind that if the handler logic has to perform storage operations, the pallet's benchmarks
-//! should be rerun. Otherwise default weights are provided in [pallet_native_token_management::weights].
+//! should be rerun. Otherwise default weights are provided in [crate::weights].
 //!
 //! ## Script configuration
 //!
 //! For token transfers to be observed, the pallet must be configured with correct Cardano addresses and
 //! scripts used to idendify them in the ledger. These scripts can be set in two ways: through genesis
 //! configuration if the pallet is present in the initial runtime of a chain; or via a governance action
-//! using the [set_main_chain_scripts] extrinsic.
+//! using the [Pallet::set_main_chain_scripts] extrinsic.
 //!
 //! ### Genesis configuratin
 //!
@@ -84,7 +84,7 @@
 //! ### Main chain scripts extrinsic
 //!
 //! Once the chain is already started, to set initial main chain scripts to a newly added pallet, or to
-//! change the existing ones, the [set_main_chain_scripts] extrinsic must be submitted through on-chain
+//! change the existing ones, the [Pallet::set_main_chain_scripts] extrinsic must be submitted through on-chain
 //! governance mechanism like `sudo` or `pallet_democracy`. Who exactly can submit this extrinsic is
 //! controlled by the [Config::MainChainScriptsOrigin] field of the pallet's configuration, but for security
 //! it must be a trusted entity.
@@ -175,7 +175,7 @@ pub mod pallet {
 	/// Stores the pallet's initialization state.
 	///
 	/// The pallet is considered initialized if its inherent has been successfuly called at least once since
-	/// genesis or the last invocation of [set_main_chain_scripts][Pallet::set_main_chain_scripts].
+	/// genesis or the last invocation of [Pallet::set_main_chain_scripts].
 	#[pallet::storage]
 	pub type Initialized<T: Config> = StorageValue<_, bool, ValueQuery>;
 

--- a/toolkit/native-token-management/primitives/src/lib.rs
+++ b/toolkit/native-token-management/primitives/src/lib.rs
@@ -75,7 +75,7 @@
 //!
 //! The same constructor can be used for both proposal and validation of blocks.
 //!
-//! [NativeTokenManagementApi]: sp_native_token_management::NativeTokenManagementApi
+//! [NativeTokenManagementApi]: crate::NativeTokenManagementApi
 #![cfg_attr(not(feature = "std"), no_std)]
 #![deny(missing_docs)]
 

--- a/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
+++ b/toolkit/partner-chains-cli/src/create_chain_spec/mod.rs
@@ -152,7 +152,7 @@ impl<Keys: MaybeFromCandidateKeys> CreateChainSpecConfig<Keys> {
 		}
 	}
 
-	/// Returns [pallet_session::GenesisConfig] derived from the config, using initial permissioned candidates
+	/// Returns [pallet_partner_chains_session::GenesisConfig] derived from the config, using initial permissioned candidates
 	/// as initial validators
 	pub fn pallet_partner_chains_session_config<T: pallet_partner_chains_session::Config>(
 		&self,

--- a/toolkit/sidechain/domain/src/lib.rs
+++ b/toolkit/sidechain/domain/src/lib.rs
@@ -46,7 +46,7 @@ use {
 
 /// The number of main chain epochs back a Partner Chain queries for committee selection inputs.
 /// This offset is necessary to ensure that data is present and stable.
-const DATA_MC_EPOCH_OFFSET: u32 = 2;
+pub const DATA_MC_EPOCH_OFFSET: u32 = 2;
 
 /// Shifts given epoch back by [DATA_MC_EPOCH_OFFSET] accounting for underflow.
 pub fn offset_data_epoch(epoch: &McEpochNumber) -> Result<McEpochNumber, u32> {

--- a/toolkit/sidechain/pallet/src/lib.rs
+++ b/toolkit/sidechain/pallet/src/lib.rs
@@ -46,7 +46,7 @@
 //! the pallet can be configured with a handler that will be triggered during initialization
 //! of each first block of a new epoch.
 //!
-//! To create a new epoch handler, simply define a type and have it implement the [OnNewEpoch] trait:
+//! To create a new epoch handler, simply define a type and have it implement the [sp_sidechain::OnNewEpoch] trait:
 //! ```rust
 //! use sidechain_domain::{ ScEpochNumber, ScSlotNumber };
 //! use sp_runtime::Weight;

--- a/toolkit/sidechain/rpc/src/lib.rs
+++ b/toolkit/sidechain/rpc/src/lib.rs
@@ -95,7 +95,7 @@ mod tests;
 #[cfg(any(test))]
 mod mock;
 
-/// Response type of the [SidechainRpcApi::get_params] method
+/// Response type of the [crate::SidechainRpcApiServer::get_params] method
 #[derive(serde::Serialize, serde::Deserialize, Clone, PartialEq, Debug)]
 pub struct GetParamsOutput {
 	/// Genesis UTXO of the queried Partner Chain

--- a/toolkit/sidechain/rpc/src/types/sidechain.rs
+++ b/toolkit/sidechain/rpc/src/types/sidechain.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use sp_core::offchain::Timestamp;
 use std::fmt::Debug;
 
-/// Response type of [SidechainRpcApiServer::get_status]
+/// Response type of [crate::SidechainRpcApiServer::get_status]
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct GetStatusResponse {
@@ -39,7 +39,7 @@ pub struct MainchainData {
 	pub next_epoch_timestamp: Timestamp,
 }
 
-/// Error type returned by [SidechainRpcApiServer::get_status]
+/// Error type returned by [crate::SidechainRpcApiServer::get_status]
 #[derive(Debug)]
 pub enum GetStatusRpcError {
 	/// Signals that the server could not convert Partner Chain slot number to timestamp

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -20,9 +20,8 @@
 //!
 //! ## Result types
 //!
-//! Most commands return a [SubCmdResult] type, which is a wrapper around a
-//! [serde_json::Value]. The returned value is printed to the ouptut at the end
-//! of the command execution.
+//! Most commands return result of [serde_json::Value].
+//! The returned value is printed to the ouptut at the end of the command execution.
 use ogmios_client::jsonrpsee::{OgmiosClients, client_for_url};
 use partner_chains_cardano_offchain::{
 	await_tx::FixedDelayRetries,

--- a/toolkit/smart-contracts/offchain/src/plutus_script.rs
+++ b/toolkit/smart-contracts/offchain/src/plutus_script.rs
@@ -190,8 +190,8 @@ impl From<raw_scripts::RawScript> for PlutusScript {
 
 /// Applies arguments to a Plutus script.
 /// The first argument is the script, the rest of the arguments are the datums that will be applied.
-/// * The script can be any type that implements [Into<PlutusScript>] for example [raw_scripts::RawScript].
-/// * The arguments can be any type that implements [Into<PlutusDataWrapper>]. Implementations are provided for
+/// * The script can be any type that implements [`Into<PlutusScript>`] for example [raw_scripts::RawScript].
+/// * The arguments can be any type that implements [`Into<PlutusDataWrapper>`]. Implementations are provided for
 ///   [uplc::PlutusData] and [plutus::Datum].
 /// Returns [anyhow::Result<uplc::PlutusData>].
 ///

--- a/toolkit/smart-contracts/plutus-data/Cargo.toml
+++ b/toolkit/smart-contracts/plutus-data/Cargo.toml
@@ -17,9 +17,9 @@ sidechain-domain = { workspace = true, features = ["std"] }
 sp-core = { workspace = true }
 cardano-serialization-lib = { workspace = true }
 thiserror = { workspace = true }
+raw-scripts = { workspace = true }
 
 [dev-dependencies]
-raw-scripts = { workspace = true }
 serde_json = { workspace = true }
 hex = { workspace = true }
 hex-literal = { workspace = true }

--- a/toolkit/smart-contracts/plutus-data/src/d_param.rs
+++ b/toolkit/smart-contracts/plutus-data/src/d_param.rs
@@ -34,7 +34,7 @@ impl From<DParamDatum> for sidechain_domain::DParameter {
 	}
 }
 
-/// Convert [DParameter] to [PlutusData].
+/// Convert [sidechain_domain::DParameter] to [PlutusData].
 ///
 /// Encoding:
 ///   VersionedGenericDatum:

--- a/toolkit/smart-contracts/plutus-data/src/lib.rs
+++ b/toolkit/smart-contracts/plutus-data/src/lib.rs
@@ -114,9 +114,12 @@ fn decoding_error_and_log(data: &PlutusData, to: &str, msg: &str) -> DataDecodin
 /// This struct has the same shape as `VersionedGenericDatum` from smart-contracts.
 /// It is used to help implementing a proper `From` trait for `PlutusData` for
 /// datum types.
-pub(crate) struct VersionedGenericDatum {
+pub struct VersionedGenericDatum {
+	/// data that is interpreted by smart-contract
 	pub datum: PlutusData,
+	/// generic data ignored by smart-contract logic, schema is version dependent
 	pub appendix: PlutusData,
+	/// version number
 	pub version: u64,
 }
 

--- a/toolkit/smart-contracts/plutus-data/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/plutus-data/src/permissioned_candidates.rs
@@ -77,6 +77,7 @@ impl From<PermissionedCandidateDatums> for Vec<PermissionedCandidateData> {
 /// Converts a list of [PermissionedCandidateData] values to [VersionedGenericDatum] encoded as [PlutusData].
 ///
 /// Encoding:
+/// ```ignore
 ///   VersionedGenericDatum:
 ///   - datum: ()
 ///   - appendix:
@@ -93,6 +94,7 @@ impl From<PermissionedCandidateDatums> for Vec<PermissionedCandidateData> {
 ///       // etc.
 ///     ]
 ///   - version: 0
+/// ```
 pub fn permissioned_candidates_to_plutus_data(
 	candidates: &[PermissionedCandidateData],
 ) -> PlutusData {

--- a/toolkit/utils/ogmios-client/src/lib.rs
+++ b/toolkit/utils/ogmios-client/src/lib.rs
@@ -3,7 +3,7 @@
 //! Ogmios is a JSON-RPC server that provides a high-level API for interacting with the Cardano blockchain.
 //! It can be accessed via a HTTP or WebSocket connection.
 //!
-//! More information about Ogmios API can be found at https://ogmios.dev/api/
+//! More information about Ogmios API can be found at <https://ogmios.dev/api/>
 
 #[cfg(feature = "jsonrpsee-client")]
 pub mod jsonrpsee;

--- a/toolkit/utils/time-source/src/lib.rs
+++ b/toolkit/utils/time-source/src/lib.rs
@@ -36,7 +36,7 @@ impl TimeSource for SystemTimeSource {
 	}
 }
 
-#[cfg(feature = "mock")]
+#[cfg(any(feature = "mock", doc))]
 /// A mock implementation of `TimeSource` for testing purposes.
 pub struct MockedTimeSource {
 	/// The mocked current time in milliseconds since Unix epoch


### PR DESCRIPTION
# Description

Fixes docs warnings in `cargo doc --no-deps`. Usually fixed by qualifying (scoping) type. See comments in the PR changes.


