### PR TITLE
Split ICS (bridge) from reserve init and create - Part 1

### DIFF
--- a/e2e-tests/src/partner_chains_node/smart_contracts.py
+++ b/e2e-tests/src/partner_chains_node/smart_contracts.py
@@ -176,15 +176,16 @@ class SmartContracts:
         response = self.run_command.exec(cmd)
         return parse_json_response(response)
 
-    def bridge(self, genesis_utxo: str, amount, pc_address, payment_key, spend_ics_utxo):
+    def bridge(self, genesis_utxo: str, token, amount, pc_address, payment_key, spend_ics_utxo):
         if spend_ics_utxo:
             simple_param = ""
         else:
             simple_param = "--simple "
         cmd = (
-            f"{self.cli} smart-contracts bridge "
+            f"{self.cli} smart-contracts bridge deposit "
             f"--payment-key-file {payment_key} "
             f"--genesis-utxo {genesis_utxo} "
+            f"--token {token} "
             f"--amount {amount} "
             f"--pc-address {pc_address} "
             f"{simple_param}"

--- a/e2e-tests/tests/reserve/test_reserve_management.py
+++ b/e2e-tests/tests/reserve/test_reserve_management.py
@@ -233,7 +233,7 @@ class TestBridge:
         amount = 1
         balance_before = api.get_pc_balance(node_1_aura_pub_key)
         assert balance_before > 0, "Test account is not over existential limit"
-        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = False)
+        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, reserve_asset_id, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = False)
         wait_until(
             lambda: api.get_pc_balance(node_1_aura_pub_key) == balance_before + amount,
             timeout=config.timeouts.main_chain_tx * config.main_chain.security_param * 2,
@@ -244,7 +244,7 @@ class TestBridge:
         amount = 1
         balance_before = api.get_pc_balance(node_1_aura_pub_key)
         assert balance_before > 0, "Test account is not over existential limit"
-        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = True)
+        api.partner_chains_node.smart_contracts.bridge(genesis_utxo, reserve_asset_id, amount, node_1_aura_pub_key, payment_key, spend_ics_utxo = True)
         wait_until(
             lambda: api.get_pc_balance(node_1_aura_pub_key) == balance_before + amount,
             timeout=config.timeouts.main_chain_tx * config.main_chain.security_param * 2,

--- a/toolkit/smart-contracts/commands/src/bridge.rs
+++ b/toolkit/smart-contracts/commands/src/bridge.rs
@@ -1,12 +1,100 @@
 use crate::{GenesisUtxo, PaymentFilePath, transaction_submitted_json};
-use partner_chains_cardano_offchain::bridge::{deposit_with_ics_spend, deposit_without_ics_input};
+use partner_chains_cardano_offchain::bridge::{
+	create_validator_utxos, deposit_with_ics_spend, deposit_without_ics_input, init_ics_scripts,
+};
+use sidechain_domain::AssetId;
 use sp_runtime::AccountId32;
 
+#[derive(Clone, Debug, clap::Subcommand)]
+/// Command to initialize and make deposits to the bridge
+pub enum BridgeCmd {
+	/// Initialize Bridge Smart Conctracts in the Versioning System
+	Init(BridgeInitCmd),
+	/// Create UTXOs with special tokens at the Bridge Validator. These tokens are used to help with coin selection problem.
+	CreateUtxos(BridgeCreateUtxosCmd),
+	/// Deposits tokens from payment key wallet to the reserve
+	Deposit(BridgeDepositCmd),
+}
+
+impl BridgeCmd {
+	/// Executes the internal command
+	pub async fn execute(self) -> crate::SubCmdResult {
+		match self {
+			Self::Init(cmd) => cmd.execute().await,
+			Self::CreateUtxos(cmd) => cmd.execute().await,
+			Self::Deposit(cmd) => cmd.execute().await,
+		}
+	}
+}
+
 #[derive(Clone, Debug, clap::Parser)]
-/// Command for sending a native token bridge transfer. Token to be sent is defined in the Reserve Settings.
-pub struct BridgeCmd {
+/// Initializes bridge smart contracts in the versioning system.
+pub struct BridgeInitCmd {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+	#[clap(flatten)]
+	/// Path to the payment key file
+	payment_key_file: PaymentFilePath,
+	#[clap(flatten)]
+	/// Genesis UTXO
+	genesis_utxo: GenesisUtxo,
+}
+
+impl BridgeInitCmd {
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let payment_key = self.payment_key_file.read_key()?;
+		let client = self.common_arguments.get_ogmios_client().await?;
+		let result = init_ics_scripts(
+			self.genesis_utxo.into(),
+			&payment_key,
+			&client,
+			&self.common_arguments.retries(),
+		)
+		.await?;
+		Ok(serde_json::json!(result))
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+/// Create UTXOs with special tokens at the Bridge Validator. These tokens are used to help with coin selection problem.
+pub struct BridgeCreateUtxosCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[clap(flatten)]
+	/// Path to the payment key file
+	payment_key_file: PaymentFilePath,
+	#[clap(flatten)]
+	/// Genesis UTXO
+	genesis_utxo: GenesisUtxo,
+	#[arg(long)]
+	/// Number of UTXOs to create
+	amount: u64,
+}
+
+impl BridgeCreateUtxosCmd {
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let payment_key = self.payment_key_file.read_key()?;
+		let client = self.common_arguments.get_ogmios_client().await?;
+		let result = create_validator_utxos(
+			self.genesis_utxo.into(),
+			self.amount,
+			&payment_key,
+			&client,
+			&self.common_arguments.retries(),
+		)
+		.await?;
+		Ok(serde_json::json!(result))
+	}
+}
+
+#[derive(Clone, Debug, clap::Parser)]
+/// Command for sending a native token bridge transfer.
+pub struct BridgeDepositCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long)]
+	/// AssetId of tokens to transfer
+	token: AssetId,
 	#[arg(long)]
 	/// Number of tokens to transfer
 	amount: u64,
@@ -24,14 +112,15 @@ pub struct BridgeCmd {
 	genesis_utxo: GenesisUtxo,
 }
 
-impl BridgeCmd {
-	/// Creates the D-parameter and upserts it on the main chain.
+impl BridgeDepositCmd {
+	/// Deposits user token in the Bridge.
 	pub async fn execute(self) -> crate::SubCmdResult {
 		let payment_key = self.payment_key_file.read_key()?;
 		let client = self.common_arguments.get_ogmios_client().await?;
 		let tx_hash = if self.simple {
 			deposit_without_ics_input(
 				self.genesis_utxo.into(),
+				self.token,
 				self.amount,
 				self.pc_address.as_ref(),
 				&payment_key,
@@ -42,6 +131,7 @@ impl BridgeCmd {
 		} else {
 			deposit_with_ics_spend(
 				self.genesis_utxo.into(),
+				self.token,
 				self.amount,
 				self.pc_address.as_ref(),
 				&payment_key,

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -70,6 +70,7 @@ pub enum SmartContractsCmd {
 	#[command(subcommand)]
 	/// Manage the Governed Map key-value store on Cardano
 	GovernedMap(governed_map::GovernedMapCmd),
+	#[command(subcommand)]
 	/// Send token to bridge contract
 	Bridge(bridge::BridgeCmd),
 }

--- a/toolkit/smart-contracts/offchain/src/bridge/create_utxos.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/create_utxos.rs
@@ -1,0 +1,94 @@
+use crate::{
+	await_tx::AwaitTx,
+	bridge::ICSData,
+	cardano_keys::CardanoPaymentSigningKey,
+	csl::{
+		Costs, MultiAssetExt, OgmiosUtxoExt, Script, TransactionBuilderExt, TransactionContext,
+		TransactionExt, TransactionOutputAmountBuilderExt, get_builder_config, unit_plutus_data,
+	},
+	governance::GovernanceData,
+	multisig::{MultiSigSmartContractResult, submit_or_create_tx_to_sign},
+	scripts_data::ICSScripts,
+};
+use cardano_serialization_lib::{
+	Int, JsError, MultiAsset, Transaction, TransactionBuilder, TransactionOutput,
+	TransactionOutputBuilder,
+};
+use ogmios_client::{
+	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
+	query_network::QueryNetwork,
+	transactions::Transactions,
+};
+use sidechain_domain::UtxoId;
+
+/// Creates "blessed" UTXOs at the ICS (Bridge) validator.
+pub async fn create_validator_utxos<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	amount: u64,
+	payment_key: &CardanoPaymentSigningKey,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<MultiSigSmartContractResult> {
+	let payment_ctx = TransactionContext::for_payment_key(payment_key, client).await?;
+	let governance = GovernanceData::get(genesis_utxo, client).await?;
+	let ics_data = ICSData::get(genesis_utxo, &payment_ctx, client).await?;
+
+	submit_or_create_tx_to_sign(
+		&governance,
+		payment_ctx,
+		|costs, ctx| create_reserve_tx(amount, &ics_data, &governance, costs, &ctx),
+		"Create Bridge UTXOs",
+		client,
+		await_tx,
+	)
+	.await
+}
+
+fn create_reserve_tx(
+	amount: u64,
+	ics_data: &ICSData,
+	governance: &GovernanceData,
+	costs: Costs,
+	ctx: &TransactionContext,
+) -> anyhow::Result<Transaction> {
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+
+	let gov_tx_input = governance.utxo_id_as_tx_input();
+	tx_builder.add_mint_one_script_token_using_reference_script(
+		&governance.policy.script(),
+		&gov_tx_input,
+		&costs,
+	)?;
+
+	tx_builder.add_mint_script_token_using_reference_script(
+		&Script::Plutus(ics_data.scripts.auth_policy.clone()),
+		&ics_data.auth_policy_version_utxo.to_csl_tx_input(),
+		&Int::new(&amount.into()),
+		&costs,
+	)?;
+	// Create ICS Authorized Outputs. These contain special ICS Authority Token,
+	// that prevents UTxOs from being merged all into one.
+	for _ in 0u64..amount {
+		tx_builder.add_output(&ics_validator_output(&ics_data.scripts, ctx)?)?;
+	}
+
+	let tx = tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses();
+
+	Ok(tx)
+}
+
+fn ics_validator_output(
+	scripts: &ICSScripts,
+	ctx: &TransactionContext,
+) -> Result<TransactionOutput, JsError> {
+	let amount_builder = TransactionOutputBuilder::new()
+		.with_address(&scripts.validator.address(ctx.network))
+		.with_plutus_data(&unit_plutus_data())
+		.next()?;
+	let ma = MultiAsset::new().with_asset_amount(&scripts.auth_policy.empty_name_asset(), 1u64)?;
+
+	amount_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()
+}

--- a/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
@@ -1,4 +1,4 @@
-//! Bride transaction deposits an UTXO that contains the specified token at the IlliquidCirculationSupplyValidator.
+//! Bridge transaction deposits an UTXO that contains the specified token at the IlliquidCirculationSupplyValidator.
 //! Such transaction can either be simple deposit or can involve consuming exactly one UTXO from
 //! the ICS Validator that has special token (for some reason called 'auth token').
 //! The former increases the number of UTXOs at ICS Validator, but the latter preserve it.

--- a/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/deposit.rs
@@ -1,0 +1,256 @@
+//! Bride transaction deposits an UTXO that contains the specified token at the IlliquidCirculationSupplyValidator.
+//! Such transaction can either be simple deposit or can involve consuming exactly one UTXO from
+//! the ICS Validator that has special token (for some reason called 'auth token').
+//! The former increases the number of UTXOs at ICS Validator, but the latter preserve it.
+//! Arbitrary number of UTXOs that does not have 'auth token' could be consumed, to decrese the number
+//! of UTXOs, but it is not implemented yet.
+
+use crate::{
+	TokenAmount,
+	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
+	csl::{
+		CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
+		TransactionOutputAmountBuilderExt, get_builder_config,
+	},
+};
+use cardano_serialization_lib::{
+	Address, AssetName, BigNum, MultiAsset, PlutusData, ScriptHash, Transaction,
+	TransactionBuilder, TransactionOutputBuilder, TxInputsBuilder,
+};
+use ogmios_client::{
+	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
+	query_network::QueryNetwork,
+	transactions::Transactions,
+	types::OgmiosUtxo,
+};
+use partner_chains_plutus_data::bridge::TokenTransferDatumV1;
+use sidechain_domain::{AssetId, McTxHash, UtxoId, byte_string::ByteString, crypto::blake2b};
+
+use super::{ICSData, add_ics_utxo_input_with_validator_script_reference};
+
+/// This function deposits bridge token to the Illiquid Circulation Supply from the payment wallet.
+/// It does not consume existing UTXO at the validator address.
+///  - `genesis_utxo`: UTxO identifying the Partner Chain.
+///  - `amount` number of tokens to be deposited.
+///  - `pc_address` information to partner chain node, where to transfer funds
+///  - `payment_signing_key`: Signing key of the party paying fees.
+///  - `await_tx`: [AwaitTx] strategy.
+pub async fn deposit_without_ics_input<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	token: AssetId,
+	amount: u64,
+	pc_address: &[u8],
+	payment_signing_key: &CardanoPaymentSigningKey,
+	client: &C,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
+	let ctx = TransactionContext::for_payment_key(payment_signing_key, client).await?;
+	let scripts = crate::scripts_data::get_scripts_data(genesis_utxo, ctx.network)?;
+	let ics_address =
+		Address::from_bech32(&scripts.addresses.illiquid_circulation_supply_validator)?;
+	let tx_hash = submit_deposit_only_tx(
+		&ics_address,
+		TokenAmount { token, amount },
+		pc_address,
+		&ctx,
+		client,
+		await_tx,
+	)
+	.await?;
+	Ok(tx_hash)
+}
+
+async fn submit_deposit_only_tx<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	ics_address: &Address,
+	amount: TokenAmount,
+	pc_address: &[u8],
+	ctx: &TransactionContext,
+	client: &C,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
+	let tx = deposit_only_tx(ics_address, amount, pc_address, ctx)?;
+	let signed_tx = ctx.sign(&tx).to_bytes();
+	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+		anyhow::anyhow!(
+			"Bridge transfer transaction request failed: {}, tx bytes: {}",
+			e,
+			hex::encode(signed_tx)
+		)
+	})?;
+	let tx_id = res.transaction.id;
+	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
+	Ok(McTxHash(tx_id))
+}
+
+fn deposit_only_tx(
+	ics_address: &Address,
+	token_amount: TokenAmount,
+	pc_address: &[u8],
+	ctx: &TransactionContext,
+) -> anyhow::Result<Transaction> {
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	let output_builder = TransactionOutputBuilder::new()
+		.with_address(ics_address)
+		.with_plutus_data(&to_user_transfer_datum(pc_address))
+		.next()?;
+	let ma = MultiAsset::new().with_asset_amount(&token_amount.token, token_amount.amount)?;
+	let output = output_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
+	tx_builder.add_output(&output)?;
+	Ok(tx_builder.balance_update_and_build(ctx)?)
+}
+
+/// This function deposits bridge token to the Illiquid Circulation Supply from the payment wallet.
+/// It does spend existing UTXO (containing 'auth token') at the validator address.
+///  - `genesis_utxo`: UTxO identifying the Partner Chain.
+///  - `amount` number of tokens to be deposited.
+///  - `pc_address` information to partner chain node, where to transfer funds
+///  - `payment_signing_key`: Signing key of the party paying fees.
+///  - `await_tx`: [AwaitTx] strategy.
+pub async fn deposit_with_ics_spend<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	token: AssetId,
+	amount: u64,
+	pc_address: &[u8],
+	payment_signing_key: &CardanoPaymentSigningKey,
+	client: &C,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
+	let ctx = TransactionContext::for_payment_key(payment_signing_key, client).await?;
+	let scripts = crate::scripts_data::get_scripts_data(genesis_utxo, ctx.network)?;
+	let ics_data = ICSData::get(genesis_utxo, &ctx, client).await?;
+	let token_amount = TokenAmount { token, amount };
+	let ics_address =
+		Address::from_bech32(&scripts.addresses.illiquid_circulation_supply_validator)?;
+	let ics_utxos = ics_data.get_validator_utxos_with_auth_token(&ctx, client).await?;
+	let ics_utxo_to_spend = select_utxo_to_spend(&ics_utxos, &ctx).ok_or(anyhow::anyhow!(
+		"Cannot find UTXOs with an 'auth token' at ICS Validator! Use simple deposit instead."
+	))?;
+	let tx_hash = submit_tx(
+		&ics_address,
+		&ics_utxo_to_spend,
+		&ics_data,
+		token_amount,
+		pc_address,
+		&ctx,
+		client,
+		await_tx,
+	)
+	.await?;
+	Ok(tx_hash)
+}
+
+// Selects one from input utxos. To avoid randomness we take the one that combined with user own utxo has the lowest hash.
+fn select_utxo_to_spend(utxos: &[OgmiosUtxo], ctx: &TransactionContext) -> Option<OgmiosUtxo> {
+	utxos
+		.into_iter()
+		.map(|u| {
+			let utxo_id = u.utxo_id();
+			let mut v: Vec<u8> = utxo_id.tx_hash.0.to_vec();
+			v.append(&mut utxo_id.index.0.to_be_bytes().to_vec());
+			v.append(&mut ctx.payment_key_hash().to_bytes());
+			let hash: [u8; 32] = blake2b(&v);
+			(hash, u)
+		})
+		.min_by_key(|k| k.0)
+		.map(|kv| kv.1.clone())
+}
+
+async fn submit_tx<
+	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	ics_address: &Address,
+	ics_utxo: &OgmiosUtxo,
+	ics_data: &ICSData,
+	amount: TokenAmount,
+	pc_address: &[u8],
+	ctx: &TransactionContext,
+	client: &C,
+	await_tx: &A,
+) -> anyhow::Result<McTxHash> {
+	let tx = Costs::calculate_costs(
+		|costs| deposit_tx(ics_address, ics_utxo, ics_data, amount.clone(), pc_address, ctx, costs),
+		client,
+	)
+	.await?;
+
+	let signed_tx = ctx.sign(&tx).to_bytes();
+	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
+		anyhow::anyhow!(
+			"Bridge transfer transaction request failed: {}, tx bytes: {}",
+			e,
+			hex::encode(signed_tx)
+		)
+	})?;
+	let tx_id = res.transaction.id;
+	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
+	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
+	Ok(McTxHash(tx_id))
+}
+
+fn deposit_tx(
+	ics_address: &Address,
+	ics_utxo: &OgmiosUtxo,
+	ics_data: &ICSData,
+	token_amount: TokenAmount,
+	pc_address: &[u8],
+	ctx: &TransactionContext,
+	costs: Costs,
+) -> anyhow::Result<Transaction> {
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	let output_builder = TransactionOutputBuilder::new()
+		.with_address(ics_address)
+		.with_plutus_data(&to_user_transfer_datum(pc_address))
+		.next()?;
+	let mut ma = ics_utxo
+		.to_csl()
+		.unwrap()
+		.output()
+		.amount()
+		.multiasset()
+		.expect("ics_utxo has at least 'auth token'");
+	let policy_id = ScriptHash::from(token_amount.token.policy_id.0);
+	let mut assets = ma.get(&policy_id).unwrap_or_default();
+	let asset_name = AssetName::new(token_amount.token.asset_name.0.to_vec())
+		.expect("asset name that comes from ogmios is valid");
+	let amount = assets.get(&asset_name).unwrap_or_default();
+	assets.insert(&asset_name, &amount.checked_add(&BigNum::from(token_amount.amount))?);
+	let _ = ma.insert(&policy_id, &assets);
+	let output = output_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
+	tx_builder.add_output(&output)?;
+
+	let mut inputs = TxInputsBuilder::new();
+	add_ics_utxo_input_with_validator_script_reference(
+		&mut inputs,
+		ics_utxo,
+		ics_data,
+		&costs.get_one_spend(),
+	)?;
+	tx_builder.set_inputs(&inputs);
+
+	tx_builder.add_script_reference_input(
+		&ics_data.validator_version_utxo.to_csl_tx_input(),
+		ics_data.scripts.validator.bytes.len(),
+	);
+	tx_builder.add_script_reference_input(
+		&ics_data.auth_policy_version_utxo.to_csl_tx_input(),
+		ics_data.scripts.auth_policy.bytes.len(),
+	);
+
+	Ok(tx_builder.balance_update_and_build(ctx)?)
+}
+
+fn to_user_transfer_datum(pc_address: &[u8]) -> PlutusData {
+	TokenTransferDatumV1::UserTransfer { receiver: ByteString(pc_address.to_vec()) }.into()
+}

--- a/toolkit/smart-contracts/offchain/src/bridge/init.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/init.rs
@@ -1,0 +1,56 @@
+use crate::{
+	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
+	multisig::MultiSigSmartContractResult,
+	plutus_script,
+	versioning_system::{ScriptData, initialize_script},
+};
+use ogmios_client::{
+	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
+	query_network::QueryNetwork,
+	transactions::Transactions,
+};
+use raw_scripts::{
+	ILLIQUID_CIRCULATION_SUPPLY_AUTHORITY_TOKEN_POLICY, ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
+	ScriptId,
+};
+use sidechain_domain::UtxoId;
+
+/// Stores smart contracts used for bridge (Illiquid Circulation Supply) in the versioning system.
+/// Scripts stored are:
+///  - Illiquid Circulation Supply Validator
+///  - Illiquid Circulation Auth Token Policy
+pub async fn init_ics_scripts<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	genesis_utxo: UtxoId,
+	payment_key: &CardanoPaymentSigningKey,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<Vec<MultiSigSmartContractResult>> {
+	let ics_validator = ScriptData::new(
+		"Illiquid Circulation Supply Validator",
+		ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR.0.to_vec(),
+		ScriptId::IlliquidCirculationSupplyValidator,
+	);
+	let ics_auth_token_policy = ScriptData::new(
+		"Illiquid Circulation Supply Auth Token Policy",
+		plutus_script![
+			ILLIQUID_CIRCULATION_SUPPLY_AUTHORITY_TOKEN_POLICY,
+			ScriptId::IlliquidCirculationSupplyAuthorityTokenPolicy
+		]?
+		.bytes
+		.to_vec(),
+		ScriptId::IlliquidCirculationSupplyAuthorityTokenPolicy,
+	);
+
+	Ok(vec![
+		initialize_script(ics_validator, genesis_utxo, payment_key, client, await_tx).await?,
+		initialize_script(ics_auth_token_policy, genesis_utxo, payment_key, client, await_tx)
+			.await?,
+	]
+	.into_iter()
+	.flatten()
+	.collect())
+}

--- a/toolkit/smart-contracts/offchain/src/bridge/mod.rs
+++ b/toolkit/smart-contracts/offchain/src/bridge/mod.rs
@@ -1,259 +1,108 @@
-//! Bride transaction deposit an UTXO that contains the token defined in the reserve settings
-//! at the IlliquidCirculationSupplyValidator.
-//! Such transaction can either be simple deposit or can involve consuming exactly one UTXO from
-//! the ICS Validator that has special token (for some reason called 'auth token').
-//! The former increases the number of UTXOs at ICS Validator, but the latter preserve it.
-//! Arbitrary number of UTXOs that does not have 'auth token' could be consumed, to decrese the number
-//! of UTXOs, but it is not implemented yet.
+//! Offchain actions to initialize bridge (IlliquidCirculionSupply) and make deposits.
 
-use crate::await_tx::AwaitTx;
-use crate::cardano_keys::CardanoPaymentSigningKey;
-use crate::csl::{
-	CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
-	TransactionOutputAmountBuilderExt, get_builder_config,
+mod create_utxos;
+mod deposit;
+mod init;
+
+use crate::{
+	csl::{OgmiosUtxoExt, OgmiosValueExt, TransactionContext},
+	scripts_data,
+	versioning_system::find_script_utxo,
 };
-use crate::reserve::{ReserveData, TokenAmount};
+use anyhow::anyhow;
 use cardano_serialization_lib::{
-	Address, AssetName, BigNum, MultiAsset, PlutusData, ScriptHash, Transaction,
-	TransactionBuilder, TransactionOutputBuilder, TxInputsBuilder,
+	BigInt, ExUnits, JsError, PlutusData, PlutusScriptSource, PlutusWitness, Redeemer, RedeemerTag,
+	TxInputsBuilder,
 };
-use ogmios_client::types::OgmiosUtxo;
-use ogmios_client::{
-	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
-	query_network::QueryNetwork,
-	transactions::Transactions,
-};
-use partner_chains_plutus_data::bridge::TokenTransferDatumV1;
-use sidechain_domain::byte_string::ByteString;
-use sidechain_domain::crypto::blake2b;
-use sidechain_domain::{McTxHash, UtxoId};
+pub use create_utxos::create_validator_utxos;
+pub use deposit::{deposit_with_ics_spend, deposit_without_ics_input};
+pub use init::init_ics_scripts;
+use ogmios_client::{query_ledger_state::QueryLedgerState, types::OgmiosUtxo};
+use sidechain_domain::{AssetId, AssetName, UtxoId};
 
-/// This function deposits bridge token to the Illiquid Circulation Supply from the payment wallet.
-/// It does not consume existing UTXO at the validator address.
-///  - `genesis_utxo`: UTxO identifying the Partner Chain.
-///  - `amount` number of tokens to be deposited.
-///  - `pc_address` information to partner chain node, where to transfer funds
-///  - `payment_signing_key`: Signing key of the party paying fees.
-///  - `await_tx`: [AwaitTx] strategy.
-pub async fn deposit_without_ics_input<
-	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
-	A: AwaitTx,
->(
-	genesis_utxo: UtxoId,
-	amount: u64,
-	pc_address: &[u8],
-	payment_signing_key: &CardanoPaymentSigningKey,
-	client: &C,
-	await_tx: &A,
-) -> anyhow::Result<McTxHash> {
-	let ctx = TransactionContext::for_payment_key(payment_signing_key, client).await?;
-	let scripts = crate::scripts_data::get_scripts_data(genesis_utxo, ctx.network)?;
-	let reserve = ReserveData::get(genesis_utxo, &ctx, client).await?;
-	let reserve_utxo = reserve.get_reserve_utxo(&ctx, client).await?;
-	let token = reserve_utxo.datum.immutable_settings.token;
-	let token_amount = TokenAmount { token, amount };
-	let ics_address =
-		Address::from_bech32(&scripts.addresses.illiquid_circulation_supply_validator)?;
-	let tx_hash =
-		submit_deposit_only_tx(&ics_address, token_amount, pc_address, &ctx, client, await_tx)
-			.await?;
-	Ok(tx_hash)
+#[derive(Clone, Debug)]
+pub(crate) struct ICSData {
+	pub(crate) scripts: scripts_data::ICSScripts,
+	pub(crate) auth_policy_version_utxo: OgmiosUtxo,
+	pub(crate) validator_version_utxo: OgmiosUtxo,
 }
 
-async fn submit_deposit_only_tx<
-	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
-	A: AwaitTx,
->(
-	ics_address: &Address,
-	amount: TokenAmount,
-	pc_address: &[u8],
-	ctx: &TransactionContext,
-	client: &C,
-	await_tx: &A,
-) -> anyhow::Result<McTxHash> {
-	let tx = deposit_only_tx(ics_address, amount, pc_address, ctx)?;
-	let signed_tx = ctx.sign(&tx).to_bytes();
-	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
-		anyhow::anyhow!(
-			"Bridge transfer transaction request failed: {}, tx bytes: {}",
-			e,
-			hex::encode(signed_tx)
+impl ICSData {
+	pub(crate) async fn get<T: QueryLedgerState>(
+		genesis_utxo: UtxoId,
+		ctx: &TransactionContext,
+		client: &T,
+	) -> Result<Self, anyhow::Error> {
+		let version_oracle = scripts_data::version_oracle(genesis_utxo, ctx.network)?;
+		let validator_version_utxo = find_script_utxo(
+			raw_scripts::ScriptId::IlliquidCirculationSupplyValidator as u32,
+			&version_oracle,
+			ctx,
+			client,
 		)
-	})?;
-	let tx_id = res.transaction.id;
-	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
-	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
-	Ok(McTxHash(tx_id))
-}
-
-fn deposit_only_tx(
-	ics_address: &Address,
-	token_amount: TokenAmount,
-	pc_address: &[u8],
-	ctx: &TransactionContext,
-) -> anyhow::Result<Transaction> {
-	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
-	let output_builder = TransactionOutputBuilder::new()
-		.with_address(ics_address)
-		.with_plutus_data(&to_user_transfer_datum(pc_address))
-		.next()?;
-	let ma = MultiAsset::new().with_asset_amount(&token_amount.token, token_amount.amount)?;
-	let output = output_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
-	tx_builder.add_output(&output)?;
-	Ok(tx_builder.balance_update_and_build(ctx)?)
-}
-
-/// This function deposits bridge token to the Illiquid Circulation Supply from the payment wallet.
-/// It does spend existing UTXO (containing 'auth token') at the validator address.
-///  - `genesis_utxo`: UTxO identifying the Partner Chain.
-///  - `amount` number of tokens to be deposited.
-///  - `pc_address` information to partner chain node, where to transfer funds
-///  - `payment_signing_key`: Signing key of the party paying fees.
-///  - `await_tx`: [AwaitTx] strategy.
-pub async fn deposit_with_ics_spend<
-	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
-	A: AwaitTx,
->(
-	genesis_utxo: UtxoId,
-	amount: u64,
-	pc_address: &[u8],
-	payment_signing_key: &CardanoPaymentSigningKey,
-	client: &C,
-	await_tx: &A,
-) -> anyhow::Result<McTxHash> {
-	let ctx = TransactionContext::for_payment_key(payment_signing_key, client).await?;
-	let scripts = crate::scripts_data::get_scripts_data(genesis_utxo, ctx.network)?;
-	let reserve = ReserveData::get(genesis_utxo, &ctx, client).await?;
-	let reserve_utxo = reserve.get_reserve_utxo(&ctx, client).await?;
-	let token = reserve_utxo.datum.immutable_settings.token;
-	let token_amount = TokenAmount { token, amount };
-	let ics_address =
-		Address::from_bech32(&scripts.addresses.illiquid_circulation_supply_validator)?;
-	let ics_utxos = reserve.get_illiquid_circulation_supply_utxos(&ctx, client).await?;
-	let ics_utxo_to_spend = select_utxo_to_spend(&ics_utxos, &ctx).ok_or(anyhow::anyhow!(
-		"Cannot find UTXOs with an 'auth token' at ICS Validator! Use simple deposit instead."
-	))?;
-	let tx_hash = submit_tx(
-		&ics_address,
-		&ics_utxo_to_spend,
-		&reserve,
-		token_amount,
-		pc_address,
-		&ctx,
-		client,
-		await_tx,
-	)
-	.await?;
-	Ok(tx_hash)
-}
-
-// Selects one from input utxos. To avoid randomness we take the one that combined with user own utxo has the lowest hash.
-fn select_utxo_to_spend(utxos: &[OgmiosUtxo], ctx: &TransactionContext) -> Option<OgmiosUtxo> {
-	utxos
-		.into_iter()
-		.map(|u| {
-			let utxo_id = u.utxo_id();
-			let mut v: Vec<u8> = utxo_id.tx_hash.0.to_vec();
-			v.append(&mut utxo_id.index.0.to_be_bytes().to_vec());
-			v.append(&mut ctx.payment_key_hash().to_bytes());
-			let hash: [u8; 32] = blake2b(&v);
-			(hash, u)
-		})
-		.min_by_key(|k| k.0)
-		.map(|kv| kv.1.clone())
-}
-
-async fn submit_tx<
-	C: QueryLedgerState + QueryNetwork + Transactions + QueryUtxoByUtxoId,
-	A: AwaitTx,
->(
-	ics_address: &Address,
-	ics_utxo: &OgmiosUtxo,
-	reserve_data: &ReserveData,
-	amount: TokenAmount,
-	pc_address: &[u8],
-	ctx: &TransactionContext,
-	client: &C,
-	await_tx: &A,
-) -> anyhow::Result<McTxHash> {
-	let tx = Costs::calculate_costs(
-		|costs| {
-			deposit_tx(ics_address, ics_utxo, reserve_data, amount.clone(), pc_address, ctx, costs)
-		},
-		client,
-	)
-	.await?;
-
-	let signed_tx = ctx.sign(&tx).to_bytes();
-	let res = client.submit_transaction(&signed_tx).await.map_err(|e| {
-		anyhow::anyhow!(
-			"Bridge transfer transaction request failed: {}, tx bytes: {}",
-			e,
-			hex::encode(signed_tx)
+		.await?
+		.ok_or_else(|| {
+			anyhow!(
+				"Illiquid Circulation Supply Validator Version Utxo not found, is the Bridge initialized?"
+			)
+		})?;
+		let auth_policy_version_utxo = find_script_utxo(
+			raw_scripts::ScriptId::IlliquidCirculationSupplyAuthorityTokenPolicy as u32,
+			&version_oracle,
+			ctx,
+			client,
 		)
-	})?;
-	let tx_id = res.transaction.id;
-	log::info!("Bridge transfer transaction submitted: {}", hex::encode(tx_id));
-	await_tx.await_tx_output(client, McTxHash(tx_id)).await?;
-	Ok(McTxHash(tx_id))
+		.await?
+		.ok_or_else(|| {
+			anyhow!("Illiquid Circulation Supply Authority Token Policy Version Utxo not found, is the Bridge initialized?")
+		})?;
+		let scripts = scripts_data::ics_scripts(genesis_utxo, ctx.network)?;
+		Ok(ICSData { scripts, auth_policy_version_utxo, validator_version_utxo })
+	}
+
+	pub(crate) async fn get_validator_utxos_with_auth_token<T: QueryLedgerState>(
+		&self,
+		ctx: &TransactionContext,
+		client: &T,
+	) -> Result<Vec<OgmiosUtxo>, anyhow::Error> {
+		let validator_address = self.scripts.validator.address(ctx.network).to_bech32(None)?;
+		let validator_utxos = client.query_utxos(&[validator_address]).await?;
+
+		let auth_token_asset_id = AssetId {
+			policy_id: self.scripts.auth_policy.policy_id(),
+			asset_name: AssetName::empty(),
+		};
+
+		Ok(validator_utxos
+			.into_iter()
+			.filter(|utxo| utxo.get_asset_amount(&auth_token_asset_id) == 1u64)
+			.collect())
+	}
 }
 
-fn deposit_tx(
-	ics_address: &Address,
+pub(crate) fn add_ics_utxo_input_with_validator_script_reference(
+	inputs: &mut TxInputsBuilder,
 	ics_utxo: &OgmiosUtxo,
-	reserve_data: &ReserveData,
-	token_amount: TokenAmount,
-	pc_address: &[u8],
-	ctx: &TransactionContext,
-	costs: Costs,
-) -> anyhow::Result<Transaction> {
-	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
-	let output_builder = TransactionOutputBuilder::new()
-		.with_address(ics_address)
-		.with_plutus_data(&to_user_transfer_datum(pc_address))
-		.next()?;
-	let mut ma = ics_utxo
-		.to_csl()
-		.unwrap()
-		.output()
-		.amount()
-		.multiasset()
-		.expect("ics_utxo has at least 'auth token'");
-	let policy_id = ScriptHash::from(token_amount.token.policy_id.0);
-	let mut assets = ma.get(&policy_id).unwrap_or_default();
-	let asset_name = AssetName::new(token_amount.token.asset_name.0.to_vec())
-		.expect("asset name that comes from ogmios is valid");
-	let amount = assets.get(&asset_name).unwrap_or_default();
-	assets.insert(&asset_name, &amount.checked_add(&BigNum::from(token_amount.amount))?);
-	let _ = ma.insert(&policy_id, &assets);
-	let output = output_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
-	tx_builder.add_output(&output)?;
-
-	let mut inputs = TxInputsBuilder::new();
-	crate::reserve::add_ics_utxo_input_with_validator_script_reference(
-		&mut inputs,
-		ics_utxo,
-		reserve_data,
-		&costs.get_one_spend(),
-	)?;
-	tx_builder.set_inputs(&inputs);
-
-	tx_builder.add_script_reference_input(
-		&reserve_data
-			.illiquid_circulation_supply_validator_version_utxo
-			.to_csl_tx_input(),
-		reserve_data.scripts.illiquid_circulation_supply_validator.bytes.len(),
+	ics_data: &ICSData,
+	cost: &ExUnits,
+) -> Result<(), JsError> {
+	let input = ics_utxo.to_csl_tx_input();
+	let amount = ics_utxo.value.to_csl()?;
+	let script = &ics_data.scripts.validator;
+	let witness = PlutusWitness::new_with_ref_without_datum(
+		&PlutusScriptSource::new_ref_input(
+			&script.csl_script_hash(),
+			&ics_data.validator_version_utxo.to_csl_tx_input(),
+			&script.language,
+			script.bytes.len(),
+		),
+		&Redeemer::new(
+			&RedeemerTag::new_spend(),
+			&0u32.into(),
+			&PlutusData::new_integer(&BigInt::zero()),
+			cost,
+		),
 	);
-	tx_builder.add_script_reference_input(
-		&reserve_data
-			.illiquid_circulation_supply_authority_token_policy_version_utxo
-			.to_csl_tx_input(),
-		reserve_data.scripts.illiquid_circulation_supply_auth_token_policy.bytes.len(),
-	);
-
-	Ok(tx_builder.balance_update_and_build(ctx)?)
-}
-
-fn to_user_transfer_datum(pc_address: &[u8]) -> PlutusData {
-	TokenTransferDatumV1::UserTransfer { receiver: ByteString(pc_address.to_vec()) }.into()
+	inputs.add_plutus_script_input(&witness, &input, &amount);
+	Ok(())
 }

--- a/toolkit/smart-contracts/offchain/src/lib.rs
+++ b/toolkit/smart-contracts/offchain/src/lib.rs
@@ -38,3 +38,14 @@ pub mod sign_tx;
 mod test_values;
 /// Supports governance updates
 pub mod update_governance;
+
+mod versioning_system;
+
+/// Simply wraps asset id with amount.
+#[derive(Clone)]
+pub struct TokenAmount {
+	/// The asset id
+	pub token: sidechain_domain::AssetId,
+	/// Amount of the assets
+	pub amount: u64,
+}

--- a/toolkit/smart-contracts/offchain/src/scripts_data.rs
+++ b/toolkit/smart-contracts/offchain/src/scripts_data.rs
@@ -72,19 +72,15 @@ pub fn get_scripts_data(
 	let committee_candidate_validator =
 		plutus_script![COMMITTEE_CANDIDATE_VALIDATOR, genesis_utxo]?;
 	let d_parameter_data = d_parameter_scripts(genesis_utxo, network)?;
-	let illiquid_circulation_supply_validator = plutus_script![
-		ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
-		version_oracle_data.policy_id_as_plutus_data()
-	]?;
 	let permissioned_candidates_data = permissioned_candidates_scripts(genesis_utxo, network)?;
 	let reserve = reserve_scripts(genesis_utxo, network)?;
+	let ics = ics_scripts(genesis_utxo, network)?;
 	let governed_map_data = governed_map_scripts(genesis_utxo, network)?;
 	Ok(ScriptsData {
 		addresses: Addresses {
 			committee_candidate_validator: committee_candidate_validator.address_bech32(network)?,
 			d_parameter_validator: d_parameter_data.validator_address.clone(),
-			illiquid_circulation_supply_validator: illiquid_circulation_supply_validator
-				.address_bech32(network)?,
+			illiquid_circulation_supply_validator: ics.validator.address_bech32(network)?,
 			permissioned_candidates_validator: permissioned_candidates_data
 				.validator_address
 				.clone(),
@@ -98,9 +94,7 @@ pub fn get_scripts_data(
 			reserve_auth: reserve.auth_policy.policy_id(),
 			version_oracle: version_oracle_data.policy_id(),
 			governed_map: governed_map_data.policy_id(),
-			illiquid_circulation_supply_auth_token: reserve
-				.illiquid_circulation_supply_auth_token_policy
-				.policy_id(),
+			illiquid_circulation_supply_auth_token: ics.auth_policy.policy_id(),
 		},
 	})
 }
@@ -222,6 +216,12 @@ pub(crate) struct ReserveScripts {
 	pub(crate) illiquid_circulation_supply_auth_token_policy: PlutusScript,
 }
 
+#[derive(Clone, Debug)]
+pub(crate) struct ICSScripts {
+	pub(crate) validator: PlutusScript,
+	pub(crate) auth_policy: PlutusScript,
+}
+
 pub(crate) fn reserve_scripts(
 	genesis_utxo: UtxoId,
 	network: NetworkIdKind,
@@ -246,6 +246,23 @@ pub(crate) fn reserve_scripts(
 		illiquid_circulation_supply_validator,
 		illiquid_circulation_supply_auth_token_policy,
 	})
+}
+
+pub(crate) fn ics_scripts(
+	genesis_utxo: UtxoId,
+	network: NetworkIdKind,
+) -> Result<ICSScripts, anyhow::Error> {
+	let version_oracle_data = version_oracle(genesis_utxo, network)?;
+	let validator = plutus_script![
+		ILLIQUID_CIRCULATION_SUPPLY_VALIDATOR,
+		version_oracle_data.policy_id_as_plutus_data()
+	]?;
+	let auth_policy = plutus_script![
+		ILLIQUID_CIRCULATION_SUPPLY_AUTHORITY_TOKEN_POLICY,
+		ScriptId::IlliquidCirculationSupplyAuthorityTokenPolicy,
+		version_oracle_data.policy_id_as_plutus_data()
+	]?;
+	Ok(ICSScripts { validator, auth_policy })
 }
 
 #[cfg(test)]

--- a/toolkit/smart-contracts/offchain/src/versioning_system.rs
+++ b/toolkit/smart-contracts/offchain/src/versioning_system.rs
@@ -1,0 +1,395 @@
+use crate::{
+	await_tx::AwaitTx,
+	cardano_keys::CardanoPaymentSigningKey,
+	csl::{
+		CostStore, Costs, MultiAssetExt, OgmiosUtxoExt, TransactionBuilderExt, TransactionContext,
+		TransactionExt, TransactionOutputAmountBuilderExt, get_builder_config,
+	},
+	governance::GovernanceData,
+	multisig::{MultiSigSmartContractResult, submit_or_create_tx_to_sign},
+	plutus_script::PlutusScript,
+	scripts_data::{self, PlutusScriptData},
+};
+use cardano_serialization_lib::{
+	AssetName, BigNum, ConstrPlutusData, JsError, MultiAsset, PlutusData, PlutusList, ScriptRef,
+	Transaction, TransactionBuilder, TransactionOutputBuilder,
+};
+use ogmios_client::{
+	query_ledger_state::{QueryLedgerState, QueryUtxoByUtxoId},
+	query_network::QueryNetwork,
+	transactions::Transactions,
+	types::OgmiosUtxo,
+};
+use partner_chains_plutus_data::version_oracle::VersionOracleDatum;
+use raw_scripts::ScriptId;
+use sidechain_domain::UtxoId;
+
+pub(crate) struct ScriptData {
+	name: String,
+	plutus_script: PlutusScript,
+	id: u32,
+}
+
+impl ScriptData {
+	pub(crate) fn new(name: &str, raw_bytes: Vec<u8>, id: ScriptId) -> Self {
+		let plutus_script =
+			PlutusScript::v2_from_cbor(&raw_bytes).expect("Plutus script should be valid");
+		Self { name: name.to_string(), plutus_script, id: id as u32 }
+	}
+
+	pub(crate) fn applied_plutus_script(
+		&self,
+		version_oracle: &PlutusScriptData,
+	) -> Result<PlutusScript, JsError> {
+		self.plutus_script
+			.clone()
+			.apply_data_uplc(version_oracle.policy_id_as_plutus_data())
+			.map_err(|e| JsError::from_str(&e.to_string()))
+	}
+}
+
+pub(crate) async fn initialize_script<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+	A: AwaitTx,
+>(
+	script: ScriptData,
+	genesis_utxo: UtxoId,
+	payment_key: &CardanoPaymentSigningKey,
+	client: &T,
+	await_tx: &A,
+) -> anyhow::Result<Option<MultiSigSmartContractResult>> {
+	let payment_ctx = TransactionContext::for_payment_key(payment_key, client).await?;
+	let governance = GovernanceData::get(genesis_utxo, client).await?;
+	let version_oracle = scripts_data::version_oracle(genesis_utxo, payment_ctx.network)?;
+
+	if script_is_initialized(&script, &version_oracle, &payment_ctx, client).await? {
+		log::info!("Script '{}' is already initialized", script.name);
+		return Ok(None);
+	}
+	Ok(Some(
+		submit_or_create_tx_to_sign(
+			&governance,
+			payment_ctx,
+			|costs, ctx| init_script_tx(&script, &governance, &version_oracle, costs, &ctx),
+			&format!("Init {}", script.name),
+			client,
+			await_tx,
+		)
+		.await?,
+	))
+}
+
+fn init_script_tx(
+	script: &ScriptData,
+	governance: &GovernanceData,
+	version_oracle: &PlutusScriptData,
+	costs: Costs,
+	ctx: &TransactionContext,
+) -> anyhow::Result<Transaction> {
+	let mut tx_builder = TransactionBuilder::new(&get_builder_config(ctx)?);
+	let applied_script = script.applied_plutus_script(version_oracle)?;
+	{
+		let witness = PlutusData::new_constr_plutus_data(&ConstrPlutusData::new(
+			&BigNum::one(),
+			&version_oracle_plutus_list(script.id, &applied_script.script_hash()),
+		));
+		tx_builder.add_mint_one_script_token(
+			&version_oracle.policy,
+			&version_oracle_asset_name(),
+			&witness,
+			&costs.get_mint(&version_oracle.policy.clone()),
+		)?;
+	}
+	{
+		let script_ref = ScriptRef::new_plutus_script(&applied_script.to_csl());
+		let amount_builder = TransactionOutputBuilder::new()
+			.with_address(&version_oracle.validator.address(ctx.network))
+			.with_plutus_data(&PlutusData::new_list(&version_oracle_plutus_list(
+				script.id,
+				&version_oracle.policy.script_hash(),
+			)))
+			.with_script_ref(&script_ref)
+			.next()?;
+		let ma = MultiAsset::new()
+			.with_asset_amount(&version_oracle.policy.asset(version_oracle_asset_name())?, 1u64)?;
+		let output = amount_builder.with_minimum_ada_and_asset(&ma, ctx)?.build()?;
+		tx_builder.add_output(&output)?;
+	}
+	// Mint governance token
+	let gov_tx_input = governance.utxo_id_as_tx_input();
+	tx_builder.add_mint_one_script_token_using_reference_script(
+		&governance.policy.script(),
+		&gov_tx_input,
+		&costs,
+	)?;
+	Ok(tx_builder.balance_update_and_build(ctx)?.remove_native_script_witnesses())
+}
+
+fn version_oracle_asset_name() -> AssetName {
+	AssetName::new(b"Version oracle".to_vec()).unwrap()
+}
+
+fn version_oracle_plutus_list(script_id: u32, script_hash: &[u8]) -> PlutusList {
+	let mut list = PlutusList::new();
+	list.add(&PlutusData::new_integer(&script_id.into()));
+	list.add(&PlutusData::new_bytes(script_hash.to_vec()));
+	list
+}
+
+// There exist UTXO at Version Oracle Validator with Datum that contains
+// * script id of the script being initialized
+// * Version Oracle Policy Id
+async fn script_is_initialized<T: QueryLedgerState>(
+	script: &ScriptData,
+	version_oracle: &PlutusScriptData,
+	ctx: &TransactionContext,
+	client: &T,
+) -> Result<bool, anyhow::Error> {
+	Ok(find_script_utxo(script.id, version_oracle, ctx, client).await?.is_some())
+}
+
+/// Finds an UTXO at Version Oracle Validator with Datum that contains
+/// * given script id
+/// * Version Oracle Policy Id
+pub(crate) async fn find_script_utxo<T: QueryLedgerState>(
+	script_id: u32,
+	version_oracle: &PlutusScriptData,
+	ctx: &TransactionContext,
+	client: &T,
+) -> Result<Option<OgmiosUtxo>, anyhow::Error> {
+	let validator_address = version_oracle.validator.address(ctx.network).to_bech32(None)?;
+	let validator_utxos = client.query_utxos(&[validator_address]).await?;
+	// Decode datum from utxos and check if it contains script id
+	Ok(validator_utxos.into_iter().find(|utxo| {
+		utxo.get_plutus_data()
+			.and_then(|data| TryInto::<VersionOracleDatum>::try_into(data).ok())
+			.is_some_and(|datum| {
+				datum.version_oracle == script_id
+					&& datum.currency_symbol == version_oracle.policy.script_hash()
+			})
+	}))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::{ScriptData, init_script_tx};
+	use crate::{
+		csl::{Costs, OgmiosUtxoExt, TransactionContext, unit_plutus_data},
+		governance::GovernanceData,
+		scripts_data::{self, PlutusScriptData},
+		test_values::{
+			make_utxo, payment_addr, payment_key, protocol_parameters, test_governance_policy,
+		},
+	};
+	use cardano_serialization_lib::{
+		AssetName, BigNum, ConstrPlutusData, ExUnits, Int, NetworkIdKind, PlutusData, PlutusList,
+		RedeemerTag, ScriptHash, Transaction,
+	};
+	use ogmios_client::types::{OgmiosTx, OgmiosUtxo};
+	use raw_scripts::ScriptId;
+	use sidechain_domain::UtxoId;
+
+	#[test]
+	fn init_script_tx_version_oracle_output_test() {
+		let outputs = make_init_script_tx().body().outputs();
+		let voo = outputs
+			.into_iter()
+			.find(|o| o.address() == version_oracle_validator_address())
+			.expect("Init Script Transaction should have output to Version Oracle Validator");
+		let voo_script_ref = voo
+			.script_ref()
+			.expect("Version Oracle Validator output should have script reference");
+		let voo_plutus_script = voo_script_ref
+			.plutus_script()
+			.expect("Script reference should be Plutus script");
+		assert_eq!(
+			voo_plutus_script,
+			test_initialized_script()
+				.applied_plutus_script(&version_oracle_data())
+				.unwrap()
+				.to_csl()
+		);
+		let amount = voo
+			.amount()
+			.multiasset()
+			.and_then(|ma| ma.get(&version_oracle_policy_csl_script_hash()))
+			.and_then(|vo_ma| vo_ma.get(&AssetName::new(b"Version oracle".to_vec()).unwrap()))
+			.expect("Version Oracle Validator output has a token of Version Oracle Policy");
+
+		assert_eq!(amount, 1u64.into());
+
+		let voo_plutus_data = voo
+			.plutus_data()
+			.and_then(|pd| pd.as_list())
+			.expect("Version Oracle Validator output should have Plutus Data of List type");
+		assert_eq!(
+			voo_plutus_data.get(0),
+			PlutusData::new_integer(&test_initialized_script().id.into())
+		);
+		assert_eq!(
+			voo_plutus_data.get(1),
+			PlutusData::new_bytes(version_oracle_data().policy.script_hash().to_vec())
+		);
+	}
+
+	#[test]
+	fn init_script_tx_change_output_test() {
+		let outputs = make_init_script_tx().body().outputs();
+		let change_output = outputs
+			.into_iter()
+			.find(|o| o.address() == payment_addr())
+			.expect("Change output has to be present to keep governance token")
+			.clone();
+		let gov_token_amount = change_output
+			.amount()
+			.multiasset()
+			.and_then(|ma| ma.get(&test_governance_data().policy.script().script_hash().into()))
+			.and_then(|gov_ma| gov_ma.get(&AssetName::new(vec![]).unwrap()))
+			.unwrap();
+		assert_eq!(gov_token_amount, BigNum::one(), "Change contains one governance token");
+	}
+
+	#[test]
+	fn init_script_tx_reference_input() {
+		// a script reference input of the current Governance UTXO
+		let ref_input = make_init_script_tx()
+			.body()
+			.reference_inputs()
+			.expect("Init transaction should have reference input")
+			.get(0);
+		assert_eq!(ref_input, test_governance_input().to_csl_tx_input());
+	}
+
+	#[test]
+	fn init_script_tx_mints() {
+		let tx = make_init_script_tx();
+		let vo_mint = tx
+			.body()
+			.mint()
+			.and_then(|mint| mint.get(&version_oracle_policy_csl_script_hash()))
+			.and_then(|assets| assets.get(0))
+			.and_then(|assets| assets.get(&AssetName::new(b"Version oracle".to_vec()).unwrap()))
+			.expect("Transaction should have a mint of Version Oracle Policy token");
+		assert_eq!(vo_mint, Int::new_i32(1));
+
+		let gov_mint = tx
+			.body()
+			.mint()
+			.and_then(|mint| mint.get(&test_governance_data().policy.script().script_hash().into()))
+			.and_then(|assets| assets.get(0))
+			.and_then(|assets| assets.get(&AssetName::new(vec![]).unwrap()))
+			.expect("Transaction should have a mint of Governance Policy token");
+		assert_eq!(gov_mint, Int::new_i32(1));
+	}
+
+	#[test]
+	fn init_script_tx_redeemers() {
+		// This is so cumbersome, because of the CSL interface for Redeemers
+		let ws = make_init_script_tx()
+			.witness_set()
+			.redeemers()
+			.expect("Transaction has two redeemers");
+		let redeemers = vec![ws.get(0), ws.get(1)];
+
+		let expected_vo_redeemer_data = {
+			let mut list = PlutusList::new();
+			let script_id: u64 = test_initialized_script().id.into();
+			list.add(&PlutusData::new_integer(&script_id.into()));
+			list.add(&PlutusData::new_bytes(
+				test_initialized_script()
+					.applied_plutus_script(&version_oracle_data())
+					.unwrap()
+					.script_hash()
+					.to_vec(),
+			));
+			let constr_plutus_data = ConstrPlutusData::new(&BigNum::one(), &list);
+			PlutusData::new_constr_plutus_data(&constr_plutus_data)
+		};
+
+		let _ = redeemers
+			.iter()
+			.find(|r| {
+				r.tag() == RedeemerTag::new_mint()
+					&& r.data() == expected_vo_redeemer_data
+					&& r.ex_units() == versioning_script_cost()
+			})
+			.expect("Transaction should have a mint redeemer for Version Oracle Policy");
+		let _ = redeemers
+			.iter()
+			.find(|r| {
+				r.tag() == RedeemerTag::new_mint()
+					&& r.data() == unit_plutus_data()
+					&& r.ex_units() == governance_script_cost()
+			})
+			.expect("Transaction should have a mint redeemer for Governance Policy");
+	}
+
+	fn make_init_script_tx() -> Transaction {
+		init_script_tx(
+			&test_initialized_script(),
+			&test_governance_data(),
+			&version_oracle_data(),
+			test_costs(),
+			&test_transaction_context(),
+		)
+		.unwrap()
+	}
+
+	fn test_initialized_script() -> ScriptData {
+		ScriptData::new(
+			"Test Script",
+			raw_scripts::RESERVE_VALIDATOR.0.to_vec(),
+			ScriptId::ReserveValidator,
+		)
+	}
+
+	fn test_governance_input() -> OgmiosUtxo {
+		OgmiosUtxo { transaction: OgmiosTx { id: [16; 32] }, index: 0, ..Default::default() }
+	}
+
+	fn test_governance_data() -> GovernanceData {
+		GovernanceData { policy: test_governance_policy(), utxo: test_governance_input() }
+	}
+
+	fn version_oracle_data() -> PlutusScriptData {
+		scripts_data::version_oracle(UtxoId::new([255u8; 32], 0), NetworkIdKind::Testnet).unwrap()
+	}
+
+	fn version_oracle_validator_address() -> cardano_serialization_lib::Address {
+		version_oracle_data().validator.address(NetworkIdKind::Testnet)
+	}
+
+	fn version_oracle_policy_csl_script_hash() -> ScriptHash {
+		version_oracle_data().policy.csl_script_hash()
+	}
+
+	fn test_transaction_context() -> TransactionContext {
+		TransactionContext {
+			payment_key: payment_key(),
+			payment_key_utxos: vec![make_utxo(121u8, 3, 996272387, &payment_addr())],
+			network: NetworkIdKind::Testnet,
+			protocol_parameters: protocol_parameters(),
+			change_address: payment_addr(),
+		}
+	}
+
+	fn governance_script_cost() -> ExUnits {
+		ExUnits::new(&100u64.into(), &200u64.into())
+	}
+
+	fn versioning_script_cost() -> ExUnits {
+		ExUnits::new(&300u64.into(), &400u64.into())
+	}
+
+	fn test_costs() -> Costs {
+		Costs::new(
+			vec![
+				(test_governance_policy().script().script_hash().into(), governance_script_cost()),
+				(version_oracle_policy_csl_script_hash(), versioning_script_cost()),
+			]
+			.into_iter()
+			.collect(),
+			std::collections::HashMap::new(),
+		)
+	}
+}

--- a/toolkit/smart-contracts/offchain/tests/integration_tests.rs
+++ b/toolkit/smart-contracts/offchain/tests/integration_tests.rs
@@ -250,8 +250,9 @@ async fn bridge_deposits() {
 	let container = image.start().await.unwrap();
 	let client = initialize(&container).await;
 	let genesis_utxo = run_init_governance(&client).await;
-	let _ = run_init_reserve_management(genesis_utxo, &client).await;
-	let _ = run_create_reserve_management(genesis_utxo, V_FUNCTION_HASH, &client).await;
+	let results = run_init_bridge(genesis_utxo, &client).await;
+	assert_eq!(results.len(), 2);
+	let _ = run_create_bridge_utxos(genesis_utxo, &client).await;
 	let ics_utxos_count_0 = get_isc_utxos_count(genesis_utxo, &client).await;
 	let _ = run_bridge_deposit_to_without_ics_spend(genesis_utxo, &client).await;
 	assert_illiquid_supply(genesis_utxo, DEPOSIT_AMOUNT, &client).await;
@@ -567,6 +568,41 @@ fn make_candidate(n: u8) -> PermissionedCandidateData {
 	}
 }
 
+async fn run_init_bridge<T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId>(
+	genesis_utxo: UtxoId,
+	client: &T,
+) -> Vec<MultiSigSmartContractResult> {
+	let results = bridge::init_ics_scripts(
+		genesis_utxo,
+		&governance_authority_payment_key(),
+		client,
+		&FixedDelayRetries::new(Duration::from_millis(500), 100),
+	)
+	.await
+	.unwrap();
+	results.iter().for_each(cleanup_temp_wallet_file);
+	results
+}
+
+async fn run_create_bridge_utxos<
+	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
+>(
+	genesis_utxo: UtxoId,
+	client: &T,
+) -> MultiSigSmartContractResult {
+	let result = bridge::create_validator_utxos(
+		genesis_utxo,
+		4,
+		&governance_authority_payment_key(),
+		client,
+		&FixedDelayRetries::new(Duration::from_millis(500), 100),
+	)
+	.await
+	.unwrap();
+	cleanup_temp_wallet_file(&result);
+	result
+}
+
 async fn run_init_reserve_management<
 	T: QueryLedgerState + Transactions + QueryNetwork + QueryUtxoByUtxoId,
 >(
@@ -658,8 +694,13 @@ async fn run_bridge_deposit_to_without_ics_spend<
 	genesis_utxo: UtxoId,
 	client: &T,
 ) -> McTxHash {
+	let token = AssetId {
+		policy_id: REWARDS_TOKEN_POLICY_ID,
+		asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
+	};
 	bridge::deposit_without_ics_input(
 		genesis_utxo,
+		token,
 		DEPOSIT_AMOUNT,
 		&[1u8; 32],
 		&governance_authority_payment_key(),
@@ -676,8 +717,13 @@ async fn run_bridge_deposit_to_with_ics_spend<
 	genesis_utxo: UtxoId,
 	client: &T,
 ) -> McTxHash {
+	let token = AssetId {
+		policy_id: REWARDS_TOKEN_POLICY_ID,
+		asset_name: AssetName::from_hex_unsafe(REWARDS_TOKEN_ASSET_NAME_STR),
+	};
 	bridge::deposit_with_ics_spend(
 		genesis_utxo,
+		token,
 		DEPOSIT_AMOUNT,
 		&[2u8; 32],
 		&governance_authority_payment_key(),


### PR DESCRIPTION
# Description

This PR:
* adds command `bridge init` to initialize ICS Validator and ICS Auth Policy scripts in Versioning System
* adds command `bridge create` to create UTXOs at ICS Validator (it requires `init` to be executed first, so it cannot be done during `init`).
* renames `bridge` to `bridge deposit`
* adds `token` parameter to `bridge deposit`, so token AssetId is not read from reserve settings

This PR does not (there will be follow up):
* remove duplicated code
* remove initialization of ICS Validator nor ICS Auth Policy from `reserve init`
* remove creating UTXOs at ICS Validator

