### PR TITLE
Start an additional session to accelerate usage of the new committee

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 ## Changed
 
 * Updated partner-chains-smart-contracts (raw-scripts) dependency to v8.2.0. Not breaking.
+* `SessionManager` and `ShouldEndSession` implementations of `pallet-session-validator-management` rotate one additional
+session in order to make `pallet_session` use authorities with less delay.
 
 ## Removed
 

--- a/demo/runtime/src/lib.rs
+++ b/demo/runtime/src/lib.rs
@@ -1201,49 +1201,46 @@ mod tests {
 			// Needs to be run to initialize first slot and epoch numbers;
 			advance_block();
 
-			// Scheduled committee goes into effect after a 2-epoch delay
+			// Committee goes into effect 1-epoch and 1-block after selection
 			set_committee_through_inherent_data(&[alice()]);
 			until_epoch_after_finalizing(1, &|| {
-				assert_current_epoch!(0);
 				assert_grandpa_weights();
 				assert_grandpa_authorities!([alice(), bob()]);
 			});
-
+			for_next_n_blocks_after_finalizing(1, &|| {
+				assert_grandpa_weights();
+				assert_grandpa_authorities!([alice(), bob()]);
+			});
 			set_committee_through_inherent_data(&[bob()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(1);
-				assert_grandpa_weights();
-				assert_grandpa_authorities!([alice(), bob()]);
-			});
-			set_committee_through_inherent_data(&[alice()]);
-			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(2);
 				assert_grandpa_weights();
 				assert_grandpa_authorities!([alice()]);
 			});
-			set_committee_through_inherent_data(&[alice(), bob()]);
+			set_committee_through_inherent_data(&[alice()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(3);
 				assert_grandpa_weights();
 				assert_grandpa_authorities!([bob()]);
 			});
-			set_committee_through_inherent_data(&[bob(), alice()]);
+			set_committee_through_inherent_data(&[alice(), bob()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(4);
 				assert_grandpa_weights();
 				assert_grandpa_authorities!([alice()]);
 			});
-			set_committee_through_inherent_data(&[alice()]);
+			set_committee_through_inherent_data(&[bob(), alice()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(5);
 				assert_grandpa_weights();
 				assert_grandpa_authorities!([alice(), bob()]);
+			});
+			set_committee_through_inherent_data(&[alice()]);
+			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
+				assert_grandpa_weights();
+				assert_grandpa_authorities!([bob(), alice()]);
 			});
 
 			// When there's no new committees being scheduled, the last committee stays in power
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH * 3, &|| {
 				assert_grandpa_weights();
-				assert_grandpa_authorities!([bob(), alice()]);
+				assert_grandpa_authorities!([alice()]);
 			});
 		});
 
@@ -1260,38 +1257,32 @@ mod tests {
 		new_test_ext().execute_with(|| {
 			// Needs to be run to initialize first slot and epoch numbers;
 			advance_block();
-
-			// Scheduled committee goes into effect after a 2-epoch delay
+			// Committee goes into effect 1-epoch and 1-block after selection
 			set_committee_through_inherent_data(&[alice()]);
 			until_epoch_after_finalizing(1, &|| {
-				assert_current_epoch!(0);
 				assert_aura_authorities!([alice(), bob()]);
 			});
-
+			for_next_n_blocks_after_finalizing(1, &|| {
+				assert_aura_authorities!([alice(), bob()]);
+			});
 			set_committee_through_inherent_data(&[bob()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(1);
-				assert_aura_authorities!([alice(), bob()]);
+				assert_aura_authorities!([alice()]);
 			});
 			set_committee_through_inherent_data(&[alice()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(2);
-				assert_aura_authorities!([alice()]);
+				assert_aura_authorities!([bob()]);
 			});
 			set_committee_through_inherent_data(&[alice(), bob()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(3);
-				assert_aura_authorities!([bob()]);
+				assert_aura_authorities!([alice()]);
 			});
 			set_committee_through_inherent_data(&[bob(), alice()]);
 			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(4);
-				assert_aura_authorities!([alice()]);
-			});
-			set_committee_through_inherent_data(&[alice()]);
-			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
-				assert_current_epoch!(5);
 				assert_aura_authorities!([alice(), bob()]);
+			});
+			for_next_n_blocks_after_finalizing(SLOTS_PER_EPOCH, &|| {
+				assert_aura_authorities!([bob(), alice()]);
 			});
 
 			// When there's no new committees being scheduled, the last committee stays in power
@@ -1326,9 +1317,7 @@ mod tests {
 		});
 	}
 
-	pub fn set_committee_through_inherent_data(
-		expected_authorities: &[TestKeys],
-	) -> PostDispatchInfo {
+	fn set_committee_through_inherent_data(expected_authorities: &[TestKeys]) -> PostDispatchInfo {
 		let epoch = Sidechain::current_epoch_number();
 		let slot = *pallet_aura::CurrentSlot::<Test>::get();
 		println!(

--- a/e2e-tests/tests/committee/test_committee.py
+++ b/e2e-tests/tests/committee/test_committee.py
@@ -486,7 +486,7 @@ class TestCommitteeMembers:
 
         # There's a delay between selecting a committee and it being in power, which means the current
         # committee was selected based on inputs from the previous epoch
-        committee = api.get_epoch_committee(current_epoch - 1).result['committee']
+        committee = api.get_epoch_committee(current_epoch).result['committee']
         authorities = api.get_authorities()
 
         if api.get_pc_epoch() > current_epoch:

--- a/toolkit/committee-selection/pallet/src/mock.rs
+++ b/toolkit/committee-selection/pallet/src/mock.rs
@@ -280,3 +280,18 @@ pub(crate) fn start_session(session_index: u32) {
 
 	assert_eq!(Session::current_index(), session_index);
 }
+
+pub(crate) fn advance_one_block() {
+	let block_number = System::block_number();
+	System::on_finalize(block_number);
+	Session::on_finalize(block_number);
+	let parent_hash =
+		if block_number > 1 { System::finalize().hash() } else { System::parent_hash() };
+	System::reset_events();
+	let next_block_number = block_number as u64 + 1;
+	System::initialize(&next_block_number, &parent_hash, &Default::default());
+	System::set_block_number(next_block_number.into());
+
+	System::on_initialize(next_block_number);
+	Session::on_initialize(next_block_number);
+}


### PR DESCRIPTION
# Description

Currently we do 1-to-1 session and committee rotation. We select the next committee at some point of time, and when PC epoch changes, we end session, then on new session we rotate committee (this triggers selection of the committee at the next block) and pass the new committee to pallet_session. Pallet session queues new committee keys to be used in the next session. So, effectively there is a session and a block (~= partner chain epoch) delay between when according to our rules we would like to allow block production and when it happens.

Changes in this PR cause additional session end at the first block of a session caused by epoch boundary.
This effectively reduces the delay to two blocks

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [x] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
