### PR TITLE
tests: compare raw plutus script

### DIFF
--- a/e2e-tests/requirements.txt
+++ b/e2e-tests/requirements.txt
@@ -13,3 +13,4 @@ pytest-json-ctrf==0.3.5
 numpy==2.2.3
 ecdsa==0.19.1
 bech32==1.2.0
+cbor2==5.6.5

--- a/e2e-tests/tests/reserve/conftest.py
+++ b/e2e-tests/tests/reserve/conftest.py
@@ -5,6 +5,8 @@ from src.cardano_cli import cbor_to_bech32, hex_to_bech32
 from src.partner_chains_node.models import Reserve, VFunction
 import json
 import logging
+import binascii
+import cbor2
 
 
 def pytest_collection_modifyitems(items):
@@ -202,14 +204,32 @@ def attach_v_function_to_utxo(transaction_input, governance_address, cardano_pay
     return _attach_v_function_to_utxo
 
 
+def unwrap_cbor(data: bytes) -> bytes:
+    """Decode CBOR until we get raw bytes (Plutus script code)."""
+    decoded = cbor2.loads(data)
+    while isinstance(decoded, bytes):
+        try:
+            decoded = cbor2.loads(decoded)
+        except Exception:
+            break
+    return decoded
+
+
 @fixture(scope="package")
 def reference_utxo(api: BlockchainApi):
 
     def _reference_utxo(v_function_address, cbor):
+        target_inner = unwrap_cbor(binascii.unhexlify(cbor))
+
         utxo_dict = api.cardano_cli.get_utxos(v_function_address)
-        reference_utxo = next(
-            filter(lambda utxo: utxo_dict[utxo]["referenceScript"]["script"]["cborHex"] == cbor, utxo_dict), None
-        )
-        return reference_utxo
+
+        # Find the UTxO whose reference script matches (after CBOR unwrapping)
+        for utxo, details in utxo_dict.items():
+            ref_cbor_hex = details["referenceScript"]["script"]["cborHex"]
+            ref_inner = unwrap_cbor(binascii.unhexlify(ref_cbor_hex))
+            if ref_inner == target_inner:
+                return utxo
+
+        return None
 
     return _reference_utxo


### PR DESCRIPTION
# Description

changed:
- reference_utxo fixture is now unwrapping cborHex to compare raw plutus  script, omitting cbor byte length header, useful in cardano-node 10.4.1

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
