### PR TITLE
fix: fix spo journey test

### DIFF
--- a/e2e-tests/config/substrate/local.json
+++ b/e2e-tests/config/substrate/local.json
@@ -6,7 +6,7 @@
     "slot_length": 1,
     "active_slots_coeff": 0.4,
     "security_param": 5,
-    "init_timestamp": 1742993000,
+    "init_timestamp": 1766496559,
     "block_stability_margin": 0
   },
   "nodes_config": {


### PR DESCRIPTION
# Description

Fix SPO journey tests and auto-calculate init_timestamp

What Changed
•  Auto-calculate init_timestamp: Dynamically calculate based on current network state instead of hardcoding, eliminating manual config updates after network restarts
•  Fix epoch mapping errors: Handle None returns from find_mc_epoch() to prevent TypeError crashes  
•  Fix participation validation: Properly remove all entries per producer (not just one) since participation data contains multiple entries with different block counts

[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages.
- [ ] The size limit of 400 LOC isn't needlessly exceeded
- [ ] The PR refers to a JIRA ticket (if one exists)
- [ ] New tests are added if needed and existing tests are updated.
- [ ] New code is documented and existing documentation is updated.
- [ ] Relevant logging and metrics added
- [ ] Any changes are noted in the `changelog.md` for affected crate
- [ ] Self-reviewed the diff
