### PR TITLE
add 'pc-node smart-contracts upsert-script' command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8523,8 +8523,8 @@ dependencies = [
 
 [[package]]
 name = "raw-scripts"
-version = "8.1.0"
-source = "git+https://github.com/input-output-hk/partner-chains-smart-contracts.git?tag=v8.1.0#08bc5346d17d258ab84e4312e22339eaa1762c57"
+version = "8.2.0"
+source = "git+https://github.com/input-output-hk/partner-chains-smart-contracts.git?tag=v8.2.0#8d57492a9d9a8e3ccda4165bf2ec61f98aa9430c"
 dependencies = [
  "hex-literal 0.4.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -258,8 +258,7 @@ substrate-prometheus-endpoint = { package = "substrate-prometheus-endpoint", git
 substrate-test-runtime-client = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2506-2" }
 substrate-wasm-builder = { default-features = false, git = "https://github.com/paritytech/polkadot-sdk.git", tag = "polkadot-stable2506-2" }
 
-raw-scripts = { git = "https://github.com/input-output-hk/partner-chains-smart-contracts.git", tag = "v8.1.0" }
-
+raw-scripts = { git = "https://github.com/input-output-hk/partner-chains-smart-contracts.git", tag = "v8.2.0" }
 # local dependencies
 
 # utils

--- a/changelog.md
+++ b/changelog.md
@@ -6,11 +6,18 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Changed
 
+* **BREAKING**: Updated partner-chains-smart-contracts (raw-scripts) dependency to v8.2.0.
+  Possibility to interact with smart-contracts used by earlier versions is lost.
+  Governance authority will have to establish new partner chain on Cardano.
+  All initialization and candidates registrations have to be repeated.
+
 ## Removed
 
 ## Fixed
 
 ## Added
+
+* Added `partner-chains-node smart-contracts upsert-script` command for inserting and updating versioned scripts.
 
 # v1.8.0
 

--- a/toolkit/sidechain/domain/src/lib.rs
+++ b/toolkit/sidechain/domain/src/lib.rs
@@ -661,6 +661,11 @@ impl From<ecdsa::Public> for SidechainPublicKey {
 	}
 }
 
+/// CBOR bytes of Plutus smart contract.
+#[derive(Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq, Hash)]
+#[byte_string(debug, hex_serialize, hex_deserialize, decode_hex)]
+pub struct PlutusScriptCbor(pub Vec<u8>);
+
 /// CBOR bytes of Cardano Transaction.
 #[derive(Clone, Encode, Decode, DecodeWithMemTracking, TypeInfo, PartialEq, Eq, Hash)]
 #[byte_string(debug, hex_serialize, hex_deserialize, decode_hex)]

--- a/toolkit/smart-contracts/commands/src/lib.rs
+++ b/toolkit/smart-contracts/commands/src/lib.rs
@@ -42,6 +42,7 @@ pub mod permissioned_candidates;
 pub mod register;
 pub mod reserve;
 pub mod sign_tx;
+pub mod versioning;
 
 #[derive(Clone, Debug, clap::Subcommand)]
 #[allow(clippy::large_enum_variant)]
@@ -73,6 +74,8 @@ pub enum SmartContractsCmd {
 	#[command(subcommand)]
 	/// Send token to bridge contract
 	Bridge(bridge::BridgeCmd),
+	/// Upsert versioned smart contract
+	UpsertScript(versioning::UpsertScriptCmd),
 }
 
 #[derive(Clone, Debug, clap::Parser)]
@@ -132,6 +135,7 @@ impl SmartContractsCmd {
 			Self::SignTx(cmd) => cmd.execute().await,
 			Self::GovernedMap(cmd) => cmd.execute().await,
 			Self::Bridge(cmd) => cmd.execute().await,
+			Self::UpsertScript(cmd) => cmd.execute().await,
 		}?;
 		println!("{}", result);
 		Ok(())

--- a/toolkit/smart-contracts/commands/src/versioning.rs
+++ b/toolkit/smart-contracts/commands/src/versioning.rs
@@ -1,0 +1,45 @@
+use crate::{GenesisUtxo, PaymentFilePath, option_to_json};
+use partner_chains_cardano_offchain::{
+	plutus_script::PlutusScript, versioning_system::upsert_script,
+};
+use sidechain_domain::PlutusScriptCbor;
+
+#[derive(Clone, Debug, clap::Parser)]
+/// Command for upserting the versioned script on the mainchain
+pub struct UpsertScriptCmd {
+	#[clap(flatten)]
+	common_arguments: crate::CommonArguments,
+	#[arg(long)]
+	/// Script ID
+	script_id: u32,
+	#[arg(long)]
+	/// CBOR encoded Plutus V2 script
+	plutus_script: PlutusScriptCbor,
+	#[clap(flatten)]
+	/// Path to the payment key file
+	payment_key_file: PaymentFilePath,
+	#[clap(flatten)]
+	/// Genesis UTXO
+	genesis_utxo: GenesisUtxo,
+}
+
+impl UpsertScriptCmd {
+	/// Creates or updates a versioning utxo with reference script
+	pub async fn execute(self) -> crate::SubCmdResult {
+		let payment_key = self.payment_key_file.read_key()?;
+
+		let client = self.common_arguments.get_ogmios_client().await?;
+
+		let result = upsert_script(
+			PlutusScript::v2_from_cbor(&self.plutus_script.0)?,
+			self.script_id,
+			self.genesis_utxo.into(),
+			&payment_key,
+			&client,
+			&self.common_arguments.retries(),
+		)
+		.await?;
+
+		Ok(option_to_json(result))
+	}
+}

--- a/toolkit/smart-contracts/offchain/src/lib.rs
+++ b/toolkit/smart-contracts/offchain/src/lib.rs
@@ -38,8 +38,8 @@ pub mod sign_tx;
 mod test_values;
 /// Supports governance updates
 pub mod update_governance;
-
-mod versioning_system;
+/// Supports versioning system
+pub mod versioning_system;
 
 /// Simply wraps asset id with amount.
 #[derive(Clone)]


### PR DESCRIPTION
# Description

Adds `upsert-script` command. Works only for scripts defined in the `raw-scripts` crate generated by the partner-chains-smart-contract repository.

[link](https://input-output.atlassian.net/browse/ETCM-12319)


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
