### PR TITLE
chore: move unusued fixtures from param to usefixtures()

### DIFF
--- a/e2e-tests/tests/committee/conftest.py
+++ b/e2e-tests/tests/committee/conftest.py
@@ -84,7 +84,8 @@ def initialize_permissioned_candidates(api: BlockchainApi, db: Session, current_
 
 
 @fixture
-def candidate(request, initialize_candidates, api: BlockchainApi, config: ApiConfig, db: Session) -> Candidates:
+@mark.usefixtures("initialize_candidates")
+def candidate(request, api: BlockchainApi, config: ApiConfig, db: Session) -> Candidates:
     """Parameterized fixture to get the first 'active' or 'inactive' candidate.
 
     Use @pytest.mark.candidate_status() to pass data ('active' or 'inactive' only).
@@ -153,8 +154,8 @@ def candidate(request, initialize_candidates, api: BlockchainApi, config: ApiCon
 
 
 @fixture
-def permissioned_candidates(
-    initialize_permissioned_candidates, api: BlockchainApi, config: ApiConfig
+@mark.usefixtures("initialize_permissioned_candidates")
+def permissioned_candidates(api: BlockchainApi, config: ApiConfig
 ) -> Tuple[dict[str, Node], str]:
     """
     Creates a tuple of new permissioned candidates to set and the name of the candidate to remove.

--- a/e2e-tests/tests/conftest.py
+++ b/e2e-tests/tests/conftest.py
@@ -3,7 +3,7 @@ import json
 import logging
 import subprocess
 from omegaconf import OmegaConf
-from pytest import fixture, skip, Config, Metafunc, UsageError
+from pytest import fixture, skip, mark, Config, Metafunc, UsageError
 from src.log_filter import sensitive_filter
 from src.blockchain_api import BlockchainApi, Wallet
 from src.blockchain_types import BlockchainTypes
@@ -334,7 +334,8 @@ def secrets_ci(secrets, decrypt, ci_path):
 
 
 @fixture(scope="session", autouse=True)
-def decrypt_keys(tmp_path_factory, config, blockchain, nodes_env, decrypt, ci_run):
+@mark.usefixtures("ci_run")
+def decrypt_keys(tmp_path_factory, config, blockchain, nodes_env, decrypt):
     if decrypt:
         root_tmp_dir = tmp_path_factory.getbasetemp().parent
         fn = root_tmp_dir / "secrets"
@@ -421,7 +422,8 @@ def teardown(request, api: BlockchainApi):
 
 
 @fixture(scope="session", autouse=True)
-def check_mc_sync_progress(api: BlockchainApi, decrypt_keys) -> Wallet:
+@mark.usefixtures("decrypt_keys")
+def check_mc_sync_progress(api: BlockchainApi) -> Wallet:
     logging.info("Checking if cardano node is fully synced")
     sync_progress = api.get_mc_sync_progress()
     if float(sync_progress) != 100.00:

--- a/e2e-tests/tests/governed_map/conftest.py
+++ b/e2e-tests/tests/governed_map/conftest.py
@@ -36,7 +36,8 @@ def random_string(length=10):
 
 
 @fixture(scope="session")
-def payment_key(config: ApiConfig, governance_skey_with_cli):
+@mark.usefixtures("governance_skey_with_cli")
+def payment_key(config: ApiConfig):
     return config.nodes_config.governance_authority.mainchain_key
 
 

--- a/e2e-tests/tests/governed_map/smart_contracts/test_update.py
+++ b/e2e-tests/tests/governed_map/smart_contracts/test_update.py
@@ -7,7 +7,8 @@ pytestmark = [mark.xdist_group(name="governance_action")]
 
 class TestUpdate:
     @fixture(scope="class", autouse=True)
-    def update_data(self, api: BlockchainApi, insert_data, genesis_utxo, random_key, new_value_hex_bytes, payment_key):
+    @mark.usefixtures("insert_data")
+    def update_data(self, api: BlockchainApi, genesis_utxo, random_key, new_value_hex_bytes, payment_key):
         result = api.partner_chains_node.smart_contracts.governed_map.update(
             genesis_utxo,
             random_key,
@@ -26,7 +27,8 @@ class TestUpdate:
 
 class TestUpdateWithTheSameValue:
     @fixture(scope="class", autouse=True)
-    def update_data(self, api: BlockchainApi, insert_data, genesis_utxo, random_key, random_value, payment_key):
+    @mark.usefixtures("insert_data")
+    def update_data(self, api: BlockchainApi, genesis_utxo, random_key, random_value, payment_key):
         result = api.partner_chains_node.smart_contracts.governed_map.update(
             genesis_utxo,
             random_key,
@@ -46,7 +48,8 @@ class TestUpdateWithTheSameValue:
 
 class TestUpdateWithExpectedCurrentValue:
     @fixture(scope="class", autouse=True)
-    def update_data(self, api: BlockchainApi, insert_data, genesis_utxo, random_key, random_value, new_value_hex_bytes, payment_key):
+    @mark.usefixtures("insert_data")
+    def update_data(self, api: BlockchainApi, genesis_utxo, random_key, random_value, new_value_hex_bytes, payment_key):
         result = api.partner_chains_node.smart_contracts.governed_map.update(
             genesis_utxo,
             random_key,
@@ -66,7 +69,8 @@ class TestUpdateWithExpectedCurrentValue:
 
 class TestUpdateWithExpectedCurrentValueAndTheSameValue:
     @fixture(scope="class", autouse=True)
-    def update_data(self, api: BlockchainApi, insert_data, genesis_utxo, random_key, random_value, payment_key):
+    @mark.usefixtures("insert_data")
+    def update_data(self, api: BlockchainApi, genesis_utxo, random_key, random_value, payment_key):
         result = api.partner_chains_node.smart_contracts.governed_map.update(
             genesis_utxo,
             random_key,
@@ -87,7 +91,8 @@ class TestUpdateWithExpectedCurrentValueAndTheSameValue:
 
 class TestUpdateWithNonMatchingCurrentValue:
     @fixture(scope="class", autouse=True)
-    def update_data(self, api: BlockchainApi, insert_data, genesis_utxo, random_key, new_value_hex_bytes, payment_key):
+    @mark.usefixtures("insert_data")
+    def update_data(self, api: BlockchainApi, genesis_utxo, random_key, new_value_hex_bytes, payment_key):
         result = api.partner_chains_node.smart_contracts.governed_map.update(
             genesis_utxo,
             random_key,


### PR DESCRIPTION
# Description

Refactor to e2e tests to move unused fixtures from parameters to mark.usefixtures(). It indicates dependability between features. 

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages.
- [X] The size limit of 400 LOC isn't needlessly exceeded
- [X] New tests are added if needed and existing tests are updated.
- [X] New code is documented and existing documentation is updated.
- [X] Relevant logging and metrics added
- [X] Any changes are noted in the `changelog.md` for affected crate
- [X] Self-reviewed the diff
