### PR TITLE
fix post-merge CI errors

### DIFF
--- a/demo/runtime/src/genesis_config_presets.rs
+++ b/demo/runtime/src/genesis_config_presets.rs
@@ -42,7 +42,7 @@ fn testnet_genesis(
 			dev_accounts: None,
 		},
 		aura: pallet_aura::GenesisConfig {
-			authorities: initial_authorities.iter().map(|x| (x.0.clone())).collect::<Vec<_>>(),
+			authorities: initial_authorities.iter().map(|x| x.0.clone()).collect::<Vec<_>>(),
 		},
 		grandpa: pallet_grandpa::GenesisConfig {
 			authorities: initial_authorities.iter().map(|x| (x.1.clone(), 1)).collect::<Vec<_>>(),

--- a/e2e-tests/config/substrate/ci_nodes.json
+++ b/e2e-tests/config/substrate/ci_nodes.json
@@ -1,5 +1,5 @@
 {
-  "deployment_mc_epoch": 1018,
+  "deployment_mc_epoch": 1019,
   "deployment_version": "master",
   "test_environment": "ci",
   "keys_path": "secrets/substrate/staging/keys",


### PR DESCRIPTION
* Additional epoch change, because today ci-preview was down for few hours
* removes redundant parentheses