### PR TITLE
fix: don't read bridge token from Reserve Settings

### DIFF
--- a/e2e-tests/src/partner_chains_node/smart_contracts.py
+++ b/e2e-tests/src/partner_chains_node/smart_contracts.py
@@ -176,7 +176,7 @@ class SmartContracts:
         response = self.run_command.exec(cmd)
         return parse_json_response(response)
 
-    def bridge(self, genesis_utxo: str, amount, pc_address, payment_key, spend_ics_utxo):
+    def bridge(self, genesis_utxo: str, token, amount, pc_address, payment_key, spend_ics_utxo):
         if spend_ics_utxo:
             simple_param = ""
         else:
@@ -185,6 +185,7 @@ class SmartContracts:
             f"{self.cli} smart-contracts bridge "
             f"--payment-key-file {payment_key} "
             f"--genesis-utxo {genesis_utxo} "
+            f"--token {token} "
             f"--amount {amount} "
             f"--pc-address {pc_address} "
             f"{simple_param}"

--- a/e2e-tests/tests/reserve/test_reserve_management.py
+++ b/e2e-tests/tests/reserve/test_reserve_management.py
@@ -228,23 +228,23 @@ class TestUpdateVFunction:
 
 class TestBridge:
 
-    @mark.usefixtures("create_reserve")
+    @mark.usefixtures("init_reserve")
     def test_lock_without_spending_ics_utxo(self, api: BlockchainApi, genesis_utxo, payment_key, reserve_asset_id, node_1_aura_pub_key, wait_until, config: ApiConfig):
         amount = 1
         balance_before = api.get_pc_balance(node_1_aura_pub_key)
         assert balance_before > 0, "Test account is not over existential limit"
-        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = False)
+        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, reserve_asset_id, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = False)
         wait_until(
             lambda: api.get_pc_balance(node_1_aura_pub_key) == balance_before + amount,
             timeout=config.timeouts.main_chain_tx * config.main_chain.security_param * 2,
         )
 
-    @mark.usefixtures("create_reserve")
+    @mark.usefixtures("init_reserve")
     def test_lock_with_spending_ics_utxo(self, api: BlockchainApi, genesis_utxo, payment_key, reserve_asset_id, node_1_aura_pub_key, wait_until, config: ApiConfig):
         amount = 1
         balance_before = api.get_pc_balance(node_1_aura_pub_key)
         assert balance_before > 0, "Test account is not over existential limit"
-        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = True)
+        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, reserve_asset_id, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = True)
         wait_until(
             lambda: api.get_pc_balance(node_1_aura_pub_key) == balance_before + amount,
             timeout=config.timeouts.main_chain_tx * config.main_chain.security_param * 2,

--- a/toolkit/smart-contracts/commands/src/bridge.rs
+++ b/toolkit/smart-contracts/commands/src/bridge.rs
@@ -1,5 +1,6 @@
 use crate::{GenesisUtxo, PaymentFilePath, transaction_submitted_json};
 use partner_chains_cardano_offchain::bridge::{deposit_with_ics_spend, deposit_without_ics_input};
+use sidechain_domain::AssetId;
 use sp_runtime::AccountId32;
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -8,6 +9,8 @@ pub struct BridgeCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
 	#[arg(long)]
+	/// AssetId of tokens to transfer
+	token: AssetId,
 	/// Number of tokens to transfer
 	amount: u64,
 	#[arg(long)]
@@ -32,6 +35,7 @@ impl BridgeCmd {
 		let tx_hash = if self.simple {
 			deposit_without_ics_input(
 				self.genesis_utxo.into(),
+				self.token,
 				self.amount,
 				self.pc_address.as_ref(),
 				&payment_key,
@@ -42,6 +46,7 @@ impl BridgeCmd {
 		} else {
 			deposit_with_ics_spend(
 				self.genesis_utxo.into(),
+				self.token,
 				self.amount,
 				self.pc_address.as_ref(),
 				&payment_key,

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -250,6 +250,7 @@ async fn bridge_deposits() {
 	let container = image.start().await.unwrap();
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_governance(&client).await;
+	// TODO: replace 'reserve init' with `bridge init` and remove `reserve_create`
 	let _ = run_init_reserve_management(genesis_utxo, &client).await;
 	let _ = run_create_reserve_management(genesis_utxo, V_FUNCTION_HASH, &client).await;
 	let ics_utxos_count_0 = get_isc_utxos_count(genesis_utxo, &client).await;
@@ -658,8 +659,13 @@ async fn run_bridge_deposit_to_without_ics_spend<
 	genesis_utxo: UtxoId,
 	client: &T,
 ) -> McTxHash {
+	let token = AssetId {
+		policy_id: REWARDS_TOKEN_POLICY_ID,
+		asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
+	};
 	bridge::deposit_without_ics_input(
 		genesis_utxo,
+		token,
 		DEPOSIT_AMOUNT,
 		&[1u8; 32],
 		&governance_authority_payment_key(),
@@ -676,8 +682,13 @@ async fn run_bridge_deposit_to_with_ics_spend<
 	genesis_utxo: UtxoId,
 	client: &T,
 ) -> McTxHash {
+	let token = AssetId {
+		policy_id: REWARDS_TOKEN_POLICY_ID,
+		asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
+	};
 	bridge::deposit_with_ics_spend(
 		genesis_utxo,
+		token,
 		DEPOSIT_AMOUNT,
 		&[2u8; 32],
 		&governance_authority_payment_key(),


### PR DESCRIPTION
# Description

Removes reading tokens to transfer from current reserve settings, removing dependency on reserve