### PR TITLE
fix: Datum handling in bridge data source

### DIFF
--- a/toolkit/data-sources/db-sync/src/bridge/mod.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/mod.rs
@@ -122,7 +122,11 @@ where
 
 	let token_amount = token_delta.0 as u64;
 
-	let transfer = match TokenTransferDatum::try_from(utxo.datum.0.clone()) {
+	let Some(datum) = utxo.datum.clone() else {
+		return Some(BridgeTransferV1::InvalidTransfer { token_amount, utxo_id: utxo.utxo_id() });
+	};
+
+	let transfer = match TokenTransferDatum::try_from(datum.0) {
 		Ok(TokenTransferDatum::V1(TokenTransferDatumV1::UserTransfer { receiver })) => {
 			match RecipientAddress::try_from(receiver.0.as_ref()) {
 				Ok(recipient) => BridgeTransferV1::UserTransfer { token_amount, recipient },

--- a/toolkit/data-sources/db-sync/src/bridge/tests.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/tests.rs
@@ -191,7 +191,7 @@ with_migration_versions_and_caching! {
 	async fn gets_transfers_from_init_to_block_4(data_source: &dyn TokenBridgeDataSource<ByteString>) {
 		let data_checkpoint = BridgeDataCheckpoint::Utxo(last_ics_init_utxo());
 		let current_mc_block = block_4_hash();
-		let max_transfers = 4;
+		let max_transfers = 5;
 
 		let (transfers, new_checkpoint) = data_source
 			.get_transfers(main_chain_scripts(), data_checkpoint, max_transfers, current_mc_block)
@@ -210,7 +210,7 @@ with_migration_versions_and_caching! {
 	async fn accepts_block_checkpoint(data_source: &dyn TokenBridgeDataSource<ByteString>) {
 		let data_checkpoint = BridgeDataCheckpoint::Block(McBlockNumber(1));
 		let current_mc_block = block_4_hash();
-		let max_transfers = 4;
+		let max_transfers = 5;
 
 		let (transfers, new_checkpoint) = data_source
 			.get_transfers(main_chain_scripts(), data_checkpoint, max_transfers, current_mc_block)

--- a/toolkit/data-sources/db-sync/src/bridge/tests.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/tests.rs
@@ -65,6 +65,7 @@ fn user_transfer_2() -> BridgeTransferV1<ByteString> {
 	}
 }
 
+// transfer with invalid datum
 fn invalid_transfer_1() -> BridgeTransferV1<ByteString> {
 	BridgeTransferV1::InvalidTransfer {
 		// invalid transfer consumes utxo from user transfer 2
@@ -73,6 +74,7 @@ fn invalid_transfer_1() -> BridgeTransferV1<ByteString> {
 	}
 }
 
+// transfer with no datum
 fn invalid_transfer_2() -> BridgeTransferV1<ByteString> {
 	BridgeTransferV1::InvalidTransfer { token_amount: 1000, utxo_id: invalid_transfer_2_utxo() }
 }

--- a/toolkit/data-sources/db-sync/src/bridge/tests.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/tests.rs
@@ -73,6 +73,10 @@ fn invalid_transfer_1() -> BridgeTransferV1<ByteString> {
 	}
 }
 
+fn invalid_transfer_2() -> BridgeTransferV1<ByteString> {
+	BridgeTransferV1::InvalidTransfer { token_amount: 1000, utxo_id: invalid_transfer_2_utxo() }
+}
+
 fn reserve_transfer_utxo() -> UtxoId {
 	UtxoId::new(hex!("c000000000000000000000000000000000000000000000000000000000000002"), 0)
 }
@@ -83,6 +87,10 @@ fn user_transfer_1_utxo() -> UtxoId {
 
 fn invalid_transfer_1_utxo() -> UtxoId {
 	UtxoId::new(hex!("c000000000000000000000000000000000000000000000000000000000000005"), 0)
+}
+
+fn invalid_transfer_2_utxo() -> UtxoId {
+	UtxoId::new(hex!("c000000000000000000000000000000000000000000000000000000000000006"), 0)
 }
 
 fn main_chain_scripts() -> MainChainScripts {
@@ -201,10 +209,10 @@ with_migration_versions_and_caching! {
 		// There's three valid transfers and one invalid done between blocks 2 and 4
 		assert_eq!(
 			transfers,
-			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1()]
+			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1(), invalid_transfer_2()]
 		);
 
-		assert_eq!(new_checkpoint, BridgeDataCheckpoint::Utxo(invalid_transfer_1_utxo()))
+		assert_eq!(new_checkpoint, BridgeDataCheckpoint::Utxo(invalid_transfer_2_utxo()))
 	}
 
 	async fn accepts_block_checkpoint(data_source: &dyn TokenBridgeDataSource<ByteString>) {
@@ -220,10 +228,10 @@ with_migration_versions_and_caching! {
 		// There's three valid transfers and one invalid done between blocks 2 and 4
 		assert_eq!(
 			transfers,
-			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1()]
+			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1(), invalid_transfer_2()]
 		);
 
-		assert_eq!(new_checkpoint, BridgeDataCheckpoint::Utxo(invalid_transfer_1_utxo()))
+		assert_eq!(new_checkpoint, BridgeDataCheckpoint::Utxo(invalid_transfer_2_utxo()))
 	}
 
 	async fn returns_block_checkpoint_when_no_transfers_are_found(data_source: &dyn TokenBridgeDataSource<ByteString>) {
@@ -253,7 +261,7 @@ with_migration_versions_and_caching! {
 
 		assert_eq!(
 			transfers,
-			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1()]
+			vec![reserve_transfer(), user_transfer_1(), user_transfer_2(), invalid_transfer_1(), invalid_transfer_2()]
 		);
 
 		assert_eq!(new_checkpoint, BridgeDataCheckpoint::Block(McBlockNumber(8)))

--- a/toolkit/data-sources/db-sync/src/bridge/tests.rs
+++ b/toolkit/data-sources/db-sync/src/bridge/tests.rs
@@ -99,6 +99,8 @@ macro_rules! with_migration_versions_and_caching {
 		$(
 		mod $name {
 			use super::*;
+			#[allow(unused_imports)]
+			use pretty_assertions::assert_eq;
 
 			async fn $name($data_source: &dyn TokenBridgeDataSource<ByteString>) $body
 
@@ -120,8 +122,6 @@ macro_rules! with_migration_versions_and_caching {
 
 			mod cached {
 				use super::*;
-				#[allow(unused_imports)]
-				use pretty_assertions::assert_eq;
 
 				#[sqlx::test(migrations = "./testdata/bridge/migrations-tx-in-enabled")]
 				async fn tx_in_enabled(pool: PgPool) {

--- a/toolkit/data-sources/db-sync/src/db_model.rs
+++ b/toolkit/data-sources/db-sync/src/db_model.rs
@@ -1038,7 +1038,7 @@ async fn get_bridge_utxos_tx_in_consumed(
 	JOIN block                     ON tx.block_id = block.id
 	JOIN ma_tx_out   output_tokens ON output_tokens.tx_out_id = outputs.id
 	JOIN multi_asset native_token  ON native_token.id = output_tokens.ident
-	JOIN datum                     ON datum.tx_id = tx.id
+	JOIN datum                     ON datum.hash = outputs.data_hash
 
 	LEFT JOIN tx_out     inputs        ON inputs.consumed_by_tx_id = tx.id   AND inputs.address = $1
 	LEFT JOIN ma_tx_out  input_tokens  ON input_tokens.tx_out_id = inputs.id AND input_tokens.ident = native_token.id
@@ -1105,7 +1105,7 @@ async fn get_bridge_utxos_tx_in_enabled(
 	JOIN block                     ON tx.block_id = block.id
 	JOIN ma_tx_out   output_tokens ON output_tokens.tx_out_id = outputs.id
 	JOIN multi_asset native_token  ON native_token.id = output_tokens.ident
-	JOIN datum                     ON datum.tx_id = tx.id
+	JOIN datum                     ON datum.hash = outputs.data_hash
 
 	LEFT JOIN tx_in      inputs_join   ON tx.id = inputs_join.tx_in_id
 	LEFT JOIN tx_out     inputs        ON inputs_join.tx_out_id = inputs.tx_id and inputs_join.tx_out_index = inputs.index AND inputs.address = $1

--- a/toolkit/data-sources/db-sync/src/db_model.rs
+++ b/toolkit/data-sources/db-sync/src/db_model.rs
@@ -930,7 +930,7 @@ pub(crate) struct BridgeUtxo {
 	pub(crate) utxo_ix: TxIndex,
 	pub(crate) tokens_out: NativeTokenAmount,
 	pub(crate) tokens_in: NativeTokenAmount,
-	pub(crate) datum: DbDatum,
+	pub(crate) datum: Option<DbDatum>,
 }
 #[cfg(feature = "bridge")]
 impl BridgeUtxo {
@@ -1038,7 +1038,7 @@ async fn get_bridge_utxos_tx_in_consumed(
 	JOIN block                     ON tx.block_id = block.id
 	JOIN ma_tx_out   output_tokens ON output_tokens.tx_out_id = outputs.id
 	JOIN multi_asset native_token  ON native_token.id = output_tokens.ident
-	JOIN datum                     ON datum.hash = outputs.data_hash
+	LEFT JOIN datum                ON datum.hash = outputs.data_hash
 
 	LEFT JOIN tx_out     inputs        ON inputs.consumed_by_tx_id = tx.id   AND inputs.address = $1
 	LEFT JOIN ma_tx_out  input_tokens  ON input_tokens.tx_out_id = inputs.id AND input_tokens.ident = native_token.id
@@ -1105,7 +1105,7 @@ async fn get_bridge_utxos_tx_in_enabled(
 	JOIN block                     ON tx.block_id = block.id
 	JOIN ma_tx_out   output_tokens ON output_tokens.tx_out_id = outputs.id
 	JOIN multi_asset native_token  ON native_token.id = output_tokens.ident
-	JOIN datum                     ON datum.hash = outputs.data_hash
+	LEFT JOIN datum                ON datum.hash = outputs.data_hash
 
 	LEFT JOIN tx_in      inputs_join   ON tx.id = inputs_join.tx_in_id
 	LEFT JOIN tx_out     inputs        ON inputs_join.tx_out_id = inputs.tx_id and inputs_join.tx_out_index = inputs.index AND inputs.address = $1

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
@@ -38,6 +38,7 @@ DECLARE
  user_transfer_tx_1 integer := 21;
  user_transfer_tx_2 integer  := 22;
  invalid_transfer_tx_1 integer  := 31;
+ invalid_transfer_tx_2 integer  := 32;
  irrelevant_tx integer  := 41;
 
  -- those hashes are not really important but putting them in variables help to make the data more readable
@@ -46,6 +47,7 @@ DECLARE
  user_transfer_tx_hash_1 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000003','hex');
  user_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000004','hex');
  ivalid_transfer_tx_hash_1 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000005','hex');
+ ivalid_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000006','hex');
  irrelevant_tx_hash hash32type := decode('4242424242424242424242424242424242424242424242424242424242424242','hex');
 
  reserve_transfer_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
@@ -62,6 +64,7 @@ INSERT INTO tx ( id                    , hash                       , block_id, 
               ,( user_transfer_tx_1    , user_transfer_tx_hash_1    , 2       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
               ,( user_transfer_tx_2    , user_transfer_tx_hash_2    , 4       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
               ,( invalid_transfer_tx_1 , ivalid_transfer_tx_hash_1  , 4       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
+              ,( invalid_transfer_tx_2 , ivalid_transfer_tx_hash_2  , 4       , 2          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
 ;
 
 
@@ -74,7 +77,8 @@ INSERT INTO tx_out ( id, tx_id                 , index, address     , address_ra
                   ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , reserve_transfer_datum_hash , user_transfer_tx_1    ) -- transfers 100 tokens
                   ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_1   , user_transfer_tx_2    ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo, consumes `irrelevant_tx#0`
                   ,( 32, user_transfer_tx_2    , 1    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_2   , invalid_transfer_tx_1 ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
-                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      , NULL                  ) -- invalid transfer
+                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      , NULL                  ) -- invalid transfer, with invalid datum
+                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        , NULL                  ) -- invalid transfer, no datum
 ;
 
 INSERT INTO datum ( id, hash                        , tx_id                  , value            )
@@ -94,7 +98,8 @@ VALUES                (11 , 100      , 21        , native_token_id )
                      ,(12 , 110      , 31        , native_token_id )
                      ,(13 , 120      , 32        , native_token_id )
                      ,(14 , 1000     , 41        , native_token_id )
-                     ,(15 , 1000     , 15        , native_token_id )
+                     ,(15 , 1000     , 42        , native_token_id )
+                     ,(16 , 1000     , 15        , native_token_id )
 
                      ,(21 , 9999     , 21        , irrelevant_token_id )
                      ,(22 , 9999     , 31        , irrelevant_token_id )

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-consumed/6_insert_transactions.sql
@@ -30,7 +30,6 @@ DECLARE
 
 
  native_token_policy hash28type := decode('500000000000000000000000000000000000434845434b504f494e69', 'hex');
- irrelevant_token_policy hash28type := decode('50000000000000000000000000000000000000000000000000000042', 'hex');
  native_token_id integer := 1;
  irrelevant_token_id integer := 2;
 
@@ -79,10 +78,10 @@ INSERT INTO tx_out ( id, tx_id                 , index, address     , address_ra
 ;
 
 INSERT INTO datum ( id, hash                        , tx_id                  , value            )
-           VALUES ( 0 , reserve_transfer_datum_hash , reserve_transfer_tx    , reserve_datum    )
-                 ,( 1 , user_tranfer_datum_hash_2   , user_transfer_tx_1     , transfer_datum_1 )
-                 ,( 2 , user_tranfer_datum_hash_2   , user_transfer_tx_2     , transfer_datum_2 )
-                 ,( 3 , invalid_transfer_datum      , invalid_transfer_tx_1  , invalid_datum    )
+           VALUES ( 0 , reserve_transfer_datum_hash , irrelevant_tx          , reserve_datum    )
+                 ,( 1 , user_tranfer_datum_hash_1   , irrelevant_tx          , transfer_datum_1 )
+                 ,( 2 , user_tranfer_datum_hash_2   , irrelevant_tx          , transfer_datum_2 )
+                 ,( 3 , invalid_transfer_datum      , irrelevant_tx          , invalid_datum    )
 ;
 
 INSERT INTO multi_asset ( id                  , policy                  , name               , fingerprint       )

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
@@ -38,6 +38,7 @@ DECLARE
  user_transfer_tx_1 integer := 21;
  user_transfer_tx_2 integer  := 22;
  invalid_transfer_tx_1 integer  := 31;
+ invalid_transfer_tx_2 integer  := 32;
  irrelevant_tx integer  := 41;
 
  -- those hashes are not really important but putting them in variables help to make the data more readable
@@ -46,6 +47,7 @@ DECLARE
  user_transfer_tx_hash_1 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000003','hex');
  user_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000004','hex');
  ivalid_transfer_tx_hash_1 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000005','hex');
+ ivalid_transfer_tx_hash_2 hash32type := decode('c000000000000000000000000000000000000000000000000000000000000006','hex');
  irrelevant_tx_hash hash32type := decode('4242424242424242424242424242424242424242424242424242424242424242','hex');
 
  reserve_transfer_datum_hash hash32type := decode('0000000000000000000000000000000000000000000000000000000000000001','hex');
@@ -62,6 +64,7 @@ INSERT INTO tx ( id                    , hash                       , block_id, 
               ,( user_transfer_tx_1    , user_transfer_tx_hash_1    , 2       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
               ,( user_transfer_tx_2    , user_transfer_tx_hash_2    , 4       , 0          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
               ,( invalid_transfer_tx_1 , ivalid_transfer_tx_hash_1  , 4       , 1          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
+              ,( invalid_transfer_tx_2 , ivalid_transfer_tx_hash_2  , 4       , 2          , 0      , 0  , 0      , 1024, NULL          , NULL             , TRUE          , 1024        )
 ;
 
 
@@ -74,7 +77,8 @@ INSERT INTO tx_out ( id, tx_id                 , index, address     , address_ra
                   ,( 21, reserve_transfer_tx   , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , reserve_transfer_datum_hash ) -- transfers 100 tokens
                   ,( 31, user_transfer_tx_1    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_1   ) -- transfers 10 tokens + 100 tokens from previous transaction's utxo
                   ,( 32, user_transfer_tx_2    , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , user_tranfer_datum_hash_2   ) -- transfers 10 tokens + 110 tokens from previous transaction's utxo
-                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      ) -- invalid transfer
+                  ,( 41, invalid_transfer_tx_1 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , invalid_transfer_datum      ) -- invalid transfer, invalid datum
+                  ,( 42, invalid_transfer_tx_2 , 0    , 'ics address', ''         , TRUE              , NULL        , NULL            , 0    , NULL                        ) -- invalid transfer, no datum
 ;
 
 INSERT INTO datum ( id, hash                        , tx_id                  , value            )
@@ -94,7 +98,8 @@ VALUES                (11 , 100      , 21        , native_token_id )
                      ,(12 , 110      , 31        , native_token_id )
                      ,(13 , 120      , 32        , native_token_id )
                      ,(14 , 1000     , 41        , native_token_id )
-                     ,(15 , 1000     , 15        , native_token_id )
+                     ,(15 , 1000     , 42        , native_token_id )
+                     ,(16 , 1000     , 15        , native_token_id )
 
                      ,(21 , 9999     , 21        , irrelevant_token_id )
                      ,(22 , 9999     , 31        , irrelevant_token_id )

--- a/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
+++ b/toolkit/data-sources/db-sync/testdata/bridge/migrations-tx-in-enabled/6_insert_transactions.sql
@@ -78,10 +78,10 @@ INSERT INTO tx_out ( id, tx_id                 , index, address     , address_ra
 ;
 
 INSERT INTO datum ( id, hash                        , tx_id                  , value            )
-           VALUES ( 0 , reserve_transfer_datum_hash , reserve_transfer_tx    , reserve_datum    )
-                 ,( 1 , user_tranfer_datum_hash_2   , user_transfer_tx_1     , transfer_datum_1 )
-                 ,( 2 , user_tranfer_datum_hash_2   , user_transfer_tx_2     , transfer_datum_2 )
-                 ,( 3 , invalid_transfer_datum      , invalid_transfer_tx_1  , invalid_datum    )
+           VALUES ( 0 , reserve_transfer_datum_hash , irrelevant_tx          , reserve_datum    )
+                 ,( 1 , user_tranfer_datum_hash_1   , irrelevant_tx          , transfer_datum_1 )
+                 ,( 2 , user_tranfer_datum_hash_2   , irrelevant_tx          , transfer_datum_2 )
+                 ,( 3 , invalid_transfer_datum      , irrelevant_tx          , invalid_datum    )
 ;
 
 INSERT INTO multi_asset ( id                  , policy              , name               , fingerprint       )


### PR DESCRIPTION
# Description

Fixes two issues:
1. Joining `datum` table on incorrect column
2. Reads the datum as optional and treats datum-less utxos with token as invalid transfers

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
