### PR TITLE
feat(partner-chains-cli): add interactive contract selection to setup wizard

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 # Unreleased
 
+## Added
+
+* Added `--skip-d-parameter` and `--skip-permissioned-candidates` flags to the `setup-main-chain-state` wizard command.
+These flags allow selective deployment of smart contracts, enabling mainnet deployments that exclude legacy Haskell D-parameter contracts while retaining the option to deploy permissioned candidates contracts.
+
 ## Changed
 
 * Updated polkadot-sdk dependency to polkadot-stable2509.

--- a/changelog.md
+++ b/changelog.md
@@ -6,8 +6,8 @@ This changelog is based on [Keep A Changelog](https://keepachangelog.com/en/1.1.
 
 ## Added
 
-* Added `--skip-d-parameter` and `--skip-permissioned-candidates` flags to the `setup-main-chain-state` wizard command.
-These flags allow selective deployment of smart contracts, enabling mainnet deployments that exclude legacy Haskell D-parameter contracts while retaining the option to deploy permissioned candidates contracts.
+* Added interactive contract selection prompts to the `setup-main-chain-state` wizard command.
+Users are now prompted to choose which contracts to deploy (D-parameter and/or Permissioned Candidates), enabling mainnet deployments that exclude legacy Haskell D-parameter contracts while retaining the option to deploy permissioned candidates contracts.
 
 ## Changed
 

--- a/dev/local-environment/configurations/wizard/governance-authority/entrypoint.sh
+++ b/dev/local-environment/configurations/wizard/governance-authority/entrypoint.sh
@@ -145,6 +145,10 @@ echo "Setting up main chain state..."
 expect <<EOF
 spawn ./partner-chains-node wizards setup-main-chain-state
 set timeout 300
+expect "Do you want to deploy/update the D-parameter contract?"
+send "y\r"
+expect "Do you want to deploy/update the Permissioned Candidates contract?"
+send "y\r"
 expect "Ogmios protocol (http/https)"
 send "\r"
 expect "Ogmios hostname (ogmios)"

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -71,16 +71,6 @@ impl ContractDeploymentConfig {
 pub struct SetupMainChainStateCmd<T: PartnerChainRuntime> {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
-
-	/// Skip deploying the D-parameter contract (legacy Haskell contract).
-	/// Use this flag for mainnet deployments where D-parameter is not needed.
-	#[clap(long)]
-	skip_d_parameter: bool,
-
-	/// Skip deploying the permissioned candidates contract.
-	#[clap(long)]
-	skip_permissioned_candidates: bool,
-
 	#[clap(skip)]
 	_phantom: PhantomData<T>,
 }
@@ -108,33 +98,33 @@ impl SortedPermissionedCandidates {
 
 impl<T: PartnerChainRuntime> CmdRun for SetupMainChainStateCmd<T> {
 	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
+		context.print(
+			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain.",
+		);
+		context.print("You can choose which contracts to deploy. Setting contracts costs ADA!");
+
+		// Prompt user for which contracts to deploy
+		let deploy_d_parameter =
+			context.prompt_yes_no("Do you want to deploy/update the D-parameter contract?", true);
+		let deploy_permissioned_candidates = context.prompt_yes_no(
+			"Do you want to deploy/update the Permissioned Candidates contract?",
+			true,
+		);
+
 		let deployment_config = ContractDeploymentConfig {
-			skip_d_parameter: self.skip_d_parameter,
-			skip_permissioned_candidates: self.skip_permissioned_candidates,
+			skip_d_parameter: !deploy_d_parameter,
+			skip_permissioned_candidates: !deploy_permissioned_candidates,
 		};
 
-		// Show deployment summary if any contracts are being skipped
-		if deployment_config.skip_d_parameter || deployment_config.skip_permissioned_candidates {
-			context.print(&deployment_config.deployment_summary());
+		if deployment_config.skip_d_parameter && deployment_config.skip_permissioned_candidates {
+			context.print("No contracts selected for deployment. Exiting.");
+			return Ok(());
 		}
 
-		let chain_config = crate::config::load_chain_config(context)?;
+		// Show deployment summary
+		context.print(&deployment_config.deployment_summary());
 
-		// Build info message based on which contracts will be deployed
-		let info_message = if deployment_config.skip_d_parameter
-			&& deployment_config.skip_permissioned_candidates
-		{
-			return Err(anyhow!(
-				"Both D-parameter and Permissioned Candidates are skipped. Nothing to deploy."
-			));
-		} else if deployment_config.skip_d_parameter {
-			"This wizard will set or update Permissioned Candidates on the main chain. Setting this costs ADA!"
-		} else if deployment_config.skip_permissioned_candidates {
-			"This wizard will set or update D-Parameter on the main chain. Setting this costs ADA!"
-		} else {
-			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!"
-		};
-		context.print(info_message);
+		let chain_config = crate::config::load_chain_config(context)?;
 
 		// Only load permissioned candidates config if we're going to deploy them
 		let config_initial_authorities = if !deployment_config.skip_permissioned_candidates {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/mod.rs
@@ -26,10 +26,61 @@ use std::marker::PhantomData;
 #[cfg(test)]
 mod tests;
 
+/// Configuration for which contracts to deploy during main chain state setup.
+#[derive(Clone, Debug, Default)]
+pub struct ContractDeploymentConfig {
+	/// Skip deploying D-parameter contract (legacy Haskell contract).
+	pub skip_d_parameter: bool,
+	/// Skip deploying permissioned candidates contract.
+	pub skip_permissioned_candidates: bool,
+}
+
+impl ContractDeploymentConfig {
+	/// Returns a summary of which contracts will be deployed.
+	pub fn deployment_summary(&self) -> String {
+		let mut deploying = Vec::new();
+		let mut skipping = Vec::new();
+
+		if self.skip_d_parameter {
+			skipping.push("D-parameter");
+		} else {
+			deploying.push("D-parameter");
+		}
+
+		if self.skip_permissioned_candidates {
+			skipping.push("Permissioned Candidates");
+		} else {
+			deploying.push("Permissioned Candidates");
+		}
+
+		let mut summary = String::new();
+		if !deploying.is_empty() {
+			summary.push_str(&format!("Contracts to deploy: {}", deploying.join(", ")));
+		}
+		if !skipping.is_empty() {
+			if !summary.is_empty() {
+				summary.push_str(". ");
+			}
+			summary.push_str(&format!("Contracts to skip: {}", skipping.join(", ")));
+		}
+		summary
+	}
+}
+
 #[derive(Clone, Debug, clap::Parser)]
 pub struct SetupMainChainStateCmd<T: PartnerChainRuntime> {
 	#[clap(flatten)]
 	common_arguments: crate::CommonArguments,
+
+	/// Skip deploying the D-parameter contract (legacy Haskell contract).
+	/// Use this flag for mainnet deployments where D-parameter is not needed.
+	#[clap(long)]
+	skip_d_parameter: bool,
+
+	/// Skip deploying the permissioned candidates contract.
+	#[clap(long)]
+	skip_permissioned_candidates: bool,
+
 	#[clap(skip)]
 	_phantom: PhantomData<T>,
 }
@@ -45,7 +96,7 @@ impl<Keys: MaybeFromCandidateKeys> TryFrom<PermissionedCandidateData>
 	}
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 struct SortedPermissionedCandidates(Vec<PermissionedCandidateData>);
 
 impl SortedPermissionedCandidates {
@@ -57,48 +108,85 @@ impl SortedPermissionedCandidates {
 
 impl<T: PartnerChainRuntime> CmdRun for SetupMainChainStateCmd<T> {
 	fn run<C: IOContext>(&self, context: &C) -> anyhow::Result<()> {
+		let deployment_config = ContractDeploymentConfig {
+			skip_d_parameter: self.skip_d_parameter,
+			skip_permissioned_candidates: self.skip_permissioned_candidates,
+		};
+
+		// Show deployment summary if any contracts are being skipped
+		if deployment_config.skip_d_parameter || deployment_config.skip_permissioned_candidates {
+			context.print(&deployment_config.deployment_summary());
+		}
+
 		let chain_config = crate::config::load_chain_config(context)?;
-		context.print(
-			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!",
-		);
-		let config_initial_authorities =
-			initial_permissioned_candidates_from_chain_config::<C, T::Keys>(context)?;
+
+		// Build info message based on which contracts will be deployed
+		let info_message = if deployment_config.skip_d_parameter
+			&& deployment_config.skip_permissioned_candidates
+		{
+			return Err(anyhow!(
+				"Both D-parameter and Permissioned Candidates are skipped. Nothing to deploy."
+			));
+		} else if deployment_config.skip_d_parameter {
+			"This wizard will set or update Permissioned Candidates on the main chain. Setting this costs ADA!"
+		} else if deployment_config.skip_permissioned_candidates {
+			"This wizard will set or update D-Parameter on the main chain. Setting this costs ADA!"
+		} else {
+			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!"
+		};
+		context.print(info_message);
+
+		// Only load permissioned candidates config if we're going to deploy them
+		let config_initial_authorities = if !deployment_config.skip_permissioned_candidates {
+			Some(initial_permissioned_candidates_from_chain_config::<C, T::Keys>(context)?)
+		} else {
+			None
+		};
+
 		context.print("Will read the current D-Parameter and Permissioned Candidates from the main chain using Ogmios client.");
 		let ogmios_config = prompt_ogmios_configuration(context)?;
 		let offchain = context.offchain_impl(&ogmios_config)?;
 		let config_file_path = context.config_file_path(ConfigFile::Chain);
 
-		match get_permissioned_candidates::<C>(&offchain, &chain_config)? {
-			Some(candidates) if candidates == config_initial_authorities => {
-				context.print(&format!("Permissioned candidates in the {} file match the most recent on-chain initial permissioned candidates.", config_file_path));
-			},
-			candidates => {
-				print_on_chain_and_config_permissioned_candidates(
-					context,
-					candidates,
-					&config_initial_authorities,
-				);
-				set_candidates_on_main_chain(
-					self.common_arguments.retries(),
-					context,
-					&offchain,
-					config_initial_authorities,
-					chain_config.chain_parameters.genesis_utxo,
-				)?;
-			},
-		};
-		let d_parameter = get_d_parameter::<C>(&offchain, &chain_config)?;
-		print_on_chain_d_parameter(context, &d_parameter);
-		set_d_parameter_on_main_chain(
-			self.common_arguments.retries(),
-			context,
-			&offchain,
-			d_parameter.unwrap_or(DParameter {
-				num_permissioned_candidates: 0,
-				num_registered_candidates: 0,
-			}),
-			chain_config.chain_parameters.genesis_utxo,
-		)?;
+		// Handle permissioned candidates if not skipped
+		if let Some(ref config_initial_authorities) = config_initial_authorities {
+			match get_permissioned_candidates::<C>(&offchain, &chain_config)? {
+				Some(candidates) if candidates == *config_initial_authorities => {
+					context.print(&format!("Permissioned candidates in the {} file match the most recent on-chain initial permissioned candidates.", config_file_path));
+				},
+				candidates => {
+					print_on_chain_and_config_permissioned_candidates(
+						context,
+						candidates,
+						config_initial_authorities,
+					);
+					set_candidates_on_main_chain(
+						self.common_arguments.retries(),
+						context,
+						&offchain,
+						config_initial_authorities.clone(),
+						chain_config.chain_parameters.genesis_utxo,
+					)?;
+				},
+			};
+		}
+
+		// Handle D-parameter if not skipped
+		if !deployment_config.skip_d_parameter {
+			let d_parameter = get_d_parameter::<C>(&offchain, &chain_config)?;
+			print_on_chain_d_parameter(context, &d_parameter);
+			set_d_parameter_on_main_chain(
+				self.common_arguments.retries(),
+				context,
+				&offchain,
+				d_parameter.unwrap_or(DParameter {
+					num_permissioned_candidates: 0,
+					num_registered_candidates: 0,
+				}),
+				chain_config.chain_parameters.genesis_utxo,
+			)?;
+		}
+
 		context.print("Done. Please remember that any changes to the Cardano state can be observed immediately, but from the Partner Chain point of view they will be effective in two main chain epochs.");
 		Ok(())
 	}

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -252,7 +252,10 @@ fn skip_both_contracts_fails_with_error() {
 		.with_expected_io(vec![print_skip_both_summary_io()]);
 	let result = setup_main_chain_state_cmd_skip_both().run(&mock_context);
 	let err = result.expect_err("should return error");
-	assert!(err.to_string().contains("Both D-parameter and Permissioned Candidates are skipped"));
+	assert!(
+		err.to_string()
+			.contains("Both D-parameter and Permissioned Candidates are skipped")
+	);
 }
 
 fn setup_main_chain_state_cmd() -> SetupMainChainStateCmd<MockRuntime> {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -27,7 +27,9 @@ fn no_ariadne_parameters_on_main_chain_no_updates() {
 			mock_with_ariadne_parameters_not_found(),
 		))
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_permissioned_candidates_are_not_set(),
 			prompt_permissioned_candidates_update_io(false),
@@ -65,7 +67,9 @@ fn no_ariadne_parameters_on_main_chain_do_updates() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_permissioned_candidates_are_not_set(),
 			prompt_permissioned_candidates_update_io(true),
@@ -89,7 +93,9 @@ fn ariadne_parameters_are_on_main_chain_no_updates() {
 			mock_with_ariadne_parameters_found(),
 		))
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(false),
@@ -127,7 +133,9 @@ fn ariadne_parameters_are_on_main_chain_do_update() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(true),
@@ -155,7 +163,9 @@ fn fails_if_update_permissioned_candidates_fail() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_main_chain_and_configuration_candidates_difference_io(),
 			prompt_permissioned_candidates_update_io(true),
@@ -176,7 +186,9 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
 		.with_expected_io(vec![
-			print_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, true),
+			print_deploy_both_summary_io(),
 			get_ariadne_parameters_io(),
 			print_main_chain_and_configuration_candidates_are_equal_io(),
 			print_d_param_from_main_chain_io(),
@@ -207,15 +219,16 @@ fn skip_d_parameter_only_deploys_permissioned_candidates() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			print_skip_d_parameter_summary_io(),
-			print_permissioned_candidates_only_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(false, true),
+			print_deploy_permissioned_only_summary_io(),
 			get_ariadne_parameters_io(),
 			print_permissioned_candidates_are_not_set(),
 			prompt_permissioned_candidates_update_io(true),
 			upsert_permissioned_candidates_io(),
 			print_post_update_info_io(),
 		]);
-	let result = setup_main_chain_state_cmd_skip_d_parameter().run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 }
 
@@ -233,95 +246,77 @@ fn skip_permissioned_candidates_only_deploys_d_parameter() {
 		.with_json_file("payment.skey", valid_payment_signing_key_content())
 		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
 		.with_expected_io(vec![
-			print_skip_permissioned_candidates_summary_io(),
-			print_d_parameter_only_info_io(),
+			print_intro_io(),
+			prompt_contract_selection_io(true, false),
+			print_deploy_d_param_only_summary_io(),
 			get_ariadne_parameters_io(),
 			prompt_d_parameter_update_io(true),
 			insert_d_parameter_io(),
 			print_post_update_info_io(),
 		]);
-	let result = setup_main_chain_state_cmd_skip_permissioned().run(&mock_context);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
 	result.expect("should succeed");
 }
 
 #[test]
-fn skip_both_contracts_fails_with_error() {
+fn skip_both_contracts_exits_gracefully() {
 	let mock_context = MockIOContext::new()
 		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
 		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
-		.with_expected_io(vec![print_skip_both_summary_io()]);
-	let result = setup_main_chain_state_cmd_skip_both().run(&mock_context);
-	let err = result.expect_err("should return error");
-	assert!(
-		err.to_string()
-			.contains("Both D-parameter and Permissioned Candidates are skipped")
-	);
+		.with_expected_io(vec![
+			print_intro_io(),
+			prompt_contract_selection_io(false, false),
+			print_no_contracts_selected_io(),
+		]);
+	let result = setup_main_chain_state_cmd().run(&mock_context);
+	result.expect("should succeed with graceful exit");
 }
 
 fn setup_main_chain_state_cmd() -> SetupMainChainStateCmd<MockRuntime> {
 	SetupMainChainStateCmd {
 		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
-		skip_d_parameter: false,
-		skip_permissioned_candidates: false,
 		_phantom: std::marker::PhantomData,
 	}
 }
 
-fn setup_main_chain_state_cmd_skip_d_parameter() -> SetupMainChainStateCmd<MockRuntime> {
-	SetupMainChainStateCmd {
-		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
-		skip_d_parameter: true,
-		skip_permissioned_candidates: false,
-		_phantom: std::marker::PhantomData,
-	}
+fn print_intro_io() -> MockIO {
+	MockIO::Group(vec![
+		MockIO::print(
+			"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain.",
+		),
+		MockIO::print("You can choose which contracts to deploy. Setting contracts costs ADA!"),
+	])
 }
 
-fn setup_main_chain_state_cmd_skip_permissioned() -> SetupMainChainStateCmd<MockRuntime> {
-	SetupMainChainStateCmd {
-		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
-		skip_d_parameter: false,
-		skip_permissioned_candidates: true,
-		_phantom: std::marker::PhantomData,
-	}
+fn prompt_contract_selection_io(deploy_d_param: bool, deploy_permissioned: bool) -> MockIO {
+	MockIO::Group(vec![
+		MockIO::prompt_yes_no(
+			"Do you want to deploy/update the D-parameter contract?",
+			true,
+			deploy_d_param,
+		),
+		MockIO::prompt_yes_no(
+			"Do you want to deploy/update the Permissioned Candidates contract?",
+			true,
+			deploy_permissioned,
+		),
+	])
 }
 
-fn setup_main_chain_state_cmd_skip_both() -> SetupMainChainStateCmd<MockRuntime> {
-	SetupMainChainStateCmd {
-		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
-		skip_d_parameter: true,
-		skip_permissioned_candidates: true,
-		_phantom: std::marker::PhantomData,
-	}
+fn print_deploy_both_summary_io() -> MockIO {
+	MockIO::print("Contracts to deploy: D-parameter, Permissioned Candidates")
 }
 
-fn print_info_io() -> MockIO {
-	MockIO::print(
-		"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!",
-	)
-}
-
-fn print_permissioned_candidates_only_info_io() -> MockIO {
-	MockIO::print(
-		"This wizard will set or update Permissioned Candidates on the main chain. Setting this costs ADA!",
-	)
-}
-
-fn print_d_parameter_only_info_io() -> MockIO {
-	MockIO::print(
-		"This wizard will set or update D-Parameter on the main chain. Setting this costs ADA!",
-	)
-}
-
-fn print_skip_d_parameter_summary_io() -> MockIO {
+fn print_deploy_permissioned_only_summary_io() -> MockIO {
 	MockIO::print("Contracts to deploy: Permissioned Candidates. Contracts to skip: D-parameter")
 }
 
-fn print_skip_permissioned_candidates_summary_io() -> MockIO {
+fn print_deploy_d_param_only_summary_io() -> MockIO {
 	MockIO::print("Contracts to deploy: D-parameter. Contracts to skip: Permissioned Candidates")
 }
 
-fn print_skip_both_summary_io() -> MockIO {
-	MockIO::print("Contracts to skip: D-parameter, Permissioned Candidates")
+fn print_no_contracts_selected_io() -> MockIO {
+	MockIO::print("No contracts selected for deployment. Exiting.")
 }
 
 fn get_ariadne_parameters_io() -> MockIO {

--- a/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
+++ b/toolkit/partner-chains-cli/src/setup_main_chain_state/tests.rs
@@ -192,9 +192,101 @@ fn candidates_on_main_chain_are_same_as_in_config_no_updates() {
 	);
 }
 
+#[test]
+fn skip_d_parameter_only_deploys_permissioned_candidates() {
+	let offchain_mock = mock_with_ariadne_parameters_not_found()
+		.with_upsert_permissioned_candidates(
+			genesis_utxo(),
+			&initial_permissioned_candidates(),
+			payment_signing_key(),
+			Ok(Some(MultiSigSmartContractResult::tx_submitted([2; 32]))),
+		);
+	let mock_context = MockIOContext::new()
+		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
+		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
+		.with_json_file("payment.skey", valid_payment_signing_key_content())
+		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
+		.with_expected_io(vec![
+			print_skip_d_parameter_summary_io(),
+			print_permissioned_candidates_only_info_io(),
+			get_ariadne_parameters_io(),
+			print_permissioned_candidates_are_not_set(),
+			prompt_permissioned_candidates_update_io(true),
+			upsert_permissioned_candidates_io(),
+			print_post_update_info_io(),
+		]);
+	let result = setup_main_chain_state_cmd_skip_d_parameter().run(&mock_context);
+	result.expect("should succeed");
+}
+
+#[test]
+fn skip_permissioned_candidates_only_deploys_d_parameter() {
+	let offchain_mock = mock_with_ariadne_parameters_not_found().with_upsert_d_param(
+		genesis_utxo(),
+		new_d_parameter(),
+		payment_signing_key(),
+		Ok(Some(MultiSigSmartContractResult::tx_submitted([1; 32]))),
+	);
+	let mock_context = MockIOContext::new()
+		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
+		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
+		.with_json_file("payment.skey", valid_payment_signing_key_content())
+		.with_offchain_mocks(OffchainMocks::new_with_mock("http://localhost:1337", offchain_mock))
+		.with_expected_io(vec![
+			print_skip_permissioned_candidates_summary_io(),
+			print_d_parameter_only_info_io(),
+			get_ariadne_parameters_io(),
+			prompt_d_parameter_update_io(true),
+			insert_d_parameter_io(),
+			print_post_update_info_io(),
+		]);
+	let result = setup_main_chain_state_cmd_skip_permissioned().run(&mock_context);
+	result.expect("should succeed");
+}
+
+#[test]
+fn skip_both_contracts_fails_with_error() {
+	let mock_context = MockIOContext::new()
+		.with_json_file(CHAIN_CONFIG_FILE_PATH, test_chain_config_content())
+		.with_json_file(RESOURCES_CONFIG_FILE_PATH, test_resources_config_content())
+		.with_expected_io(vec![print_skip_both_summary_io()]);
+	let result = setup_main_chain_state_cmd_skip_both().run(&mock_context);
+	let err = result.expect_err("should return error");
+	assert!(err.to_string().contains("Both D-parameter and Permissioned Candidates are skipped"));
+}
+
 fn setup_main_chain_state_cmd() -> SetupMainChainStateCmd<MockRuntime> {
 	SetupMainChainStateCmd {
 		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
+		skip_d_parameter: false,
+		skip_permissioned_candidates: false,
+		_phantom: std::marker::PhantomData,
+	}
+}
+
+fn setup_main_chain_state_cmd_skip_d_parameter() -> SetupMainChainStateCmd<MockRuntime> {
+	SetupMainChainStateCmd {
+		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
+		skip_d_parameter: true,
+		skip_permissioned_candidates: false,
+		_phantom: std::marker::PhantomData,
+	}
+}
+
+fn setup_main_chain_state_cmd_skip_permissioned() -> SetupMainChainStateCmd<MockRuntime> {
+	SetupMainChainStateCmd {
+		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
+		skip_d_parameter: false,
+		skip_permissioned_candidates: true,
+		_phantom: std::marker::PhantomData,
+	}
+}
+
+fn setup_main_chain_state_cmd_skip_both() -> SetupMainChainStateCmd<MockRuntime> {
+	SetupMainChainStateCmd {
+		common_arguments: CommonArguments { retry_delay_seconds: 5, retry_count: 59 },
+		skip_d_parameter: true,
+		skip_permissioned_candidates: true,
 		_phantom: std::marker::PhantomData,
 	}
 }
@@ -203,6 +295,30 @@ fn print_info_io() -> MockIO {
 	MockIO::print(
 		"This wizard will set or update D-Parameter and Permissioned Candidates on the main chain. Setting either of these costs ADA!",
 	)
+}
+
+fn print_permissioned_candidates_only_info_io() -> MockIO {
+	MockIO::print(
+		"This wizard will set or update Permissioned Candidates on the main chain. Setting this costs ADA!",
+	)
+}
+
+fn print_d_parameter_only_info_io() -> MockIO {
+	MockIO::print(
+		"This wizard will set or update D-Parameter on the main chain. Setting this costs ADA!",
+	)
+}
+
+fn print_skip_d_parameter_summary_io() -> MockIO {
+	MockIO::print("Contracts to deploy: Permissioned Candidates. Contracts to skip: D-parameter")
+}
+
+fn print_skip_permissioned_candidates_summary_io() -> MockIO {
+	MockIO::print("Contracts to deploy: D-parameter. Contracts to skip: Permissioned Candidates")
+}
+
+fn print_skip_both_summary_io() -> MockIO {
+	MockIO::print("Contracts to skip: D-parameter, Permissioned Candidates")
 }
 
 fn get_ariadne_parameters_io() -> MockIO {


### PR DESCRIPTION
## Summary

Add interactive contract selection prompts to the `setup-main-chain-state` wizard command, enabling operators to selectively deploy smart contracts for mainnet without legacy Haskell D-parameter contracts.


🎫 [Ticket](https://shielded.atlassian.net/browse/PM-21261)

---

## Motivation

The wizard currently deploys all partnership smart contracts including the legacy Haskell versions. For mainnet launch, we must NOT deploy the legacy Haskell D-parameter contracts. Only the new Aiken-migrated contracts should exist on-chain.

Deploying legacy contracts to mainnet creates:
- Confusion about which contracts are the source of truth
- Risk that legacy contracts could be reused for unintended purposes
- Chain history pollution with deprecated contracts

---

## Changes

- **Interactive prompts** - Users are now asked which contracts to deploy via yes/no prompts:
  - "Do you want to deploy/update the D-parameter contract?" (default: yes)
  - "Do you want to deploy/update the Permissioned Candidates contract?" (default: yes)
- **Configuration** - `ContractDeploymentConfig` struct manages contract selection state
- **Execution** - Conditionally skip contract deployments based on user selection with deployment summary output
- **Graceful exit** - Selecting neither contract exits with informational message (no error)
- **Tests** - 9 tests covering all contract selection combinations
- **Changelog** - Added feature entry under "Unreleased"

---

## 📌 Submission Checklist

- [x] Changes are backward-compatible (or flagged if breaking)
- [x] Pull request description explains why the change is needed
- [ ] Self-reviewed the diff
- [x] I have included a change file, or skipped for this reason: Updated changelog.md
- [ ] If the changes introduce a new feature, I have bumped the node minor version
- [x] Update documentation (if relevant)
- [x] No new todos introduced

---

## 🔱 Fork Strategy

- [ ] Node Runtime Update
- [ ] Node Client Update
- [x] Other
- [ ] N/A

---

## 🗹 TODO before merging

- [x] Ready for review