### PR TITLE
bugfix: do not count irrelevant tokens transfer to ICS validator count

### DIFF
--- a/toolkit/data-sources/db-sync/src/lib.rs
+++ b/toolkit/data-sources/db-sync/src/lib.rs
@@ -188,7 +188,7 @@ pub(crate) type Result<T> = std::result::Result<T, DataSourceError>;
 mod tests {
 	use ctor::{ctor, dtor};
 	use std::sync::OnceLock;
-	use testcontainers_modules::testcontainers::Container;
+	use testcontainers_modules::testcontainers::{Container, RunnableImage};
 	use testcontainers_modules::{postgres::Postgres as PostgresImg, testcontainers::clients::Cli};
 
 	static POSTGRES: OnceLock<Container<PostgresImg>> = OnceLock::new();
@@ -196,7 +196,7 @@ mod tests {
 
 	fn init_postgres() -> Container<'static, PostgresImg> {
 		let docker = CLI.get_or_init(Cli::default);
-		docker.run(PostgresImg::default())
+		docker.run(RunnableImage::from(PostgresImg::default()).with_tag("17.2"))
 	}
 
 	#[ctor]

--- a/toolkit/data-sources/db-sync/testdata/native-token/migrations/2_data.sql
+++ b/toolkit/data-sources/db-sync/testdata/native-token/migrations/2_data.sql
@@ -88,7 +88,7 @@ INSERT INTO tx_out
 VALUES
 ( transfer_utxo_id_1      , transfer_tx_id_1      , 0    , validator_addr  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
 ( transfer_utxo_id_2      , transfer_tx_id_2      , 1    , validator_addr  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
-( irrelevant_utxo_id_1    , irrelevant_tx_id      , 0    , 'other_addr'    , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
+( irrelevant_utxo_id_1    , irrelevant_tx_id      , 0    , validator_addr  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
 ( irrelevant_utxo_id_2    , irrelevant_tx_id      , 1    , 'another_addr'  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
 ( transfer_utxo_id_3      , transfer_tx_id_3      , 2    , validator_addr  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),
 ( transfer_utxo_id_4      , transfer_tx_id_4      , 0    , validator_addr  , ''         , TRUE              , NULL        , NULL            , 0    , NULL      ),


### PR DESCRIPTION
# Description

Before the left join was counting in also other tokens transfer.
I've adjusted test data for this case by making irrelevant token transfer to the validator address.

EXPLAIN ANALYZE that I have run for ci-preview addresses and huge blocks range shown that this query is cheaper than the previous one.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [x] Any changes are noted in the `changelog.md` for affected crate - this is fix to unreleased code, so I don't write it
- [x] Self-reviewed the diff
