### PR TITLE
ci: run fmt check first and test all-features to avoid recompilation for clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,17 +158,17 @@ jobs:
             echo "sccache not in devshell; skipping wrapper."
           fi
 
-      - name: Build
-        run: nix develop -c bash -c "cargo build --locked --profile=release"
-
-      - name: Test
-        run: nix develop -c bash -c "cargo test --locked --profile=release --features=runtime-benchmarks"
-
-      - name: Lint
-        run: nix develop -c bash -c "RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features"
-
       - name: Formatting
         run: nix develop -c bash -c "cargo fmt --check"
+
+      - name: Build
+        run: nix develop -c bash -c "cargo build --locked --release"
+
+      - name: Test
+        run: nix develop -c bash -c "cargo test --locked --release --all-features"
+
+      - name: Lint
+        run: nix develop -c bash -c "RUSTFLAGS=-Dwarnings cargo clippy --locked --release --all-features"
 
       - name: sccache stats
         if: always()
@@ -899,17 +899,17 @@ jobs:
             echo "sccache not in devshell; skipping wrapper."
           fi
 
-      - name: Build
-        run: nix develop -c bash -c "cargo build --locked --profile=release"
-
-      - name: Test
-        run: nix develop -c bash -c "cargo test --locked --profile=release --features=runtime-benchmarks"
-
-      - name: Lint
-        run: nix develop -c bash -c "RUSTFLAGS=-Dwarnings cargo clippy --all-targets --all-features"
-
       - name: Formatting
         run: nix develop -c bash -c "cargo fmt --check"
+
+      - name: Build
+        run: nix develop -c bash -c "cargo build --locked --release"
+
+      - name: Test
+        run: nix develop -c bash -c "cargo test --locked --release --all-features"
+
+      - name: Lint
+        run: nix develop -c bash -c "RUSTFLAGS=-Dwarnings cargo clippy --locked --release --all-features"
 
       - name: sccache stats
         if: always()


### PR DESCRIPTION
* Format check first, because it is the cheapest and fastest check
* Use --all-features in test - it still tests runtime-benchmarks but clippy doesn't need to recompile dependencies