### PR TITLE
change: Bridge data sources code improvements

### DIFF
--- a/toolkit/data-sources/db-sync/src/bridge/mod.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/mod.rs
@@ -75,10 +75,14 @@ observed_async_trait!(
 								"Could not find block info for data checkpoint: {data_checkpoint:?}"
 							),
 						)?;
-					BridgeCheckpoint::Utxo { block_number, tx_ix, tx_out_ix: utxo.index.into() }
+					ResolvedBridgeDataCheckpoint::Utxo {
+						block_number,
+						tx_ix,
+						tx_out_ix: utxo.index.into(),
+					}
 				},
 				BridgeDataCheckpoint::Block(number) => {
-					BridgeCheckpoint::Block { number: number.into() }
+					ResolvedBridgeDataCheckpoint::Block { number: number.into() }
 				},
 			};
 

--- a/toolkit/smart-contracts/offchain/src/bridge/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/mod.rs
@@ -75,13 +75,13 @@ async fn submit_deposit_only_tx<
 	let signed_tx = ctx.sign(&tx).to_bytes();
 	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
 		anyhow::anyhow!(
-			"Reserve release transaction request failed: {}, tx bytes: {}",
+			"Bridge transfer transaction request failed: {}, tx bytes: {}",
 			e,
 			hex::encode(signed_tx)
 		)
 	})?;
 	let tx_id = res.transaction.id;
-	log::info!("Reserve release transaction submitted: {}", hex::encode(tx_id));
+	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 	Ok(McTxHash(tx_id))
 }
@@ -187,13 +187,13 @@ async fn submit_tx<
 	let signed_tx = ctx.sign(&tx).to_bytes();
 	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
 		anyhow::anyhow!(
-			"Reserve release transaction request failed: {}, tx bytes: {}",
+			"Bridge transfer transaction request failed: {}, tx bytes: {}",
 			e,
 			hex::encode(signed_tx)
 		)
 	})?;
 	let tx_id = res.transaction.id;
-	log::info!("Reserve release transaction submitted: {}", hex::encode(tx_id));
+	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
 	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
 	Ok(McTxHash(tx_id))
 }

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -664,7 +664,7 @@ async fn run_bridge_deposit_to_without_ics_spend<
 		&[1u8; 32],
 		&governance_authority_payment_key(),
 		client,
-		&FixedDelayRetries::new(Duration::from_millis(50), 100),
+		&FixedDelayRetries::new(Duration::from_millis(50), 150),
 	)
 	.await
 	.unwrap()


### PR DESCRIPTION
# Description

Some follow ups for the db-sync data source for the bridge:
- renamed `BridgeCheckpoint` to `ResolvedBridgeDataCheckpoint`
- renamed and specialized the functions used when creating `ResolvedBridgeDataCheckpoint` to already return this type
- merged the two `tx-in` variants of the query into single function, as there's only one section that is different (this query will be further simplified if/when we get rid of the non-cached data source)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
