### PR TITLE
Remove custom clap parser functions

### DIFF
--- a/toolkit/cli/commands/src/address_association_signatures.rs
+++ b/toolkit/cli/commands/src/address_association_signatures.rs
@@ -7,34 +7,28 @@ use parity_scale_codec::Encode;
 use serde::Serialize;
 use serde_json::json;
 use sidechain_domain::*;
-use std::str::FromStr;
 
 /// Generates Ed25519 signatures to associate Cardano stake addresses with Partner Chain addresses.
 /// Generic over address type to support different Partner Chain implementations.
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct AddressAssociationSignaturesCmd<
-	PartnerchainAddress: Clone + Sync + Send + FromStr + 'static,
+	PartnerchainAddress: Clone + Sync + Send + FromStrStdErr + 'static,
 > {
 	/// Genesis UTXO that identifies the target Partner Chain
 	#[arg(long)]
 	pub genesis_utxo: UtxoId,
 	/// Partner Chain address to be associated with the Cardano stake address
-	#[arg(long, value_parser=parse_pc_address::<PartnerchainAddress>)]
+	#[arg(long)]
 	pub partnerchain_address: PartnerchainAddress,
 	/// Ed25519 signing key for the Cardano stake address. Its public key will be associated with partnerchain_address.
 	#[arg(long)]
 	pub signing_key: StakeSigningKeyParam,
 }
 
-/// Parses Partner Chain address from string format.
-fn parse_pc_address<T: FromStr>(s: &str) -> Result<T, String> {
-	T::from_str(s).map_err(|_| "Failed to parse Partner Chain address".to_owned())
-}
-
 impl<PartnerchainAddress> AddressAssociationSignaturesCmd<PartnerchainAddress>
 where
-	PartnerchainAddress: Serialize + Clone + Sync + Send + FromStr + Encode + 'static,
+	PartnerchainAddress: Serialize + Clone + Sync + Send + FromStrStdErr + Encode + 'static,
 {
 	/// Generates signature and outputs JSON to stdout.
 	pub fn execute(&self) -> anyhow::Result<()> {
@@ -67,6 +61,7 @@ mod test {
 	use hex::FromHexError;
 	use hex_literal::hex;
 	use sidechain_domain::byte_string::ByteString;
+	use std::str::FromStr;
 
 	#[derive(Clone, Encode, Serialize)]
 	struct AccountId32(pub [u8; 32]);

--- a/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
+++ b/toolkit/cli/commands/src/block_producer_metadata_signatures.rs
@@ -6,13 +6,14 @@ use serde::de::DeserializeOwned;
 use serde_json::{self, json};
 use sidechain_domain::*;
 use sp_block_producer_metadata::MetadataSignedMessage;
-use std::{io::BufReader, str::FromStr};
+use std::io::BufReader;
 use time_source::{SystemTimeSource, TimeSource};
 
 /// Generates ECDSA signatures for block producer metadata using cross-chain keys.
 #[derive(Clone, Debug, clap::Subcommand)]
 #[command(author, version, about, long_about = None)]
-pub enum BlockProducerMetadataSignatureCmd<AccountId: FromStr + Clone + Send + Sync + 'static> {
+pub enum BlockProducerMetadataSignatureCmd<AccountId: FromStrStdErr + Clone + Send + Sync + 'static>
+{
 	/// Generates signature for the `upsert_metadata` extrinsic
 	Upsert {
 		/// Genesis UTXO that uniquely identifies the target Partner Chain
@@ -28,7 +29,7 @@ pub enum BlockProducerMetadataSignatureCmd<AccountId: FromStr + Clone + Send + S
 		#[arg(long, default_value = "3600")]
 		ttl: u64,
 		/// Partner Chain Account that will be used to upsert the metadata and will own it on-chain
-		#[arg(long, value_parser=parse_partner_chain_accounts::<AccountId>)]
+		#[arg(long)]
 		partner_chain_account: AccountId,
 	},
 	/// Generates signature for the `delete_metadata` extrinsic
@@ -44,16 +45,12 @@ pub enum BlockProducerMetadataSignatureCmd<AccountId: FromStr + Clone + Send + S
 		ttl: u64,
 		/// Partner Chain Account that will be used to delete the metadata.
 		/// It must be the account that owns it on-chain.
-		#[arg(long, value_parser=parse_partner_chain_accounts::<AccountId>)]
+		#[arg(long)]
 		partner_chain_account: AccountId,
 	},
 }
 
-fn parse_partner_chain_accounts<T: FromStr>(s: &str) -> Result<T, String> {
-	T::from_str(s).map_err(|_| "Failed to parse Account ID".to_owned())
-}
-
-impl<AccountId: Encode + FromStr + Clone + Send + Sync + 'static>
+impl<AccountId: Encode + FromStrStdErr + Clone + Send + Sync + 'static>
 	BlockProducerMetadataSignatureCmd<AccountId>
 {
 	/// Reads metadata file, generates signatures, and outputs JSON to stdout.

--- a/toolkit/cli/node-commands/src/lib.rs
+++ b/toolkit/cli/node-commands/src/lib.rs
@@ -16,7 +16,7 @@ pub use partner_chains_cli::PartnerChainRuntime;
 use partner_chains_smart_contracts_commands::SmartContractsCmd;
 use sc_cli::{CliConfiguration, SharedParams, SubstrateCli};
 use sc_service::TaskManager;
-use sidechain_domain::{McEpochNumber, ScEpochNumber, StakePoolPublicKey};
+use sidechain_domain::*;
 use sp_api::ProvideRuntimeApi;
 use sp_blockchain::HeaderBackend;
 use sp_runtime::AccountId32;
@@ -30,7 +30,6 @@ use sp_session_validator_management_query::commands::*;
 #[allow(deprecated)]
 use sp_sidechain::{GetGenesisUtxo, GetSidechainStatus};
 use std::future::Future;
-use std::str::FromStr;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Parser)]
@@ -104,7 +103,7 @@ static REGISTRATION_STATUS_AFTER_HELP: once_cell::sync::Lazy<String> = once_cell
 /// Entry point for all Partner Chains specific subcommand.
 pub enum PartnerChainsSubcommand<
 	RuntimeBindings: PartnerChainRuntime + Send + Sync,
-	PartnerchainAddress: Clone + Sync + Send + FromStr + 'static,
+	PartnerchainAddress: Clone + Sync + Send + FromStrStdErr + 'static,
 > {
 	/// Returns sidechain parameters.
 	/// Requires --chain parameter that results in loading a properly configured chain spec.
@@ -181,7 +180,7 @@ where
 	CommitteeMember::AuthorityId: Decode + Encode + AsRef<[u8]> + Send + Sync + 'static,
 	CommitteeMember::AuthorityKeys: Decode + Encode,
 	BlockProducerMetadata: DeserializeOwned + Encode + Send + Sync,
-	PartnerchainAddress: Serialize + Clone + Sync + Send + FromStr + Encode + 'static,
+	PartnerchainAddress: Serialize + Clone + Sync + Send + FromStrStdErr + Encode + 'static,
 {
 	match cmd {
 		PartnerChainsSubcommand::SidechainParams(cmd) => {

--- a/toolkit/smart-contracts/commands/src/assemble_tx.rs
+++ b/toolkit/smart-contracts/commands/src/assemble_tx.rs
@@ -8,10 +8,10 @@ use sidechain_domain::{TransactionCbor, VKeyWitnessCbor};
 pub struct AssembleAndSubmitCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-	#[arg(long, value_parser = TransactionCbor::decode_hex)]
+	#[arg(long)]
 	/// Hex-encoded transaction CBOR (with or without 0x prefix)
 	transaction: TransactionCbor,
-	#[arg(short, long, num_args = 1.., value_delimiter = ' ', value_parser = VKeyWitnessCbor::decode_hex)]
+	#[arg(short, long, num_args = 1.., value_delimiter = ' ')]
 	/// Witnesses of the transaction. Each witness is a hex-encoded CBOR (with or without 0x prefix), encoding a 1 element list containing a 2 elements list [[public_key, signature]].
 	witnesses: Vec<VKeyWitnessCbor>,
 }

--- a/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
+++ b/toolkit/smart-contracts/commands/src/permissioned_candidates.rs
@@ -1,6 +1,7 @@
-use crate::{GenesisUtxo, PaymentFilePath, option_to_json, parse_partnerchain_public_keys};
+use crate::{GenesisUtxo, PaymentFilePath, option_to_json};
 use partner_chains_cardano_offchain::permissioned_candidates::upsert_permissioned_candidates;
 use std::fs::read_to_string;
+use std::str::FromStr;
 
 #[derive(Clone, Debug, clap::Parser)]
 /// Command for upserting the permissioned candidates on the main chain
@@ -10,7 +11,7 @@ pub struct UpsertPermissionedCandidatesCmd {
 	#[arg(long)]
 	/// Path to the file containing the permissioned candidates data.
 	/// Each line represents one permissioned candidate in format PARTNER_CHAINS_KEY,KEY_1_ID:KEY_1_BYTES,...,KEY_N_ID:KEY_N_BYTES.
-	/// Legacy format of PARTNER_CHAINS_KEY:AURA_PUB_KEY:GRANDPA_PUB_KEY is supported, each line is eqivalent to `PARTNER_CHAINS_KEY,aura:AURA_PUB_KEY,gran:GRANDPA_PUB_KEY`.
+	/// Legacy format of PARTNER_CHAINS_KEY:AURA_PUB_KEY:GRANDPA_PUB_KEY is supported, each line is equivalent to `PARTNER_CHAINS_KEY,aura:AURA_PUB_KEY,gran:GRANDPA_PUB_KEY`.
 	permissioned_candidates_file: String,
 	#[clap(flatten)]
 	/// Path to the payment key file
@@ -37,9 +38,10 @@ impl UpsertPermissionedCandidatesCmd {
 			if line.is_empty() {
 				continue;
 			}
-			let permissioned_candidate = parse_partnerchain_public_keys(line).map_err(|e| {
-				format!("Failed to parse permissioned candidate: '{}', because of {}", line, e)
-			})?;
+			let permissioned_candidate =
+				sidechain_domain::PermissionedCandidateData::from_str(line).map_err(|e| {
+					format!("Failed to parse permissioned candidate: '{}', because of {}", line, e)
+				})?;
 			permissioned_candidates.push(permissioned_candidate);
 		}
 

--- a/toolkit/smart-contracts/commands/src/register.rs
+++ b/toolkit/smart-contracts/commands/src/register.rs
@@ -1,7 +1,4 @@
-use crate::{
-	GenesisUtxo, PaymentFilePath, option_to_json, parse_partnerchain_public_keys,
-	transaction_submitted_json,
-};
+use crate::{GenesisUtxo, PaymentFilePath, option_to_json, transaction_submitted_json};
 use partner_chains_cardano_offchain::register::{run_deregister, run_register};
 use sidechain_domain::{
 	AdaBasedStaking, CandidateRegistration, MainchainSignature, PermissionedCandidateData,
@@ -22,11 +19,7 @@ pub struct RegisterCmd {
 	#[clap(flatten)]
 	/// Path to the payment key file
 	payment_key_file: PaymentFilePath,
-	#[arg(
-		long,
-		alias = "sidechain-public-keys",
-		value_parser = parse_partnerchain_public_keys
-	)]
+	#[arg(long, alias = "sidechain-public-keys")]
 	/// Candidate public keys in format PARTNER_CHAINS_KEY_HEX:AURA_KEY_HEX:GRANDPA_KEY_HEX or PARTNER_CHAINS_KEY_HEX,KEY_ID_1:KEY_1_HEX,...,KEY_ID_N:KEY_N_HEX
 	partner_chain_public_keys: PermissionedCandidateData,
 	#[arg(long, alias = "sidechain-signature")]

--- a/toolkit/smart-contracts/commands/src/sign_tx.rs
+++ b/toolkit/smart-contracts/commands/src/sign_tx.rs
@@ -6,7 +6,7 @@ use sidechain_domain::TransactionCbor;
 #[derive(Clone, Debug, clap::Parser)]
 /// Command for signing a cardano transaction
 pub struct SignTxCmd {
-	#[arg(long, value_parser = TransactionCbor::decode_hex)]
+	#[arg(long)]
 	/// Hex-encoded transaction CBOR (with or without 0x prefix)
 	transaction: TransactionCbor,
 	#[clap(flatten)]


### PR DESCRIPTION
# Description

`clap` allows use of `value_parser` to specify what function should be used over the `FromStr` instance of a type when parsing command line arguments. In many cases we unnecessarily use this feature when a `FromStr` instance exists.

When the `FromStr` instance for a type has an `Err` type defined that does not convert to StdErr + etc as expected by clap it generates a confusing macro compile error which seems to have been worked around with custom `value_parser`s. To fix this a `FromStrStdErr` trait (quasi trait alias) is now provided that can be used when the struct used with `clap::Parser` has type params.

The parser for `PermissionedCandidateData` has been moved into a `FromStr` instance.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
