### PR TITLE
change: move data epoch offset calculation out of data sources

### DIFF
--- a/demo/node/src/tests/inherent_data_tests.rs
+++ b/demo/node/src/tests/inherent_data_tests.rs
@@ -43,7 +43,7 @@ async fn block_proposal_cidp_should_be_created_correctly() {
 
 	let inherent_data_providers = ProposalCIDP::new(
 		test_create_inherent_data_config(),
-		TestApi::new(ScEpochNumber(2))
+		TestApi::new(ScEpochNumber(20))
 			.with_headers([(mock_header().hash(), mock_header())])
 			.with_pariticipation_data(vec![(past_block_slot(), past_block_author())])
 			.into(),
@@ -124,7 +124,7 @@ async fn block_verification_cidp_should_be_created_correctly() {
 
 	let verifier_cidp = VerifierCIDP::new(
 		create_inherent_data_config.clone(),
-		TestApi::new(ScEpochNumber(2))
+		TestApi::new(ScEpochNumber(20))
 			.with_pariticipation_data(vec![(past_block_slot(), past_block_author())])
 			.into(),
 		Arc::new(mc_hash_data_source),

--- a/toolkit/committee-selection/authority-selection-inherents/src/mock.rs
+++ b/toolkit/committee-selection/authority-selection-inherents/src/mock.rs
@@ -20,7 +20,7 @@ impl Default for MockAuthoritySelectionDataSource {
 	fn default() -> Self {
 		Self {
 			candidates: vec![vec![], vec![]],
-			permissioned_candidates: vec![Some(vec![]), Some(vec![])],
+			permissioned_candidates: vec![Some(vec![]), Some(vec![]), Some(vec![])],
 			num_permissioned_candidates: 3,
 		}
 	}
@@ -79,12 +79,5 @@ impl AuthoritySelectionDataSource for MockAuthoritySelectionDataSource {
 		_epoch: McEpochNumber,
 	) -> Result<Option<EpochNonce>, Box<dyn std::error::Error + Send + Sync>> {
 		Ok(Some(EpochNonce(vec![42u8])))
-	}
-
-	async fn data_epoch(
-		&self,
-		for_epoch: McEpochNumber,
-	) -> Result<McEpochNumber, Box<dyn std::error::Error + Send + Sync>> {
-		Ok(for_epoch)
 	}
 }

--- a/toolkit/data-sources/db-sync/src/candidates/cached.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/cached.rs
@@ -71,13 +71,6 @@ impl AuthoritySelectionDataSource for CandidateDataSourceCached {
 	) -> Result<Option<EpochNonce>, Box<dyn std::error::Error + Send + Sync>> {
 		self.inner.get_epoch_nonce(epoch).await
 	}
-
-	async fn data_epoch(
-		&self,
-		for_epoch: McEpochNumber,
-	) -> Result<McEpochNumber, Box<dyn std::error::Error + Send + Sync>> {
-		self.inner.data_epoch(for_epoch).await
-	}
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -176,9 +169,8 @@ impl CandidateDataSourceCached {
 
 	async fn can_use_caching_for_request(
 		&self,
-		request_epoch: McEpochNumber,
+		data_epoch: McEpochNumber,
 	) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
-		let data_epoch = self.inner.data_epoch(request_epoch).await?;
 		if let Ok(stable_epoch) = self.highest_seen_stable_epoch.lock() {
 			if stable_epoch.map_or(false, |stable_epoch| stable_epoch >= data_epoch) {
 				return Ok(true);

--- a/toolkit/data-sources/db-sync/src/candidates/tests.rs
+++ b/toolkit/data-sources/db-sync/src/candidates/tests.rs
@@ -38,7 +38,7 @@ macro_rules! with_migration_versions {
 with_migration_versions! {
 	async fn test_get_candidates_for_epoch(pool: PgPool, tx_in_cfg: TxInConfiguration) {
 		let source = make_source(pool, tx_in_cfg);
-		let result = source.get_candidates(McEpochNumber(191), candidates_address()).await.unwrap();
+		let result = source.get_candidates(McEpochNumber(189), candidates_address()).await.unwrap();
 		let mut candidates = result;
 		candidates.sort_by(|c1, c2| c1.mainchain_pub_key().0.cmp(&c2.mainchain_pub_key().0));
 		assert_eq!(candidates, vec![leader_candidate_spo_a(), leader_candidate_spo_b()])
@@ -46,7 +46,7 @@ with_migration_versions! {
 
 	async fn test_get_candidates_after_some_deregistrations(pool: PgPool, tx_in_cfg: TxInConfiguration) {
 		let source = make_source(pool, tx_in_cfg);
-		let result = source.get_candidates(McEpochNumber(195), candidates_address()).await.unwrap();
+		let result = source.get_candidates(McEpochNumber(193), candidates_address()).await.unwrap();
 		let mut candidates = result;
 		candidates.sort_by(|c1, c2| c1.mainchain_pub_key().0.cmp(&c2.mainchain_pub_key().0));
 		assert_eq!(candidates, vec![leader_candidate_spo_c(), leader_candidate_spo_b()])
@@ -57,7 +57,7 @@ with_migration_versions! {
 		let epoch_189_nonce = EpochNonce(
 			hex!("ABEED7FB0067F14D6F6436C7F7DEDB27CE3CEB4D2D18FF249D43B22D86FAE3F1").to_vec(),
 		);
-		let result = source.get_epoch_nonce(McEpochNumber(191)).await.unwrap();
+		let result = source.get_epoch_nonce(McEpochNumber(189)).await.unwrap();
 		assert_eq!(result, Some(epoch_189_nonce));
 	}
 
@@ -66,7 +66,7 @@ with_migration_versions! {
 		// The first permissioned candidates tx was submitted at epoch 190
 		let result = source
 			.get_ariadne_parameters(
-				McEpochNumber(3),
+				McEpochNumber(1),
 				d_parameter_policy(),
 				permissioned_candidates_policy(),
 			)
@@ -79,7 +79,7 @@ with_migration_versions! {
 		// The last tx was submitted at epoch 192
 		let result = source
 			.get_ariadne_parameters(
-				McEpochNumber(200),
+				McEpochNumber(198),
 				d_parameter_policy(),
 				permissioned_candidates_policy(),
 			)
@@ -100,7 +100,7 @@ with_migration_versions! {
 		// see 6_insert_transactions.sql
 		let result = source
 			.get_ariadne_parameters(
-				McEpochNumber(192),
+				McEpochNumber(190),
 				d_parameter_policy(),
 				permissioned_candidates_policy(),
 			)
@@ -117,7 +117,7 @@ with_migration_versions! {
 		let source = make_source(pool, tx_in_cfg);
 		let result = source
 			.get_ariadne_parameters(
-				McEpochNumber(191),
+				McEpochNumber(189),
 				d_parameter_policy(),
 				permissioned_candidates_policy(),
 			)
@@ -135,7 +135,7 @@ with_migration_versions! {
 		// The last tx was submitted at epoch 192
 		let result = source
 			.get_ariadne_parameters(
-				McEpochNumber(2000),
+				McEpochNumber(1998),
 				d_parameter_policy(),
 				permissioned_candidates_policy(),
 			)
@@ -170,10 +170,10 @@ mod candidate_caching {
 			// With security parameter 2, block 3 (from epoch 191) is the latest stable block, so epoch 190 is the latest stable epoch.
 			// get_candidates(192) uses data from the last block of epoch 190 (block 2), so result should be cached.
 			let epoch_192_candidates =
-				service.get_candidates(McEpochNumber(192), candidates_address()).await.unwrap();
+				service.get_candidates(McEpochNumber(190), candidates_address()).await.unwrap();
 			// get_candidates(193) uses data from the last block of epoch 191 (block 3), so result should not be cached.
 			let epoch_193_candidates =
-				service.get_candidates(McEpochNumber(193), candidates_address()).await.unwrap();
+				service.get_candidates(McEpochNumber(191), candidates_address()).await.unwrap();
 			assert!(!epoch_193_candidates.is_empty());
 			// Remove all registrations to prove that one request was cached and the other not
 			sqlx::raw_sql("DELETE FROM tx WHERE block_id >= 0")
@@ -181,10 +181,10 @@ mod candidate_caching {
 				.await
 				.unwrap();
 			let epoch_192_candidates_after_txs_removal =
-				service.get_candidates(McEpochNumber(192), candidates_address()).await.unwrap();
+				service.get_candidates(McEpochNumber(190), candidates_address()).await.unwrap();
 			assert_eq!(epoch_192_candidates, epoch_192_candidates_after_txs_removal);
 			let epoch_193_candidates_after_txs_removal =
-				service.get_candidates(McEpochNumber(193), candidates_address()).await.unwrap();
+				service.get_candidates(McEpochNumber(191), candidates_address()).await.unwrap();
 			// Proves epoch 193 candidates were not cached
 			assert_ne!(epoch_193_candidates, epoch_193_candidates_after_txs_removal);
 		}
@@ -198,9 +198,9 @@ mod candidate_caching {
 			// With security parameter 2, block 3 (from epoch 191) is the latest stable block, so epoch 190 is the latest stable epoch.
 			// get_candidates(192) uses data from the last block of epoch 190 (block 2), so result should be cached.
 			let epoch_192_candidates =
-				service.get_candidates(McEpochNumber(192), candidates_address()).await.unwrap();
+				service.get_candidates(McEpochNumber(190), candidates_address()).await.unwrap();
 			let epoch_192_candidates_from_different_address = service
-				.get_candidates(McEpochNumber(192), MainchainAddress::from_str("script_addr2").unwrap())
+				.get_candidates(McEpochNumber(190), MainchainAddress::from_str("script_addr2").unwrap())
 				.await
 				.unwrap();
 			assert!(!epoch_192_candidates.is_empty());
@@ -219,7 +219,7 @@ mod candidate_caching {
 			// get_ariadne_parameters(192) uses data from the last block of epoch 190 (block 2), so result should be cached.
 			let epoch_192_ariadne_parameters = service
 				.get_ariadne_parameters(
-					McEpochNumber(192),
+					McEpochNumber(190),
 					d_parameter_policy(),
 					permissioned_candidates_policy(),
 				)
@@ -228,7 +228,7 @@ mod candidate_caching {
 			// get_ariadne_parameters(193) uses data from the last block of epoch 191 (block 3), so result should not be cached.
 			let epoch_193_ariadne_parameters = service
 				.get_ariadne_parameters(
-					McEpochNumber(193),
+					McEpochNumber(191),
 					d_parameter_policy(),
 					permissioned_candidates_policy(),
 				)
@@ -245,7 +245,7 @@ mod candidate_caching {
 				.unwrap();
 			let epoch_192_ariadne_parameters_after_tx_removal = service
 				.get_ariadne_parameters(
-					McEpochNumber(192),
+					McEpochNumber(190),
 					d_parameter_policy(),
 					permissioned_candidates_policy(),
 				)
@@ -254,7 +254,7 @@ mod candidate_caching {
 			assert_eq!(epoch_192_ariadne_parameters, epoch_192_ariadne_parameters_after_tx_removal);
 			let epoch_193_ariadne_parameters_after_txs_removal = service
 				.get_ariadne_parameters(
-					McEpochNumber(193),
+					McEpochNumber(191),
 					d_parameter_policy(),
 					permissioned_candidates_policy(),
 				)
@@ -273,14 +273,14 @@ mod candidate_caching {
 			// get_ariadne_parameters(192) uses data from the last block of epoch 190 (block 2), so result should be cached.
 			let epoch_192_ariadne_parameters_result = service
 				.get_ariadne_parameters(
-					McEpochNumber(192),
+					McEpochNumber(190),
 					d_parameter_policy(),
 					permissioned_candidates_policy(),
 				)
 				.await;
 			let epoch_192_ariadne_parameters_for_different_policy_result = service
 				.get_ariadne_parameters(
-					McEpochNumber(192),
+					McEpochNumber(190),
 					PolicyId(hex!("aabb00000000000000000000000000000000434845434b504f494e69")),
 					permissioned_candidates_policy(),
 				)

--- a/toolkit/data-sources/mock/src/candidate.rs
+++ b/toolkit/data-sources/mock/src/candidate.rs
@@ -295,8 +295,4 @@ impl AuthoritySelectionDataSource for AuthoritySelectionDataSourceMock {
 		);
 		Ok(Some(EpochNonce(epoch_conf.nonce.clone().0)))
 	}
-
-	async fn data_epoch(&self, for_epoch: McEpochNumber) -> Result<McEpochNumber> {
-		Ok(McEpochNumber(for_epoch.0 - 2))
-	}
 }


### PR DESCRIPTION
# Description

Removes the `data_epoch` from the `AuthoritySelectionDataSource` trait. This method was used internally to apply the 2-epoch offset within each data source method, but was also exposed outside because `AriadneInherentDataProvider` needed it too in its own logic.

Instead, the data source now simply serves data for the epoch it receives and it's solely `AriadneInherentDataProvider`'s responsibility to calculate it.

This change is backwards compatible.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages.
- [x] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [x] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [x] Self-reviewed the diff
